### PR TITLE
[Task] Added client side sanitizer

### DIFF
--- a/public/js/pimcore/htmlSanitizer.js
+++ b/public/js/pimcore/htmlSanitizer.js
@@ -1,0 +1,73 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+pimcore.registerNS("pimcore.htmlSanitizer");
+
+/**
+ * @internal
+ */
+pimcore.htmlSanitizer = Class.create({
+    allowedTags: {},
+
+    constructor: function () {
+        if(this.constructor.name === "pimcore.sanitizer"){
+            throw new Error("pimcore.sanitizer is a static class and can not be instantiated.");
+        }
+    },
+
+    sanitize: function (string) {
+        const parser = new DOMParser();
+        const testDom = parser.parseFromString(string, "text/html");
+
+        const htmlNodes = testDom.body.childNodes;
+
+        htmlNodes.forEach((node) => {
+            if (node.nodeName !== '#text') {
+                this.sanitizeNode(node);
+            }
+        });
+
+        return testDom.body.innerHTML;
+    },
+
+    sanitizeNode: function (node) {
+        if(node.hasChildNodes()){
+            node.childNodes.forEach((childNode) => {
+                if (childNode.nodeName !== '#text') {
+                    this.sanitizeNode(childNode);
+                }
+            });
+        }
+
+        if (this.allowedTags[node.nodeName.toLowerCase()]) {
+            const allowedAttributes = this.allowedTags[node.nodeName.toLowerCase()];
+            const attributes = node.attributes;
+
+            for (let i = 0; i < attributes.length; i++) {
+                const attribute = attributes[i];
+
+                if (allowedAttributes === true) {
+                    continue;
+                }
+
+                if (allowedAttributes.indexOf(attribute.name) === -1) {
+                    node.removeAttribute(attribute.name);
+                }
+            }
+        }
+
+        if (!this.allowedTags[node.nodeName.toLowerCase()]) {
+            node.remove();
+        }
+    }
+});

--- a/public/js/pimcore/htmlSanitizer/translationSanitizer.js
+++ b/public/js/pimcore/htmlSanitizer/translationSanitizer.js
@@ -1,0 +1,33 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+pimcore.registerNS("pimcore.htmlSanitizer.translationSanitizer");
+
+/**
+ * @internal
+ */
+pimcore.htmlSanitizer.translationSanitizer = Class.create(pimcore.htmlSanitizer, {
+    allowedTags: {
+        span: [ 'class', 'style', 'id' ],
+        p: [ 'class', 'style', 'id' ],
+        strong: 'class',
+        em: 'class',
+        h1: [ 'class', 'id' ],
+        h2: [ 'class', 'id' ],
+        h3: [ 'class', 'id' ],
+        h4: [ 'class', 'id' ],
+        h5: [ 'class', 'id' ],
+        h6: [ 'class', 'id' ],
+        a: [ 'class', 'id', 'href', 'target', 'title', 'rel' ]
+    }
+});


### PR DESCRIPTION
Added a sanitizer for sanitizing HTML code in the front end. 

Simillar to: https://symfony.com/doc/current/html_sanitizer.html

NOTE: this PR is not "in progress" we just keep it to talk about the client-side sanitizer after the Pimcore 11 release! So this can be ignored!