### PR TITLE
[Task]: Defer twemoji variants icons

### DIFF
--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -51,6 +51,7 @@ class AdminExtension extends AbstractExtension
     {
         return [
             new TwigFilter('pimcore_inline_icon', [$this, 'inlineIcon']),
+            new TwigFilter('pimcore_twemoji_variant_icon', [$this, 'twemojiVariantIcon']),
         ];
     }
 
@@ -104,6 +105,13 @@ class AdminExtension extends AbstractExtension
         return sprintf('<img src="data:%s;base64,%s" title="%s" data-imgpath="%s" />',
             mime_content_type($icon),
             base64_encode($content),
+            basename($icon),
+            str_replace(PIMCORE_WEB_ROOT, '', $icon)
+        );
+    }
+    public function twemojiVariantIcon(string $icon): string
+    {
+        return sprintf('<img title="%s" data-imgpath="%s" />',
             basename($icon),
             str_replace(PIMCORE_WEB_ROOT, '', $icon)
         );

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -26,6 +26,8 @@
             font-size: 10px;
             word-wrap: break-word;
             cursor: copy;
+            padding-top: 5px;
+            box-sizing: border-box;
         }
 
         .icon.black {
@@ -55,6 +57,14 @@
         .language-icon img{
             width: 16px;
             cursor: copy;
+        }
+
+        .variant + .icon:not(.variant){
+            border: 2px dotted green;
+        }
+        .variant{
+            display: none;
+            background-color: #eee;
         }
     </style>
 </head>
@@ -104,12 +114,25 @@
 </div>
 
 <div id="twemoji" class="icons">
+    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
+    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon with green border to display all its related variants. Click on the letter to display flags with the clicked initial</div>
     {% for icon in twemoji %}
         {% set iconPath = icon|replace({(webRoot): ''}) %}
-        <div class="icon">
-            {{ icon | pimcore_inline_icon | raw }}
-            <div class="label">{{ iconPath|basename }}</div>
-        </div>
+        {#
+            Any icon with basename that has a dash will be considered as a variant to avoid recurisvely searching for "parent" icon.
+            It happens that all icon that have variants have at least a prefix of 4-5 characters.
+        #}
+        {% if '-' in iconPath and iconPath|basename|split('-')[0]|length > 3 %}
+            <div class="icon variant">
+                {{ icon | pimcore_twemoji_variant_icon | raw }}
+                <div class="label">{{ iconPath|basename }}</div>
+            </div>
+        {% else %}
+            <div class="icon">
+                {{ icon | pimcore_inline_icon | raw }}
+                <div class="label">{{ iconPath|basename }}</div>
+            </div>
+        {% endif %}
     {% endfor %}
 </div>
 
@@ -132,16 +155,37 @@
     {% endfor %}
 </table>
 
+<script
+    src="https://code.jquery.com/jquery-3.7.0.slim.js"
+    integrity="sha256-7GO+jepT9gJe9LB4XFf8snVOjX3iYNb0FHYr5LI1N5c="
+    crossorigin="anonymous"
+    {{ pimcore_csp.getNonceHtmlAttribute()|raw }}></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/common.js"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/functions.js"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/helpers.js"></script>
+
 <script {{ pimcore_csp.getNonceHtmlAttribute()|raw }}>
-    [...document.getElementsByTagName('img')]
-        .forEach(el => {
-            el.addEventListener("click", () => {
-                pimcore.helpers.copyStringToClipboard(el.dataset.imgpath)
+    $( document ).ready(function() {
+        // Add click event to copy icon path on all icons
+        $('img').each(function () {
+            $(this).click(function () {
+                pimcore.helpers.copyStringToClipboard($(this).data('imgpath'));
             });
         });
+        // Twimoji only: clicking on icon with green border displays all its variants
+        $('.icon:not(.variant)').each(function () {
+            $(this).click(function () {
+                let variants = $(this).prevUntil('div.icon:not(.variant)');
+                variants.each(function () {
+                    if (!$(this).is(':visible')) {
+                        let img = $(this).children('img');
+                        img.attr('src', img.data('imgpath'));
+                        $(this).show();
+                    }
+                });
+            });
+        });
+    });
 </script>
 
 </body>


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/85

Kind of work, at least doesn't crash anymore
eg. pressing this knee, it would display all the skin tones
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/04501688-07c4-4659-b946-3d6fb3b79fa8)

but is not coveering cases like this where the basename have more dashes. like the 🫱 and handshake🤝 have the same prefix.

![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/1c86f0ab-85f3-4c5f-ab22-8fa65b5ab200)
