### PR TITLE
Add support for an in filter operator

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -75,6 +75,16 @@ class GridHelperService
                 } elseif ($filter['type'] == 'boolean') {
                     $operator = '=';
                     $filter['value'] = (int)$filter['value'];
+                } elseif ($filterOperator == 'in') {
+                    $operator = 'in';
+
+                    $matches = preg_split('/[^0-9]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
+                    if (is_array($matches) && count($matches) > 0) {
+                        $filter['value'] = implode(',', $matches);
+                    } else {
+                        $operator = '=';
+                        $filter['value'] = (int)$filter['value'];
+                    }
                 }
 
                 $keyParts = explode('~', $filterField);


### PR DESCRIPTION
## Changes in this pull request 

Add support for an 'in' filter operator when filtering numerical fields in the grid.

## Additional info 

At Notebooksbilliger we had a need to filter a column in the grid with multiple values. We have created our own bundle to achieve this but we did have to modify some core code. We are currently changing this core file using a composer patch but would like to see this extra operator check included in future.

Example: https://beta.im.ge/i/grid-in-filter.FMq2v4

(Is related to https://github.com/pimcore/pimcore/pull/15315)
