### PR TITLE
Feature/add support for an in filter operator to grid helper

### DIFF
--- a/public/js/pimcore/overrides.js
+++ b/public/js/pimcore/overrides.js
@@ -1126,7 +1126,7 @@ Ext.define('Ext.local.grid.filters.filter.TriFilter', {
             operator: 'in',
             type: 'numeric',
             value: (!stateful && value && value.in) || null
-        }, 'eq');
+        }, 'in');
         me.filter = filter;
         if (me.active) {
             me.setColumnActive(true);
@@ -1194,7 +1194,9 @@ Ext.define('Ext.local.grid.filters.filter.TriFilter', {
             }
             if ('in' in value) {
                 v = value.in;
-                if (v || v === 0) {
+                if (typeof v === "object" && v[0][0] == '') {
+                    remove.push(filters.in);
+                } else if (v || v === 0) {
                     add.push(filters.in);
                     filters.in.setValue(v);
                 } else {

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -75,6 +75,16 @@ class GridHelperService
                 } elseif ($filter['type'] == 'boolean') {
                     $operator = '=';
                     $filter['value'] = (int)$filter['value'];
+                } elseif ($filterOperator == 'in') {
+                    $operator = 'in';
+
+                    $matches = preg_split('/[^0-9]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
+                    if (is_array($matches) && count($matches) > 0) {
+                        $filter['value'] = implode(',', $matches);
+                    } else {
+                        $operator = '=';
+                        $filter['value'] = (int)$filter['value'];
+                    }
                 }
 
                 $keyParts = explode('~', $filterField);

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -75,16 +75,6 @@ class GridHelperService
                 } elseif ($filter['type'] == 'boolean') {
                     $operator = '=';
                     $filter['value'] = (int)$filter['value'];
-                } elseif ($filterOperator == 'in') {
-                    $operator = 'in';
-
-                    $matches = preg_split('/[^0-9]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
-                    if (is_array($matches) && count($matches) > 0) {
-                        $filter['value'] = implode(',', $matches);
-                    } else {
-                        $operator = '=';
-                        $filter['value'] = (int)$filter['value'];
-                    }
                 }
 
                 $keyParts = explode('~', $filterField);
@@ -214,6 +204,16 @@ class GridHelperService
                     } elseif ($filter['type'] == 'boolean') {
                         $operator = '=';
                         $filter['value'] = (int)$filter['value'];
+                    } elseif ($filterOperator == 'in') {
+                        $operator = 'in';
+
+                        $matches = preg_split('/[^0-9]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
+                        if (is_array($matches) && count($matches) > 0) {
+                            $filter['value'] = implode(',', array_unique($matches));
+                        } else {
+                            $operator = '=';
+                            $filter['value'] = (int)$filter['value'];
+                        }
                     } else {
                         if ($filterOperator == 'lt') {
                             $operator = '<';
@@ -334,7 +334,7 @@ class GridHelperService
                             $conditionPartsFilters[] = 'concat(`path`, `key`) ' . $operator . ' ' . $db->quote('%' . $filter['value'] . '%');
                         } elseif ($filterField == 'key') {
                             $conditionPartsFilters[] = '`key` ' . $operator . ' ' . $db->quote('%' . $filter['value'] . '%');
-                        } elseif ($filterField == 'id') {
+                        } elseif ($filterField == 'id' && $operator !== 'in') {
                             $conditionPartsFilters[] = 'oo_id ' . $operator . ' ' . $db->quote($filter['value']);
                         } else {
                             $filterField = $db->quoteIdentifier($filterField);
@@ -347,7 +347,11 @@ class GridHelperService
                                 if ($filter['type'] === 'boolean') {
                                     $filterField = 'IFNULL(' . $filterField . ', 0)';
                                 }
-                                $conditionPartsFilters[] = $filterField . ' ' . $operator . ' ' . $db->quote($filter['value']);
+                                if ($operator === 'in') {
+                                    $conditionPartsFilters[] = $filterField . ' ' . $operator . ' (' . $filter['value'] . ')';
+                                } else {
+                                    $conditionPartsFilters[] = $filterField . ' ' . $operator . ' ' . $db->quote($filter['value']);
+                                }
                             }
                         }
                     }

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -208,16 +208,15 @@ class GridHelperService
                         $operator = 'in';
                         $matches = preg_split('/[^0-9\.]+/', $filter['value'][0][0] ?? [], -1, PREG_SPLIT_NO_EMPTY);
                         if (is_array($matches) && count($matches) > 0) {
-                            $filter['value'][0][0] = implode(',', array_unique($matches));
+                            $filter['value'][0][0] = implode(',', array_unique(array_map(floatval(...), $matches)));
                         } else {
                             continue;
                         }
                     } elseif ($filterOperator == 'in' && !is_array($filter['value'])) {
                         $operator = 'in';
-
                         $matches = preg_split('/[^0-9\.]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
                         if (is_array($matches) && count($matches) > 0) {
-                            $filter['value'] = implode(',', array_unique($matches));
+                            $filter['value'] = implode(',', array_unique(array_map(floatval(...), $matches)));
                         } else {
                             continue;
                         }
@@ -343,6 +342,8 @@ class GridHelperService
                             $conditionPartsFilters[] = '`key` ' . $operator . ' ' . $db->quote('%' . $filter['value'] . '%');
                         } elseif ($filterField == 'id' && $operator !== 'in') {
                             $conditionPartsFilters[] = 'oo_id ' . $operator . ' ' . $db->quote($filter['value']);
+                        } elseif ($filterField == 'id' && $operator === 'in') {
+                            $conditionPartsFilters[] = 'oo_id ' . $operator . ' (' . $filter['value'] . ')';
                         } else {
                             $filterField = $db->quoteIdentifier($filterField);
                             if ($filter['type'] == 'date' && $operator == '=') {
@@ -354,11 +355,7 @@ class GridHelperService
                                 if ($filter['type'] === 'boolean') {
                                     $filterField = 'IFNULL(' . $filterField . ', 0)';
                                 }
-                                if ($operator === 'in') {
-                                    $conditionPartsFilters[] = $filterField . ' ' . $operator . ' (' . $filter['value'] . ')';
-                                } else {
-                                    $conditionPartsFilters[] = $filterField . ' ' . $operator . ' ' . $db->quote($filter['value']);
-                                }
+                                $conditionPartsFilters[] = $filterField . ' ' . $operator . ' ' . $db->quote($filter['value']);
                             }
                         }
                     }

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -204,15 +204,22 @@ class GridHelperService
                     } elseif ($filter['type'] == 'boolean') {
                         $operator = '=';
                         $filter['value'] = (int)$filter['value'];
-                    } elseif ($filterOperator == 'in') {
+                    } elseif ($filterOperator == 'in' && is_array($filter['value'])) { // quantityValue field
+                        $operator = 'in';
+                        $matches = preg_split('/[^0-9\.]+/', $filter['value'][0][0] ?? [], -1, PREG_SPLIT_NO_EMPTY);
+                        if (is_array($matches) && count($matches) > 0) {
+                            $filter['value'][0][0] = implode(',', array_unique($matches));
+                        } else {
+                            continue;
+                        }
+                    } elseif ($filterOperator == 'in' && !is_array($filter['value'])) {
                         $operator = 'in';
 
-                        $matches = preg_split('/[^0-9]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
+                        $matches = preg_split('/[^0-9\.]+/', $filter['value'], -1, PREG_SPLIT_NO_EMPTY);
                         if (is_array($matches) && count($matches) > 0) {
                             $filter['value'] = implode(',', array_unique($matches));
                         } else {
-                            $operator = '=';
-                            $filter['value'] = (int)$filter['value'];
+                            continue;
                         }
                     } else {
                         if ($filterOperator == 'lt') {

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -204,7 +204,7 @@ class GridHelperService
                     } elseif ($filter['type'] == 'boolean') {
                         $operator = '=';
                         $filter['value'] = (int)$filter['value'];
-                    } elseif ($filterOperator == 'in' && is_array($filter['value'])) { // quantityValue field
+                    } elseif ($filterOperator == 'in' && is_array($filter['value'])) {
                         $operator = 'in';
                         $matches = preg_split('/[^0-9\.]+/', $filter['value'][0][0] ?? [], -1, PREG_SPLIT_NO_EMPTY);
                         if (is_array($matches) && count($matches) > 0) {


### PR DESCRIPTION
### Changes in this pull request

Add support for an 'in' filter operator when filtering numerical fields in the grid.

#### Additional info

At Notebooksbilliger we had a need to filter a column in the grid with multiple values. We have created our own bundle to achieve this but we did have to modify some core code. We are currently changing this core file using a composer patch but would love to see this extra operator check included in future.

Example: https://beta.im.ge/i/in-filter-numeric-columns.FM5r79

(Is related to https://github.com/pimcore/pimcore/pull/15315)