### PR TITLE
[Data objects] Prevent error when opening object of a class without data object fields

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -585,7 +585,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         throw $this->createAccessDeniedHttpException();
     }
 
-    private function injectValuesForCustomLayout(array &$layout): void
+    private function injectValuesForCustomLayout(?array &$layout): void
     {
         foreach ($layout['children'] as &$child) {
             if ($child['datatype'] === 'layout') {

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -587,7 +587,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
     private function injectValuesForCustomLayout(?array &$layout): void
     {
-        foreach ($layout['children'] as &$child) {
+        foreach ($layout['children'] ?? [] as &$child) {
             if ($child['datatype'] === 'layout') {
                 $this->injectValuesForCustomLayout($child);
             } else {


### PR DESCRIPTION
Steps to reproduce:
1. Create data object class without any fields nor layout components
2. Create an object of this class

Error `Argument #1 ($layout) must be of type array, null given` will get thrown.