### PR TITLE
[Improvement]: Introduce `pimcore.events.prepareAffectedNodes`

### DIFF
--- a/public/js/pimcore/elementservice.js
+++ b/public/js/pimcore/elementservice.js
@@ -433,14 +433,6 @@ pimcore.elementservice.editDocumentKeyComplete =  function (options, button, val
             }
 
             if(rdata && rdata.success) {
-
-                const postElementChangeKey = new CustomEvent(pimcore.events.postElementChangeKey, {
-                    detail: {
-                        options: options
-                    }
-                });
-                document.dispatchEvent(postElementChangeKey);
-
                 // removes loading indicator added in the applyNewKey method
                 pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
             }
@@ -504,15 +496,6 @@ pimcore.elementservice.editObjectKeyComplete = function (options, button, value,
                 try {
                     var rdata = Ext.decode(response.responseText);
                     if (rdata && rdata.success) {
-
-                        const postElementChangeKey = new CustomEvent(pimcore.events.postElementChangeKey, {
-                            detail: {
-                                options: options
-                            }
-                        });
-                        document.dispatchEvent(postElementChangeKey);
-
-
                         pimcore.elementservice.reopenElement(options);
                         // removes loading indicator added in the applyNewKey method
                         pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
@@ -595,14 +578,6 @@ pimcore.elementservice.editAssetKeyComplete = function (options, button, value, 
                     }
 
                     if(rdata && rdata.success) {
-
-                        const postElementChangeKey = new CustomEvent(pimcore.events.postElementChangeKey, {
-                            detail: {
-                                options: options
-                            }
-                        });
-                        document.dispatchEvent(postElementChangeKey);
-
                         // removes loading indicator added in the applyNewKey method
                         pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
                     }

--- a/public/js/pimcore/elementservice.js
+++ b/public/js/pimcore/elementservice.js
@@ -359,8 +359,16 @@ pimcore.elementservice.getAffectedNodes = function(elementType, id) {
         });
     }
 
-    return affectedNodes;
+    const prepareAffectedNodes = new CustomEvent(pimcore.events.prepareAffectedNodes, {
+        detail: {
+            affectedNodes: affectedNodes,
+            id: id,
+            elementType: elementType
+        }
+    });
+    document.dispatchEvent(prepareAffectedNodes);
 
+    return affectedNodes;
 };
 
 
@@ -425,6 +433,14 @@ pimcore.elementservice.editDocumentKeyComplete =  function (options, button, val
             }
 
             if(rdata && rdata.success) {
+
+                const postElementChangeKey = new CustomEvent(pimcore.events.postElementChangeKey, {
+                    detail: {
+                        options: options
+                    }
+                });
+                document.dispatchEvent(postElementChangeKey);
+
                 // removes loading indicator added in the applyNewKey method
                 pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
             }
@@ -488,6 +504,15 @@ pimcore.elementservice.editObjectKeyComplete = function (options, button, value,
                 try {
                     var rdata = Ext.decode(response.responseText);
                     if (rdata && rdata.success) {
+
+                        const postElementChangeKey = new CustomEvent(pimcore.events.postElementChangeKey, {
+                            detail: {
+                                options: options
+                            }
+                        });
+                        document.dispatchEvent(postElementChangeKey);
+
+
                         pimcore.elementservice.reopenElement(options);
                         // removes loading indicator added in the applyNewKey method
                         pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
@@ -570,6 +595,14 @@ pimcore.elementservice.editAssetKeyComplete = function (options, button, value, 
                     }
 
                     if(rdata && rdata.success) {
+
+                        const postElementChangeKey = new CustomEvent(pimcore.events.postElementChangeKey, {
+                            detail: {
+                                options: options
+                            }
+                        });
+                        document.dispatchEvent(postElementChangeKey);
+
                         // removes loading indicator added in the applyNewKey method
                         pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
                     }

--- a/public/js/pimcore/events.js
+++ b/public/js/pimcore/events.js
@@ -198,8 +198,13 @@
   * node item is passed as parameter
   */
  pimcore.events.prepareOnObjectTreeNodeClick = "pimcore.objectTreeNode.onClick";
- 
- /**
+
+/**
+ * extends the affected nodes array on pimcore.elementservice.getAffectedNodes()
+ */
+pimcore.events.prepareAffectedNodes = "pimcore.treeNode.prepareAffectedNodes";
+
+/**
   * before the data object grid folder configuration is loaded from the server.
   * request configuration is passed as parameter
   */


### PR DESCRIPTION
This allows to add further custom trees (beside custom view and basic element trees) to be considered for node refresh when performing actions like for example rename, publish/unpublish.