### PR TITLE
Many-to-many-relations: support multi-file-upload

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1053,7 +1053,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                 });
                 win.show();
 
-                var finishedErrorHandler = function (e) {
+                let finishedErrorHandler = function (e) {
                     this.activeUploads--;
                     win.remove(pbar);
 

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1103,7 +1103,6 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                         var data = JSON.parse(request.responseText);
                         if(ev.currentTarget.status < 400 && data.success === true) {
                             success(res);
-                            uploadWindowCompatible.close();
                         } else {
                             failure(res);
                             finishedErrorHandler();
@@ -1124,7 +1123,10 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                 });
 
                 window.setTimeout(function () {
-                    win.close();
+                    if (activeUploads == filesCount) {
+                        win.close();
+                        uploadWindowCompatible.close();
+                    }
                 }.bind(this), 1000);
             },
             afterrender:function(cmp){

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1100,7 +1100,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                     };
 
                     let successWrapper = function (ev) {
-                        var data = JSON.parse(request.responseText);
+                        const data = JSON.parse(request.responseText);
                         if(ev.currentTarget.status < 400 && data.success === true) {
                             success(res);
                             if (activeUploads == filesCount) {

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1081,7 +1081,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                     win.updateLayout();
 
                     activeUploads++;
-                    let percentComplete = activeUploads / filesCount;
+                    const percentComplete = activeUploads / filesCount;
                     let progressText = file.name + " ( " + Math.floor(percentComplete * 100) + "% )";
                     if (percentComplete == 1) {
                         progressText = file.name + " " + t("please_wait");

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1071,7 +1071,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                         return;
                     }
 
-                    var pbar = new Ext.ProgressBar({
+                    let pbar = new Ext.ProgressBar({
                         width:465,
                         text: file.name,
                         style: "margin-bottom: 5px"

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1032,7 +1032,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
 
     items.push({
         xtype: 'fileuploadfield',
-        emptyText: t("select_a_file"),
+        emptyText: t("select_files"),
         fieldLabel: t("file"),
         width: 470,
         name: filename+'[]',

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1042,7 +1042,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
         },
         listeners: {
             change: function (fileUploadField) {
-                var win = new Ext.Window({
+                let win = new Ext.Window({
                     items: [],
                     modal: true,
                     closable: false,
@@ -1062,8 +1062,8 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                     }
                 }.bind(this);
 
-                var activeUploads = 0;
-                var filesCount = fileUploadField.fileInputEl.dom.files.length;
+                let activeUploads = 0;
+                let filesCount = fileUploadField.fileInputEl.dom.files.length;
 
                 Ext.each(fileUploadField.fileInputEl.dom.files, function (file) {
                     if (file.size > pimcore.settings["upload_max_filesize"]) {
@@ -1081,25 +1081,25 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                     win.updateLayout();
 
                     activeUploads++;
-                    var percentComplete = activeUploads / filesCount;
-                    var progressText = file.name + " ( " + Math.floor(percentComplete * 100) + "% )";
+                    let percentComplete = activeUploads / filesCount;
+                    let progressText = file.name + " ( " + Math.floor(percentComplete * 100) + "% )";
                     if (percentComplete == 1) {
                         progressText = file.name + " " + t("please_wait");
                     }
 
                     pbar.updateProgress(percentComplete, progressText);
 
-                    var data = new FormData();
+                    let data = new FormData();
                     data.append(filename, file);
                     data.append("filename", file.name);
                     data.append("csrfToken", pimcore.settings['csrfToken']);
 
-                    var request = new XMLHttpRequest();
-                    var res = {
+                    let request = new XMLHttpRequest();
+                    let res = {
                         'response': request
                     };
 
-                    var successWrapper = function (ev) {
+                    let successWrapper = function (ev) {
                         var data = JSON.parse(request.responseText);
                         if(ev.currentTarget.status < 400 && data.success === true) {
                             success(res);
@@ -1113,7 +1113,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                         }
                     };
 
-                    var errorWrapper = function (ev) {
+                    let errorWrapper = function (ev) {
                         failure(res);
                         finishedErrorHandler();
                     };

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1103,6 +1103,10 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                         var data = JSON.parse(request.responseText);
                         if(ev.currentTarget.status < 400 && data.success === true) {
                             success(res);
+                            if (activeUploads == filesCount) {
+                                win.close();
+                                uploadWindowCompatible.close();
+                            }
                         } else {
                             failure(res);
                             finishedErrorHandler();
@@ -1121,13 +1125,6 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                     request.send(data);
 
                 });
-
-                window.setTimeout(function () {
-                    if (activeUploads == filesCount) {
-                        win.close();
-                        uploadWindowCompatible.close();
-                    }
-                }.bind(this), 1000);
             },
             afterrender:function(cmp){
                 cmp.fileInputEl.set({

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1042,7 +1042,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
         },
         listeners: {
             change: function (fileUploadField) {
-                let win = new Ext.Window({
+                const win = new Ext.Window({
                     items: [],
                     modal: true,
                     closable: false,

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -1063,7 +1063,7 @@ pimcore.helpers.uploadDialog = function (url, filename, success, failure, descri
                 }.bind(this);
 
                 let activeUploads = 0;
-                let filesCount = fileUploadField.fileInputEl.dom.files.length;
+                const filesCount = fileUploadField.fileInputEl.dom.files.length;
 
                 Ext.each(fileUploadField.fileInputEl.dom.files, function (file) {
                     if (file.size > pimcore.settings["upload_max_filesize"]) {

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -139,7 +139,7 @@ this_element_cannot_be_edited: 'This element cannot be edited'
 details: Details
 cannot_save_object_please_try_to_edit_the_object_in_detail_view: '<b>Cannot save object!</b><br />Please try to edit the object in the detail view.'
 size: Size
-select_a_file: 'Select a file'
+select_a_file: 'Select files'
 upload_compatibility_mode: 'Upload File (Compatibility Mode)'
 the_system_is_in_maintenance_mode_please_wait: 'The system is in maintenance mode, please wait'
 activate: Activate

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -139,7 +139,8 @@ this_element_cannot_be_edited: 'This element cannot be edited'
 details: Details
 cannot_save_object_please_try_to_edit_the_object_in_detail_view: '<b>Cannot save object!</b><br />Please try to edit the object in the detail view.'
 size: Size
-select_a_file: 'Select files'
+select_a_file: 'Select a file'
+select_files: 'Select files'
 upload_compatibility_mode: 'Upload File (Compatibility Mode)'
 the_system_is_in_maintenance_mode_please_wait: 'The system is in maintenance mode, please wait'
 activate: Activate


### PR DESCRIPTION
For (advanced) many-to-many relations with assets being allowed you can directly upload assets from the relation view:
<img width="859" alt="Bildschirmfoto 2023-06-22 um 16 09 09" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/8749138/e891e7aa-58d2-4b9a-8a44-f56cc0c6cb86">

Currently this only supports single-file uploads. The same applies under assets context menu for "Upload (Compatibility mode)". With this PR all those places now support multi-file upload.