### PR TITLE
Fix/time field container cut off

### DIFF
--- a/public/js/pimcore/object/classes/data/time.js
+++ b/public/js/pimcore/object/classes/data/time.js
@@ -49,6 +49,10 @@ pimcore.object.classes.data.time = Class.create(pimcore.object.classes.data.data
 
         $super();
         this.specificPanel.removeAll();
+
+        var widthItems = this.getWidthPanelItems(this.datax);
+        this.specificPanel.add(widthItems);
+
         var specificItems = this.getSpecificPanelItems(this.datax);
         this.specificPanel.add(specificItems);
 
@@ -134,6 +138,15 @@ pimcore.object.classes.data.time = Class.create(pimcore.object.classes.data.data
         return specificItems;
 
 
+    },
+
+    getWidthPanelItems: function (datax) {
+        return [{
+            xtype: "textfield",
+            fieldLabel: t("width"),
+            name: "width",
+            value: datax.width
+        }];
     },
 
     applySpecialData: function(source) {

--- a/public/js/pimcore/object/classes/data/time.js
+++ b/public/js/pimcore/object/classes/data/time.js
@@ -50,7 +50,7 @@ pimcore.object.classes.data.time = Class.create(pimcore.object.classes.data.data
         $super();
         this.specificPanel.removeAll();
 
-        var widthItems = this.getWidthPanelItems(this.datax);
+        const widthItems = this.getWidthPanelItems(this.datax);
         this.specificPanel.add(widthItems);
 
         var specificItems = this.getSpecificPanelItems(this.datax);

--- a/public/js/pimcore/object/tags/time.js
+++ b/public/js/pimcore/object/tags/time.js
@@ -29,11 +29,11 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
     },
 
     getLayoutEdit: function () {
-        this.component = new Ext.form.TimeField({
+        const options = new Ext.form.TimeField({
             fieldLabel: this.fieldConfig.title,
             format: "H:i",
             emptyText: "",
-            width: 200,
+            width: this.fieldConfig.width ? this.fieldConfig.width : 250,
             value: this.data,
             allowBlank: (!this.fieldConfig.mandatory),
             minValue: (this.fieldConfig.minValue) ? this.fieldConfig.minValue : null,
@@ -41,6 +41,16 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
             componentCls: this.getWrapperClassNames(),
             increment: (this.fieldConfig.increment) ? this.fieldConfig.increment : 15
         });
+    
+        if (this.fieldConfig.labelWidth) {
+            options.labelWidth = this.fieldConfig.labelWidth;
+        }
+
+        if (!this.fieldConfig.labelAlign || 'left' === this.fieldConfig.labelAlign) {
+            options.width = this.sumWidths(options.width, options.labelWidth);
+        }
+
+        this.component = new Ext.form.TimeField(options)
 
         return this.component;
     },

--- a/public/js/pimcore/object/tags/time.js
+++ b/public/js/pimcore/object/tags/time.js
@@ -33,7 +33,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
             fieldLabel: this.fieldConfig.title,
             format: "H:i",
             emptyText: "",
-            width: this.fieldConfig.width ? this.fieldConfig.width : 250,
+            width: this.fieldConfig.width ? this.fieldConfig.width : 200,
             value: this.data,
             allowBlank: (!this.fieldConfig.mandatory),
             minValue: (this.fieldConfig.minValue) ? this.fieldConfig.minValue : null,

--- a/public/js/pimcore/object/tags/time.js
+++ b/public/js/pimcore/object/tags/time.js
@@ -29,7 +29,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
     },
 
     getLayoutEdit: function () {
-        const options = new Ext.form.TimeField({
+        const options = {
             fieldLabel: this.fieldConfig.title,
             format: "H:i",
             emptyText: "",
@@ -40,7 +40,7 @@ pimcore.object.tags.time = Class.create(pimcore.object.tags.abstract, {
             maxValue: (this.fieldConfig.maxValue) ? this.fieldConfig.maxValue : null,
             componentCls: this.getWrapperClassNames(),
             increment: (this.fieldConfig.increment) ? this.fieldConfig.increment : 15
-        });
+        };
     
         if (this.fieldConfig.labelWidth) {
             options.labelWidth = this.fieldConfig.labelWidth;


### PR DESCRIPTION
Added logic to expose the width element and fix the time drop down from being cutoff. In this case it wasn't the field container that was cutting off the input fields, it was time field drop down that was being cut off due to a set width. Copied the logic used in the select dropdown to change the width based on whether the field container has a value in the label width.

Original Issue: https://github.com/pimcore/pimcore/issues/12446