### PR TITLE
Fix Base Units in QuantityValue Unit Definition GridView

### DIFF
--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -64,8 +64,8 @@ class QuantityValueController extends AdminAbstractController
         $list->setOrder($order);
         $list->setOrderKey($orderKey);
 
-        $list->setLimit((int)$request->get('limit', 25));
-        $list->setOffset((int)$request->get('start', 0));
+        $list->setLimit((int)$request->get('limit'));
+        $list->setOffset((int)$request->get('start'));
 
         $condition = '1 = 1';
         if ($request->get('filter')) {


### PR DESCRIPTION
I have created 196 QuantityUnits by api and the value in the column 'Base Unit' column is incorrect. Additionally, the dropdown menu for selecting a Base Unit will only display 25 items.

This issue arises from the restriction of 25 items in the function _unitProxyGetAction_ in the _QuantityValueController_. Although this restriction doesn't affect the paging of the grid view, it limits the _baseUnitStore_ used in _unitsettings.js_ to always contain only the first 25 QuantityUnits. As a result, the Base Units may not be found in some cases and will be displayed as (Empty).

You can see this in the attached screenshots below.

Current Behaviour:
![Pimcore 11 - QuantityValue Unit Definition - Wrong](https://github.com/pimcore/admin-ui-classic-bundle/assets/3041275/461afda0-57e9-49a7-b0fc-c46999493604)


Expected Behaviour:
![Pimcore 11 - QuantityValue Unit Definition - Ok](https://github.com/pimcore/admin-ui-classic-bundle/assets/3041275/9892e919-0966-4005-9a64-393c3a0b8d3c)


Testfile for Import:
[quantityvalue_units.sql.zip](https://github.com/pimcore/admin-ui-classic-bundle/files/11980815/quantityvalue_units.sql.zip)
