### PR TITLE
Open object with incompatible latest version

### DIFF
--- a/public/js/pimcore/object/tags/wysiwyg.js
+++ b/public/js/pimcore/object/tags/wysiwyg.js
@@ -121,7 +121,6 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         this.component.on("afterrender", function() {
             Ext.get(this.editableDivId).dom.setAttribute("contenteditable", "false");
         }.bind(this));
-        this.component.disable();
         return this.component;
     },
 

--- a/public/js/pimcore/object/tags/wysiwyg.js
+++ b/public/js/pimcore/object/tags/wysiwyg.js
@@ -121,6 +121,7 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         this.component.on("afterrender", function() {
             Ext.get(this.editableDivId).dom.setAttribute("contenteditable", "false");
         }.bind(this));
+        this.component.disable();
         return this.component;
     },
 

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -585,7 +585,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         throw $this->createAccessDeniedHttpException();
     }
 
-    private function injectValuesForCustomLayout(array &$layout): void
+    private function injectValuesForCustomLayout(?array &$layout): void
     {
         foreach ($layout['children'] as &$child) {
             if ($child['datatype'] === 'layout') {

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1434,7 +1434,11 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
 
         if ($request->get('data')) {
-            $this->applyChanges($object, $this->decodeJson($request->get('data')));
+            try {
+                $this->applyChanges($object, $this->decodeJson($request->get('data')));
+            } catch(\Throwable $e) {
+                $this->applyChanges($objectFromDatabase, $this->decodeJson($request->get('data')));
+            }
         }
 
         // general settings

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -467,7 +467,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
                 }
             }
 
-            $this->getDataForObject($object, $objectFromVersion);
+            try {
+                $this->getDataForObject($object, $objectFromVersion);
+            } catch(\Throwable $e) {
+                $object = $objectFromDatabase;
+                $this->getDataForObject($object, false);
+            }
+
             $objectData['data'] = $this->objectData;
             $objectData['metaData'] = $this->metaData;
             $objectData['properties'] = Element\Service::minimizePropertiesForEditmode($object->getProperties());


### PR DESCRIPTION
Steps to reproduce:

1. Create data object class with input field `test`
2. Create object of this class and enter "test" into field `test`
3. Either an `autoSave` draft version gets created or click "Save draft"
4. Convert field `test` in the class definition to a many-to-one relation
5. Reload the object

Result: There will be the error `Pimcore\Model\DataObject\ClassDefinition\Data\ManyToOneRelation::preGetData(): Return value must be of type ?Pimcore\Model\Element\ElementInterface, string returned`

Cause: When opening a data object, the latest version gets loaded in https://github.com/pimcore/admin-ui-classic-bundle/blob/7425a0782b1697550b4019d31f8ad52e5fcbbf0a/src/Controller/Admin/DataObject/DataObjectController.php#L311
As this contains serialized data, this data may not be compatible anymore to the changed field types. Before the field getters enforced return types this was no problem but nowadays the getters do only allow `null` or the correct return value type.

Solution: If the latest version is not compatible, the object will get loaded from database.