### PR TITLE
Fix deprecation in asset/document tree

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -259,7 +259,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         $assets = [];
         $cv = [];
-        $asset = Asset::getById($allParams['node']);
+        $asset = Asset::getById((int) $allParams['node']);
 
         $filter = $request->get('filter');
         $limit = (int)$allParams['limit'];

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -155,7 +155,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
             $offset = 0;
         }
 
-        $document = Document::getById($allParams['node']);
+        $document = Document::getById((int) $allParams['node']);
         if (!$document) {
             throw $this->createNotFoundException('Document was not found');
         }

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -678,7 +678,7 @@ class GridHelperService
     public function prepareAssetListingForGrid(array $allParams, User $adminUser): Model\Asset\Listing
     {
         $db = \Pimcore\Db::get();
-        $folder = Model\Asset::getById($allParams['folderId']);
+        $folder = Model\Asset::getById((int) $allParams['folderId']);
 
         $start = 0;
         $limit = null;


### PR DESCRIPTION
```
PHP Deprecated: Since pimcore/pimcore 11.0: Passing id as string to method Pimcore\Model\Asset::getById is deprecated
```
```
PHP Deprecated: Since pimcore/pimcore 11.0: Passing id as string to method Pimcore\Model\Document::getById is deprecated
```