### PR TITLE
Support text selection for readonly wysiwyg fields

### DIFF
--- a/public/js/pimcore/object/tags/wysiwyg.js
+++ b/public/js/pimcore/object/tags/wysiwyg.js
@@ -121,7 +121,6 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         this.component.on("afterrender", function() {
             Ext.get(this.editableDivId).dom.setAttribute("contenteditable", "false");
         }.bind(this));
-        this.component.disable();
         return this.component;
     },
 


### PR DESCRIPTION
Steps to reproduce bug:

1. Create data object class with wysiwyg field
2. Create object
3. Enter some content in wysiwyg field, save object
4. change field definition for the wysiwyg field to be `not editable`
5. Reload object

The content is now not selectable.
With this PR it is selectable (and thus also copyable).

It is similar to what has been implemented in https://github.com/pimcore/pimcore/pull/3693