### PR TITLE
Support text selection / clickable UI for readonly objectbrick fields

### DIFF
--- a/public/css/ext-modifications.css
+++ b/public/css/ext-modifications.css
@@ -683,6 +683,10 @@ body > .x-mask {
     pointer-events: all !important; /* enables tooltip for disabled elements */
 }
 
+/* Ext override to allow click through not editable object-brick's mask eg. relation buttons*/
+.pimcore_objectbrick_item.x-masked .x-mask{
+    pointer-events: none;
+}
 
 /** ExtJS7 changes starting from here */
 /* base color is #5fa2dd */

--- a/public/js/pimcore/object/tags/objectbricks.js
+++ b/public/js/pimcore/object/tags/objectbricks.js
@@ -300,17 +300,12 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                     afterrender: function (childConfig, dataProvider, manuallyAdded, panel) {
                         if (!panel.__tabpanel_initialized) {
                             var copy = Ext.decode(Ext.encode(childConfig));
-                            var children = this.getRecursiveLayout(copy, null, {
+                            var children = this.getRecursiveLayout(copy, this.fieldConfig.noteditable, {
                                 containerType: "objectbrick",
                                 containerKey: type,
                                 ownerName: this.fieldConfig.name,
                                 applyDefaults: manuallyAdded
                             }, false, true, dataProvider);
-                            if (this.fieldConfig.noteditable && children) {
-                                children.forEach(function (record) {
-                                    record.disabled = true;
-                                });
-                            }
 
                             if (children) {
                                 panel.add(children);

--- a/public/js/pimcore/object/tags/objectbricks.js
+++ b/public/js/pimcore/object/tags/objectbricks.js
@@ -306,7 +306,10 @@ pimcore.object.tags.objectbricks = Class.create(pimcore.object.tags.abstract, {
                                 ownerName: this.fieldConfig.name,
                                 applyDefaults: manuallyAdded
                             }, false, true, dataProvider);
-
+                            if (this.fieldConfig.noteditable){
+                                panel.mask();
+                            }
+                            
                             if (children) {
                                 panel.add(children);
                             }


### PR DESCRIPTION
Similar to #190 when you set an object brick field to `not editable` it gets completely disabled. Thus you can neither select any text nor can you click buttons to jump to relations (or other UI actions).

Without this PR:
<img width="771" alt="Bildschirmfoto 2023-08-01 um 17 36 46" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/8749138/0c837610-a3fa-4288-bed0-7c249384cd1b">

With this PR:
<img width="729" alt="Bildschirmfoto 2023-08-01 um 17 36 19" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/8749138/ae870a5d-40d0-4ccd-b85c-d92db18d2d46">
