### PR TITLE
[Grid] Batch update of localized object brick fields always updates English value

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1623,7 +1623,20 @@ class DataObjectHelperController extends AdminAbstractController
                             $existingData = $brick->$valueGetter();
                             $newData = $field->removeData($existingData, $newData);
                         }
-                        $brick->$valueSetter($newData);
+
+                        $localizedFields = $brickClass->getFieldDefinition('localizedfields');
+                        $isLocalizedField = false;
+                        if ($localizedFields instanceof DataObject\ClassDefinition\Data\Localizedfields) {
+                            if ($localizedFields->getFieldDefinition($brickKey)) {
+                                $isLocalizedField = true;
+                            }
+                        }
+
+                        if ($isLocalizedField) {
+                            $brick->$valueSetter($newData, $params['language']);
+                        } else {
+                            $brick->$valueSetter($newData);
+                        }
                     } else {
                         // everything else
                         $field = $class->getFieldDefinition($name);


### PR DESCRIPTION
Follow-up of https://github.com/pimcore/pimcore/pull/15076 

Steps to reproduce:

1. Configure languages German and English in system settings
1. Create data object class with object brick container `bricks`
2. Create object brick `Test` with localized input field `input`, allow this object brick for above container field
3. Create object of this class and show it in grid
4. Open grid configuration, add `Test`.`input`, set grid language to `German`
5. Select the created object in the grid, click `Batch edit selected` via column header, enter any value and apply

Behaviour without this PR:
*English* value for field `input` gets set because the setter gets called without language in https://github.com/pimcore/admin-ui-classic-bundle/blob/de8fff41a353b9e850e4394bbbb086ba89ad651f/src/Controller/Admin/DataObject/DataObjectHelperController.php#L1626 and thus English as default language gets used.

Behaviour with this PR:
*German* value gets set as we have configured the grid language to be `German`.