### PR TITLE
Fix username is set to unkown when userOwner of userModification is null

### DIFF
--- a/src/Controller/Traits/UserNameTrait.php
+++ b/src/Controller/Traits/UserNameTrait.php
@@ -37,7 +37,7 @@ trait UserNameTrait
     }
 
     /**
-     * @param int $userId The User ID.
+     * @param int|null $userId The User ID.
      *
      * @return array{userName: string, fullName: string}
      */

--- a/src/Controller/Traits/UserNameTrait.php
+++ b/src/Controller/Traits/UserNameTrait.php
@@ -41,23 +41,27 @@ trait UserNameTrait
      *
      * @return array{userName: string, fullName: string}
      */
-    protected function getUserName(int $userId): array
+    protected function getUserName(?int $userId = null): array
     {
         /** @var User|null $user */
-        $user = User::getById($userId);
-
-        if (empty($user)) {
-            $data = [
+        if ($userId === null) {
+            return [
                 'userName' => '',
                 'fullName' => $this->translator->trans('user_unknown', [], 'admin'),
             ];
-        } else {
-            $data = [
-                'userName' => $user->getName(),
-                'fullName' => (empty($user->getFullName()) ? $user->getName() : $user->getFullName()),
+        }
+        $user = User::getById($userId);
+
+        if (empty($user)) {
+            return [
+                'userName' => '',
+                'fullName' => $this->translator->trans('user_unknown', [], 'admin'),
             ];
         }
 
-        return $data;
+        return [
+            'userName' => $user->getName(),
+            'fullName' => (empty($user->getFullName()) ? $user->getName() : $user->getFullName()),
+        ];
     }
 }

--- a/src/Controller/Traits/UserNameTrait.php
+++ b/src/Controller/Traits/UserNameTrait.php
@@ -43,13 +43,13 @@ trait UserNameTrait
      */
     protected function getUserName(?int $userId = null): array
     {
-        /** @var User|null $user */
         if ($userId === null) {
             return [
                 'userName' => '',
                 'fullName' => $this->translator->trans('user_unknown', [], 'admin'),
             ];
         }
+        
         $user = User::getById($userId);
 
         if (empty($user)) {


### PR DESCRIPTION
Superseeds https://github.com/pimcore/admin-ui-classic-bundle/pull/187

Imho this fix is better.

Because first of all in the other PR user is set to 0 which is `system` user, which is not correct.
In my fix this is set to unknown which is consistent with the existing behaviour when a certain userId does not exist.

Also the fix is made in the trait which also fixes it for potential other places where the trait is used.