### PR TITLE
Update DataObjectActionsTrait.php

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -276,7 +276,7 @@ trait DataObjectActionsTrait
 
                 $fieldDefinition = $this->getFieldDefinition($class, $key);
                 if ($fieldDefinition && method_exists($fieldDefinition, 'getDataFromGridEditor')) {
-                    $value = $fieldDefinition->getDataFromGridEditor((string)$value, $object, []);
+                    $value = $fieldDefinition->getDataFromGridEditor($value, $object, []);
                 }
 
                 $objectData[$key] = $value;


### PR DESCRIPTION
This commit fixes error "Pimcore\Model\DataObject\ClassDefinition\Data\ManyToOneRelation::getDataFromGridEditor(): Argument #1 ($data) must be of type array, string given, called in /var/www/html/vendor/pimcore/admin-ui-classic-bundle/src/Controller/Admin/DataObject/DataObjectActionsTrait.php on line 279"