### PR TITLE
Asset Helper Controller: get-batch-jobs action - Method not allowed

### DIFF
--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -951,7 +951,7 @@ class AssetHelperController extends AdminAbstractController
     }
 
     /**
-     * @Route("/get-batch-jobs", name="pimcore_admin_asset_assethelper_getbatchjobs", methods={"GET"})
+     * @Route("/get-batch-jobs", name="pimcore_admin_asset_assethelper_getbatchjobs", methods={"POST"})
      *
      *
      */


### PR DESCRIPTION
Follow up to https://github.com/pimcore/pimcore/pull/15754