### PR TITLE
ExtJSCommand: Don't override $defaultName property

### DIFF
--- a/src/Command/ExtJSCommand.php
+++ b/src/Command/ExtJSCommand.php
@@ -29,13 +29,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class ExtJSCommand extends AbstractCommand
 {
-    protected static $defaultName = 'pimcore:extjs';
-
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     protected function configure(): void
     {
         $this

--- a/src/Command/ExtJSCommand.php
+++ b/src/Command/ExtJSCommand.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\AdminBundle\Command;
 use MatthiasMullie\Minify\JS;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Logger;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,12 +28,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @internal
  */
+#[AsCommand('pimcore:extjs')]
 class ExtJSCommand extends AbstractCommand
 {
     protected function configure(): void
     {
         $this
-            ->setName('pimcore:extjs')
             ->setHidden(true)
             ->setDescription('Regenerate minified ext-js file')
             ->addArgument(


### PR DESCRIPTION
```
The "Symfony\Component\Console\Command\Command::$defaultName" property is considered final. You should not override it in "Pimcore\Bundle\AdminBundle\Command\ExtJSCommand".
```