### PR TITLE
feat: preselect the site based on the current host

### DIFF
--- a/src/Service/PreviewGenerator.php
+++ b/src/Service/PreviewGenerator.php
@@ -118,7 +118,7 @@ class PreviewGenerator implements PreviewGeneratorInterface
             $label = $site->getRootDocument()?->getKey();
             $sitesOptions[$label] = $site->getId();
 
-            $domains = $site->getDomains() ?? [];
+            $domains = $site->getDomains();
             array_unshift($domains, $site->getMainDomain());
 
             if(is_null($preSelectedSite) && in_array(Tool::getHostname(), $domains)) {

--- a/src/Service/PreviewGenerator.php
+++ b/src/Service/PreviewGenerator.php
@@ -113,16 +113,22 @@ class PreviewGenerator implements PreviewGeneratorInterface
             $this->translator->trans('main_site', [], Translation::DOMAIN_ADMIN) => '0',
         ];
 
+        $preSelectedSite = null;
         foreach ($sites as $site) {
             $label = $site->getRootDocument()?->getKey();
             $sitesOptions[$label] = $site->getId();
+
+            $domains = $site->getDomains() ?? [];
+            array_unshift($domains, $site->getMainDomain());
+
+            $preSelectedSite ??= in_array(Tool::getHostname(), $domains) ? $sitesOptions[$label] : $preSelectedSite;
         }
 
         return [
             'name' => PreviewGeneratorInterface::PARAMETER_SITE,
             'label' => $this->translator->trans('preview_generator_site', [], Translation::DOMAIN_ADMIN),
             'values' => $sitesOptions,
-            'defaultValue' => reset($sitesOptions),
+            'defaultValue' => $preSelectedSite ?? reset($sitesOptions),
         ];
     }
 

--- a/src/Service/PreviewGenerator.php
+++ b/src/Service/PreviewGenerator.php
@@ -121,7 +121,9 @@ class PreviewGenerator implements PreviewGeneratorInterface
             $domains = $site->getDomains() ?? [];
             array_unshift($domains, $site->getMainDomain());
 
-            $preSelectedSite ??= in_array(Tool::getHostname(), $domains) ? $sitesOptions[$label] : $preSelectedSite;
+            if(is_null($preSelectedSite) && in_array(Tool::getHostname(), $domains)) {
+                $preSelectedSite = $sitesOptions[$label];
+            }
         }
 
         return [


### PR DESCRIPTION
This PR will pre-select the site in the preview tab of an object, if the host name was found in either the main domain or the additional domains of a site.