### PR TITLE
[Bug] Remove the question mark from the Polish translation

### DIFF
--- a/translations/admin.pl.yaml
+++ b/translations/admin.pl.yaml
@@ -104,7 +104,7 @@ retype_password: "Potw\xF3rz has\u0142o"
 reports: Raporty
 roles: Grupy
 Password: "Has\u0142o"
-Forgot your password: "Zapomnia\u0142e\u015B has\u0142o?"
+Forgot your password: "Zapomnia\u0142e\u015B has\u0142o"
 Back to Login: "Powr\xF3t do strony logowania"
 Enter your username and pimcore will send a login link to your email address: "Wpisz
   nazw\u0119 u\u017Cytkownika, a system wy\u015Ble link do logowania na Tw\xF3j adres


### PR DESCRIPTION
Other translations, including [English](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/translations/admin.en.yaml#L102C1-L102C3), do not have a question mark at the end of a sentence. As a result, the Polish translation is displayed with a double question mark.

