### PR TITLE
[Bug]: Fix cannot addEventListener to null in unsupported browser

### DIFF
--- a/templates/admin/login/login.html.twig
+++ b/templates/admin/login/login.html.twig
@@ -93,11 +93,13 @@
         }
     }, true);
 
-    let unsupportedBrowser = document.getElementById('proceed_with_unsupported_browser');
-    unsupportedBrowser.addEventListener('click', function(e) {
-        document.getElementById('loginform').style.display = 'block';
-        document.getElementById('browserinfo').style.display = 'none';
-    });
+    {% if not browserSupported %}
+        let unsupportedBrowser = document.getElementById('proceed_with_unsupported_browser');
+        unsupportedBrowser.addEventListener('click', function(e) {
+            document.getElementById('loginform').style.display = 'block';
+            document.getElementById('browserinfo').style.display = 'none';
+        });
+    {% endif %}
 </script>
 
 {% for includeTemplate in includeTemplates %}


### PR DESCRIPTION
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/6960f5aa-99d9-4a44-950b-74e17ed41ad8)
Follow up https://github.com/pimcore/admin-ui-classic-bundle/pull/232

`#proceed_with_unsupported_browser` doesn't exist in the DOM when `browserSupported` is `true`