### PR TITLE
[Improvement]: Make Password Recovery Token to be one time use only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v1.2.0
+ - Bumped `pimcore/pimcore` minimum requirement to `^11.1.0`
+
 #### v1.1.0
  - `Pimcore\Bundle\AdminBundle\Service\ElementService` is marked as internal.
  - Deprecated `DocumentTreeConfigTrait`

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   },
   "require": {
-    "pimcore/pimcore": "^11.1.0",
+    "pimcore/pimcore": "pass-reset-token-dev",
     "symfony/webpack-encore-bundle": "^1.7",
     "cbschuld/browser.php": "^1.9.6"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   },
   "require": {
-    "pimcore/pimcore": "^11.0.7",
+    "pimcore/pimcore": "^11.1.0",
     "symfony/webpack-encore-bundle": "^1.7",
     "cbschuld/browser.php": "^1.9.6"
   },

--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -224,7 +224,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
             }
 
             if (!$error) {
-                $token = Authentication::generateToken($user->getName());
+                $token = Authentication::generateToken($user);
 
                 $loginUrl = $this->generateUrl('pimcore_admin_login_check', [
                     'token' => $token,

--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -224,7 +224,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
             }
 
             if (!$error) {
-                $token = Authentication::generateToken($user);
+                $token = Authentication::generateTokenByUser($user);
 
                 $loginUrl = $this->generateUrl('pimcore_admin_login_check', [
                     'token' => $token,

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -964,7 +964,7 @@ class UserController extends AdminAbstractController implements KernelController
             ], Response::HTTP_FORBIDDEN);
         }
 
-        $token = Tool\Authentication::generateToken($user->getName());
+        $token = Tool\Authentication::generateToken($user);
         $link = $this->generateCustomUrl([
             'token' => $token,
         ]);
@@ -1170,7 +1170,7 @@ class UserController extends AdminAbstractController implements KernelController
                     $user->save();
                 }
 
-                $token = Tool\Authentication::generateToken($user->getName());
+                $token = Tool\Authentication::generateToken($user);
                 $loginUrl = $this->generateCustomUrl([
                     'token' => $token,
                     'reset' => true,

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -964,7 +964,7 @@ class UserController extends AdminAbstractController implements KernelController
             ], Response::HTTP_FORBIDDEN);
         }
 
-        $token = Tool\Authentication::generateToken($user);
+        $token = Tool\Authentication::generateTokenByUser($user);
         $link = $this->generateCustomUrl([
             'token' => $token,
         ]);
@@ -1170,7 +1170,7 @@ class UserController extends AdminAbstractController implements KernelController
                     $user->save();
                 }
 
-                $token = Tool\Authentication::generateToken($user);
+                $token = Tool\Authentication::generateTokenByUser($user);
                 $loginUrl = $this->generateCustomUrl([
                     'token' => $token,
                     'reset' => true,


### PR DESCRIPTION
Related and Requires https://github.com/pimcore/pimcore/pull/15942

To be reconsider once the bundle minimum requirement of `pimcore/pimore` is `11.1`, to use a slightly better function.
`generateToken` needs `User` to work (to save the token to the given user) and currently it does a `User::getByName`, but it could be passed straightforwardly like in the PR