### PR TITLE
After renamaning the object in tree it is not getting refreshed.

### DIFF
--- a/public/js/pimcore/elementservice.js
+++ b/public/js/pimcore/elementservice.js
@@ -505,6 +505,7 @@ pimcore.elementservice.editObjectKeyComplete = function (options, button, value,
                         pimcore.elementservice.reopenElement(options);
                         // removes loading indicator added in the applyNewKey method
                         pimcore.helpers.removeTreeNodeLoadingIndicator(elementType, id);
+                        pimcore.elementservice.refreshNode(record.parentNode);
                     }  else {
                         pimcore.helpers.showNotification(t("error"), t("error_renaming_item"), "error",
                             t(rdata.message));


### PR DESCRIPTION
When any object in tree is renamed after that that object is not getting refreshed. Because of that if you try to rename that object again then in rename pop up older value is visible not the updated one.

Example - 

Object initial name - test
Rename it to - test one (Object is not getting refreshed)
Again try to rename same object without page or tree refresh, it will show initial value (test) in rename form
