### PR TITLE
[Bug]: Fix versions reload should not trigger on failed save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v1.2.0
+ - DataObject used to automatically reloaded after save in any circumstances, now it's triggered only on successfull save. The reload can be forced by setting `forceReloadAfterSave` to `true` in a `postSaveObject` event listener.
+
 #### v1.1.0
  - `Pimcore\Bundle\AdminBundle\Service\ElementService` is marked as internal.
  - Deprecated `DocumentTreeConfigTrait`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### v1.2.0
- - DataObject used to automatically reloaded after save in any circumstances, now it's triggered only on successfull save. The reload can be forced by setting `forceReloadAfterSave` to `true` in a `postSaveObject` event listener.
+ - DataObject used to automatically reload version after save, but now it's triggered only on successfull save. The reload can be forced by setting `forceReloadAfterSave` to `true` in a `postSaveObject` event listener.
 
 #### v1.1.0
  - `Pimcore\Bundle\AdminBundle\Service\ElementService` is marked as internal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### v1.2.0
- - DataObject used to automatically reload version after save, but now it's triggered only on successfull save. The reload can be forced by setting `forceReloadAfterSave` to `true` in a `postSaveObject` event listener.
+ - DataObject used to automatically reload version after save, but now it's triggered only on successfull save. The reload can be forced by setting `forceReloadVersionsAfterSave` to `true` in a `postSaveObject` event listener.
 
 #### v1.1.0
  - `Pimcore\Bundle\AdminBundle\Service\ElementService` is marked as internal.

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -805,7 +805,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 method: "PUT",
                 params: saveData,
                 success: function (response) {
-                    let shouldReload = false;
+                    let shouldReloadVersions = false;
                     if (task != "session") {
                         try {
                             var rdata = Ext.decode(response.responseText);
@@ -835,7 +835,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                                         this.data['draft'] = rdata['draft'];
                                     }
 
-                                    shouldReload = true;
+                                    shouldReloadVersions = true;
 
                                     pimcore.helpers.updateTreeElementStyle('object', this.id, rdata.treeData);
                                     const postSaveObject = new CustomEvent(pimcore.events.postSaveObject, {
@@ -855,7 +855,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                             pimcore.helpers.showNotification(t("error"), t("saving_failed"), "error");
                         }
                         // reload versions
-                        if (this.forceReloadVersionsAfterSave || (shouldReload && task != "autoSave" && this.isAllowed("versions"))) {
+                        if (this.forceReloadVersionsAfterSave || (shouldReloadVersions && task != "autoSave" && this.isAllowed("versions"))) {
                             if (typeof this.versions.reload == "function") {
                                 try {
                                     //TODO remove this as soon as it works

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -18,7 +18,7 @@ pimcore.registerNS("pimcore.object.object");
 pimcore.object.object = Class.create(pimcore.object.abstract, {
     frontendLanguages: null,
     willClose: false,
-    forceReloadAfterSave: false,
+    forceReloadVersionsAfterSave: false,
     initialize: function (id, options) {
         this.id = intval(id);
         this.options = options;
@@ -855,7 +855,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                             pimcore.helpers.showNotification(t("error"), t("saving_failed"), "error");
                         }
                         // reload versions
-                        if (this.forceReloadAfterSave || (shouldReload && task != "autoSave" && this.isAllowed("versions"))) {
+                        if (this.forceReloadVersionsAfterSave || (shouldReload && task != "autoSave" && this.isAllowed("versions"))) {
                             if (typeof this.versions.reload == "function") {
                                 try {
                                     //TODO remove this as soon as it works

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -18,6 +18,7 @@ pimcore.registerNS("pimcore.object.object");
 pimcore.object.object = Class.create(pimcore.object.abstract, {
     frontendLanguages: null,
     willClose: false,
+    forceReloadAfterSave: false,
     initialize: function (id, options) {
         this.id = intval(id);
         this.options = options;
@@ -854,7 +855,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                             pimcore.helpers.showNotification(t("error"), t("saving_failed"), "error");
                         }
                         // reload versions
-                        if (shouldReload && task != "autoSave" && this.isAllowed("versions")) {
+                        if (forceReloadAfterSave || (shouldReload && task != "autoSave" && this.isAllowed("versions"))) {
                             if (typeof this.versions.reload == "function") {
                                 try {
                                     //TODO remove this as soon as it works

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -858,7 +858,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                             if (typeof this.versions.reload == "function") {
                                 try {
                                     //TODO remove this as soon as it works
-                                    console.log('reloading');
                                     this.versions.reload();
                                 } catch (e) {
                                     console.log(e);

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -855,7 +855,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                             pimcore.helpers.showNotification(t("error"), t("saving_failed"), "error");
                         }
                         // reload versions
-                        if (forceReloadAfterSave || (shouldReload && task != "autoSave" && this.isAllowed("versions"))) {
+                        if (this.forceReloadAfterSave || (shouldReload && task != "autoSave" && this.isAllowed("versions"))) {
                             if (typeof this.versions.reload == "function") {
                                 try {
                                     //TODO remove this as soon as it works

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -804,6 +804,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 method: "PUT",
                 params: saveData,
                 success: function (response) {
+                    let shouldReload = false;
                     if (task != "session") {
                         try {
                             var rdata = Ext.decode(response.responseText);
@@ -833,6 +834,8 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                                         this.data['draft'] = rdata['draft'];
                                     }
 
+                                    shouldReload = true;
+
                                     pimcore.helpers.updateTreeElementStyle('object', this.id, rdata.treeData);
                                     const postSaveObject = new CustomEvent(pimcore.events.postSaveObject, {
                                         detail: {
@@ -842,6 +845,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                                     });
 
                                     document.dispatchEvent(postSaveObject);
+
                                 } else {
                                     pimcore.helpers.showPrettyError("error", t("saving_failed"), rdata.message);
                                 }
@@ -850,10 +854,11 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                             pimcore.helpers.showNotification(t("error"), t("saving_failed"), "error");
                         }
                         // reload versions
-                        if (task != "autoSave" && this.isAllowed("versions")) {
+                        if (shouldReload && task != "autoSave" && this.isAllowed("versions")) {
                             if (typeof this.versions.reload == "function") {
                                 try {
                                     //TODO remove this as soon as it works
+                                    console.log('reloading');
                                     this.versions.reload();
                                 } catch (e) {
                                     console.log(e);


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/272

Not sure if it has behaviour change implications, but looks buggy, i don't understand what's the[ try catch block ](https://github.com/pimcore/admin-ui-classic-bundle/pull/273/files?w=1#diff-19561231ee9a8f94a4e06afe4d726dd9f4be310a6ab04e3ed22d9289e9f1fc45L856)is doing, there's a long-time TODO there

forceReloadVersionsAfterSave is for manual overriding via event `pimcore.events.postSaveObject` by setting `e.detail.object.forceReloadVersionsAfterSave = true;` in the listener func