### PR TITLE
[Bug]: Fix old password not being empty when resetting

### DIFF
--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -550,6 +550,15 @@ class UserController extends AdminAbstractController implements KernelController
     {
         //TODO Can be completely validated with Symfony Validator
         $user = $this->getAdminUser();
+
+        $isPasswordReset = Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $adminSession) {
+            if ($adminSession->get('password_reset')) {
+                return true;
+            }
+
+            return false;
+        });
+
         if ($user != null) {
             if ($user->getId() == $request->get('id')) {
                 $values = $this->decodeJson($request->get('data'), true);
@@ -564,16 +573,10 @@ class UserController extends AdminAbstractController implements KernelController
                 if (!empty($values['new_password'])) {
                     $oldPasswordCheck = false;
 
-                    if (empty($values['old_password'])) {
+                    if ($isPasswordReset) {
                         // if the user want to reset the password, the old password isn't required
-                        $oldPasswordCheck = Tool\Session::useBag($request->getSession(), function (AttributeBagInterface $adminSession) {
-                            if ($adminSession->get('password_reset')) {
-                                return true;
-                            }
-
-                            return false;
-                        });
-                    } else {
+                        $oldPasswordCheck = true;
+                    } elseif (!empty($values['old_password'])) {
                         $errors = $validator->validate($values['old_password'], [new UserPassword()]);
 
                         if (count($errors) === 0) {


### PR DESCRIPTION
It seems that somehow due some autocomplete and the fact that oldPassword field is just hidden in frontend (`display:none`), the field is NOT always empty.
Refactored the way it checks if is password reset.

To reviewer: just put a breakpoint to check `$values['old_password']` and may see a random value, when trying to reset a password by token via email link 