### PR TITLE
[Events] add event pimcore.events.postBuildPerspectiveElementTree and…

### DIFF
--- a/public/js/pimcore/events.js
+++ b/public/js/pimcore/events.js
@@ -297,5 +297,8 @@ pimcore.events.globalLanguageChanged = "pimcore.globalLanguage.changed";
  */
 pimcore.events.postEditObjectKey = "pimcore.objectKey.postEdit";
 
-
-
+/**
+ * fired after basic perspective element trees were  built
+ *  array of custom perspective element trees  are passed as parameter
+ */
+pimcore.events.postBuildPerspectiveElementTree = "pimcore.elementTree.perspective.postBuild";

--- a/public/js/pimcore/startup.js
+++ b/public/js/pimcore/startup.js
@@ -825,7 +825,6 @@ Ext.onReady(function () {
                     if (!treeConfig.hidden) {
                         customPerspectiveElementTrees.push(treeConfig);
                     }
-                    break;
             }
 
 

--- a/public/js/pimcore/startup.js
+++ b/public/js/pimcore/startup.js
@@ -821,7 +821,7 @@ Ext.onReady(function () {
                         }
                     }
                     break;
-                case "alternative_element_tree":
+                default:
                     if (!treeConfig.hidden) {
                         customPerspectiveElementTrees.push(treeConfig);
                     }

--- a/public/js/pimcore/startup.js
+++ b/public/js/pimcore/startup.js
@@ -737,16 +737,15 @@ Ext.onReady(function () {
             });
         }
 
-
         var perspective = pimcore.globalmanager.get("perspective");
         var elementTree = perspective.getElementTree();
-
         var locateConfigs = {
             document: [],
             asset: [],
             object: []
         };
 
+        let customPerspectiveElementTrees = [];
         for (var i = 0; i < elementTree.length; i++) {
 
             var treeConfig = elementTree[i];
@@ -822,6 +821,11 @@ Ext.onReady(function () {
                         }
                     }
                     break;
+                case "alternative_element_tree":
+                    if (!treeConfig.hidden) {
+                        customPerspectiveElementTrees.push(treeConfig);
+                    }
+                    break;
             }
 
 
@@ -835,6 +839,13 @@ Ext.onReady(function () {
 
         }
         pimcore.globalmanager.add("tree_locate_configs", locateConfigs);
+
+        const postBuildPerspectiveElementTree = new CustomEvent(pimcore.events.postBuildPerspectiveElementTree, {
+            detail: {
+                customPerspectiveElementTrees: customPerspectiveElementTrees
+            }
+        });
+        document.dispatchEvent(postBuildPerspectiveElementTree);
 
     }
     catch (e) {


### PR DESCRIPTION
## Changes in this pull request
Resolves  https://pimcore.atlassian.net/browse/PSDP-326

## Additional info

### WHAT
1- Add event pimcore.events.postBuildPerspectiveElementTree
2- Allow another type of element tree in perspective ( alternative_element_tree ) 

### HOW
copilot:walkthrough