### PR TITLE
Remove redundant layout expansions in GRID config

### DIFF
--- a/public/js/pimcore/object/helpers/classTree.js
+++ b/public/js/pimcore/object/helpers/classTree.js
@@ -164,7 +164,7 @@ pimcore.object.helpers.classTree = Class.create({
                         baseNode.appendChild(this.recursiveAddNode(data[keys[i]].children[j], baseNode, brickDescriptor, this.config));
                     }
                     if (data[keys[i]].nodeType == "object") {
-                        baseNode.expand();
+                        baseNode.expand(true);
                     } else {
                         // baseNode.collapse();
                     }
@@ -227,8 +227,6 @@ pimcore.object.helpers.classTree = Class.create({
         };
 
         newNode = this.appendChild(newNode);
-
-        this.expand();
 
         return newNode;
     },


### PR DESCRIPTION
As we discussed with Pimcore at DMEXCO with one of our enterprise customers, there is a huge client performance problem in the GRID configuration when loading the field list.

As agreed with Christian Fasching yesterday we decided to check a solution to load the Brick fields asynchronously in the GRID configuration.

To implement this I first analyzed the problem with several metrics. At first I didn't notice anything else, but when I started to split the code piece by piece and collected more metrics, I found a function call, which takes an extreme load on the client side.

When loading the layout and data fields, the ExtTree was expanded for each field. This process costs enormous resources because the heights of all elements are recalculated.
Moreover, the tree is finally expanded again.

By checking the Ext documentation I realized that the expansion can be handle recursively: https://docs.sencha.com/extjs/4.2.2/#!/api/Ext.data.NodeInterface-method-expand

What I did in my PR is nothing more than remove "expand per field call" and replaced the final post call with the recursively parameter.

In my test case, I was able to reduce the wait time from an average of 30,619s to 1,434s.

FYI: @brusch  @fashxp @skochTC 