### PR TITLE
[Grid] Prevent error when using localized object brick field and localized class field

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -447,9 +447,9 @@ class DataObjectHelperController extends AdminAbstractController
                             if ($brickClass instanceof DataObject\Objectbrick\Definition) {
                                 if ($brickDescriptor) {
                                     $innerContainer = $brickDescriptor['innerContainer'] ?? 'localizedfields';
-                                    /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedFields */
-                                    $localizedFields = $brickClass->getFieldDefinition($innerContainer);
-                                    $fd = $localizedFields->getFieldDefinition($brickDescriptor['brickfield']);
+                                    /** @var DataObject\ClassDefinition\Data\Localizedfields $localizedBrickFields */
+                                    $localizedBrickFields = $brickClass->getFieldDefinition($innerContainer);
+                                    $fd = $localizedBrickFields->getFieldDefinition($brickDescriptor['brickfield']);
                                 } else {
                                     $fd = $brickClass->getFieldDefinition($fieldname);
                                 }


### PR DESCRIPTION
Steps to reproduce:
1. Create class and brick, each with localized fields
2. Create grid config with a localized brick field and a localized data object class field -> the bug only appears if the brick field is higher than the class field)
3. Apply grid config

You will get the error
> request.CRITICAL: Uncaught PHP Exception Error: "Call to a member function getFieldDefinition() on string

The reason is that `$localizedfields` gets filled in https://github.com/pimcore/admin-ui-classic-bundle/blob/2290867662070419fc792ed1ad7c5a78edffaa83/src/Controller/Admin/DataObject/DataObjectHelperController.php#L360-L370

But when there is a localized object brick field `$localizedfields` gets overwritten in
https://github.com/pimcore/admin-ui-classic-bundle/blob/2290867662070419fc792ed1ad7c5a78edffaa83/src/Controller/Admin/DataObject/DataObjectHelperController.php#L451
Now `$localizedfields` is not an array anymore but an instance of `DataObject\ClassDefinition\Data\Localizedfields`.

And then when the localized data object class field gets processed there is an error in
https://github.com/pimcore/admin-ui-classic-bundle/blob/2290867662070419fc792ed1ad7c5a78edffaa83/src/Controller/Admin/DataObject/DataObjectHelperController.php#L480-L481
(this foreach loops through the object properties of the `DataObject\ClassDefinition\Data\Localizedfields` object)

In Pimcore 11 it may be a different error because `DataObject\ClassDefinition\Data\Localizedfields::fieldtype` has been removed but nevertheless there will be an error.