### PR TITLE
[Workflows] Fix workflowTransitionHandler not considering global actions

### DIFF
--- a/public/js/pimcore/elementservice.js
+++ b/public/js/pimcore/elementservice.js
@@ -1024,7 +1024,6 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
 
         var workflowTransitionHandler = function (workflow, transition, elementEditor, elementId, elementType) {
             var applyWorkflow = function (workflow, transition, elementEditor, elementId, elementType) {
-                transition.isGlobalAction = false;
                 if (transition.notes) {
                     new pimcore.workflow.transitionPanel(elementType, elementId, elementEditor, workflow.name, transition);
                 } else {
@@ -1057,7 +1056,7 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
 
             for (i = 0; i < workflow.allowedTransitions.length; i++) {
                 var transition = workflow.allowedTransitions[i];
-
+                transition.isGlobalAction = false;
                 items.push({
                     text: t(transition.label),
                     iconCls: transition.iconCls,
@@ -1070,7 +1069,7 @@ pimcore.elementservice.getWorkflowActionsButton = function(workflows, elementTyp
 
             for (i = 0; i < workflow.globalActions.length; i++) {
                 var transition = workflow.globalActions[i];
-
+                transition.isGlobalAction = true;
                 items.push({
                     text: t(transition.label),
                     iconCls: transition.iconCls,


### PR DESCRIPTION
Global actions get treated as a normal transition since it does not get the attribute isGlobalAction set to true. This causes the global action to be posted to the wrong endpoint with an error saying unknown transition.