### PR TITLE
[Improvement]: Add the possibility to select type for Calculated Values

### DIFF
--- a/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -115,7 +115,6 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
                         ['html', t('html')],
                         ['number', t('number')],
                         ['date', t('date')],
-                        ['list', t('select')],
                         ['boolean', t('bool')]
                     ]
                 },

--- a/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -112,7 +112,11 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
                     store: [
                         ['input', t('input')],
                         ['textarea', t('textarea')],
-                        ['html', t('html')]
+                        ['html', t('html')],
+                        ['number', t('number')],
+                        ['date', t('date')],
+                        ['list', t('select')],
+                        ['boolean', t('bool')]
                     ]
                 },
                 {

--- a/public/js/pimcore/object/classes/data/calculatedValue.js
+++ b/public/js/pimcore/object/classes/data/calculatedValue.js
@@ -113,7 +113,7 @@ pimcore.object.classes.data.calculatedValue = Class.create(pimcore.object.classe
                         ['input', t('input')],
                         ['textarea', t('textarea')],
                         ['html', t('html')],
-                        ['number', t('number')],
+                        ['numeric', t('number')],
                         ['date', t('date')],
                         ['boolean', t('bool')]
                     ]

--- a/public/js/pimcore/object/tags/calculatedValue.js
+++ b/public/js/pimcore/object/tags/calculatedValue.js
@@ -107,15 +107,16 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             }
 
             if (value && this.fieldConfig?.elementType === 'date') {
-                const timestamp = intval(value) * 1000;
-                const date = new Date(timestamp);
-
-                return Ext.Date.format(date, "Y-m-d");
+                if (!isNaN(+value)) {
+                    const timestamp = parseInt(value) * 1000;
+                    const date = new Date(timestamp);
+                    return Ext.Date.format(date, "Y-m-d");
+                }
             } else if (this.fieldConfig?.elementType === 'boolean') {
-                if (value) {
-                    return "true"
+                if (this.fieldConfig.calculatorType !== "expression") {
+                    return value ? "true" : "false";
                 } else {
-                    return "false"
+                    return JSON.parse(value) ? "true" : "false";
                 }
             }
             else if (value && (this.fieldConfig === undefined || this.fieldConfig.elementType !== 'html')) {

--- a/public/js/pimcore/object/tags/calculatedValue.js
+++ b/public/js/pimcore/object/tags/calculatedValue.js
@@ -63,6 +63,8 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             this.component = new Ext.form.field.TextArea(input);
         } else if (this.fieldConfig.elementType === 'html') {
             this.component = new Ext.form.field.Display(input);
+        } else if (this.fieldConfig.elementType === 'date') {
+            this.component = new Ext.form.DateField(input);
         } else {
             this.component = new Ext.form.field.Text(input);
         }
@@ -104,7 +106,12 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
                 console.log(e);
             }
 
-            if (value && (this.fieldConfig === undefined || this.fieldConfig.elementType !== 'html')) {
+            if (value && this.fieldConfig.elementType === 'date') {
+                const timestamp = intval(value) * 1000;
+                const date = new Date(timestamp);
+
+                return Ext.Date.format(date, "Y-m-d");
+            } else if (value && (this.fieldConfig === undefined || this.fieldConfig.elementType !== 'html')) {
                 value = value.toString().replace(/\n/g,"<br>");
                 value = strip_tags(value, '<br>');
             }

--- a/public/js/pimcore/object/tags/calculatedValue.js
+++ b/public/js/pimcore/object/tags/calculatedValue.js
@@ -86,7 +86,10 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
     },
 
     getGridColumnFilter: function (field) {
-        return {type: 'string', dataIndex: field.key};
+        if (['input', 'textarea', 'html'].some((val) => field.layout.elementType.includes(val))) {
+            return {type: 'string', dataIndex: field.key};
+        }
+        return {type: field.layout.elementType, dataIndex: field.key};
     },
 
     getGridColumnConfig:function (field) {

--- a/public/js/pimcore/object/tags/calculatedValue.js
+++ b/public/js/pimcore/object/tags/calculatedValue.js
@@ -111,7 +111,14 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
                 const date = new Date(timestamp);
 
                 return Ext.Date.format(date, "Y-m-d");
-            } else if (value && (this.fieldConfig === undefined || this.fieldConfig.elementType !== 'html')) {
+            } else if (this.fieldConfig.elementType === 'boolean') {
+                if (value) {
+                    return "true"
+                } else {
+                    return "false"
+                }
+            }
+            else if (value && (this.fieldConfig === undefined || this.fieldConfig.elementType !== 'html')) {
                 value = value.toString().replace(/\n/g,"<br>");
                 value = strip_tags(value, '<br>');
             }

--- a/public/js/pimcore/object/tags/calculatedValue.js
+++ b/public/js/pimcore/object/tags/calculatedValue.js
@@ -106,12 +106,12 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
                 console.log(e);
             }
 
-            if (value && this.fieldConfig.elementType === 'date') {
+            if (value && this.fieldConfig?.elementType === 'date') {
                 const timestamp = intval(value) * 1000;
                 const date = new Date(timestamp);
 
                 return Ext.Date.format(date, "Y-m-d");
-            } else if (this.fieldConfig.elementType === 'boolean') {
+            } else if (this.fieldConfig?.elementType === 'boolean') {
                 if (value) {
                     return "true"
                 } else {


### PR DESCRIPTION
## Changes in this pull request

This pull request adds different type for calculated values. 
Sometimes, your calculator returns a boolean or a number, it should be possible to filter the value as a number instead of a string (adds greater than, less than...) in grids

![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/35225430/d7808589-e616-4ce5-9462-b72416701b8e)
 