### PR TITLE
Focal Point Marker vanishes on resize

### DIFF
--- a/public/js/pimcore/asset/image.js
+++ b/public/js/pimcore/asset/image.js
@@ -379,6 +379,7 @@ pimcore.asset.image = Class.create(pimcore.asset.asset, {
 
         var html = '<img src="' + this.data.imageInfo['previewUrl'] + '">';
         Ext.get(this.previewContainerId).setHtml(html);
+        this.marker = false;
 
         let area = this.displayPanel.getEl().down('img');
         if(area) {


### PR DESCRIPTION
If the window is resized the focal point marker element is removed from the image container ( `Ext.get(this.previewContainerId).setHtml(html);`) but the internal reference to the marker element is kept and the `addFocalPoint` method will only add a new marker if the reference is falsy

## Steps to reproduce
 - open image asset
 - set focal point
 - resize window