### PR TITLE
[Fix] - Fix problem with filtering action on a non-editable checkbox in the grid

### DIFF
--- a/public/js/pimcore/object/tags/checkbox.js
+++ b/public/js/pimcore/object/tags/checkbox.js
@@ -39,7 +39,6 @@ pimcore.object.tags.checkbox = Class.create(pimcore.object.tags.abstract, {
     getGridColumnConfig:function (field) {
         var columnConfig = {
             xtype: "checkcolumn",
-            disabled: field.layout.noteditable,
             text: t(field.label),
             dataIndex:field.key,
             renderer:function (key, value, metaData, record, rowIndex, colIndex, store) {


### PR DESCRIPTION
# Changes in this pull request

Resolves [#15394](https://github.com/pimcore/admin-ui-classic-bundle/issues/343) (from [pimcore/pimcore](https://github.com/pimcore/pimcore) repo)

Allow a user to filter on a non-editable checkbox in the grid