### PR TITLE
[Bug]: Fix refresh `Embedded meta info` on replace asset

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -616,6 +616,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $stream = fopen($_FILES['Filedata']['tmp_name'], 'r+');
         $asset->setStream($stream);
         $asset->setCustomSetting('thumbnails', null);
+        $asset->getEmbeddedMetaData(true);
         $asset->setUserModification($this->getAdminUser()->getId());
 
         $newFileExt = pathinfo($newFilename, PATHINFO_EXTENSION);

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -617,6 +617,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $asset->setStream($stream);
         $asset->setCustomSetting('thumbnails', null);
         $asset->setUserModification($this->getAdminUser()->getId());
+        $asset->getEmbeddedMetaData(true);
 
         $newFileExt = pathinfo($newFilename, PATHINFO_EXTENSION);
         $currentFileExt = pathinfo($asset->getFilename(), PATHINFO_EXTENSION);

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -616,9 +616,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $stream = fopen($_FILES['Filedata']['tmp_name'], 'r+');
         $asset->setStream($stream);
         $asset->setCustomSetting('thumbnails', null);
-        $asset->getEmbeddedMetaData(true);
+        if (method_exists($asset, 'getEmbeddedMetaData')) {
+            $asset->getEmbeddedMetaData(true);
+        }
         $asset->setUserModification($this->getAdminUser()->getId());
-        $asset->getEmbeddedMetaData(true);
 
         $newFileExt = pathinfo($newFilename, PATHINFO_EXTENSION);
         $currentFileExt = pathinfo($asset->getFilename(), PATHINFO_EXTENSION);


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/338

using method exists because the getter comes from a trait
https://github.com/pimcore/pimcore/blob/68f198d32add713f2e4025b5dcb6414754133145/models/Asset/MetaData/EmbeddedMetaDataTrait.php#L17-L22