### PR TITLE
[Translation]: Add `username` translation in login form

### DIFF
--- a/public/js/pimcore/element/permissionchecker.js
+++ b/public/js/pimcore/element/permissionchecker.js
@@ -254,7 +254,7 @@ pimcore.element.permissionchecker = Class.create({
         this.resultPanel.removeAll();
 
         var columns = [
-            {text: t("Username"), sortable: false, dataIndex: "userName", editable: false, flex: 150, filter: 'string'}
+            {text: t("username"), sortable: false, dataIndex: "userName", editable: false, flex: 150, filter: 'string'}
         ];
 
         var columnCount = data.columns.length;

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -970,6 +970,7 @@ email_log_subject: Subject
 gdpr_data_extractor_label_email: 'Email Address'
 workflow_notes: Notes
 2fa_code: Code
+username: Username
 password: Password
 show_metainfo: Info
 email_log_from: From

--- a/translations/admin_ext.en.yaml
+++ b/translations/admin_ext.en.yaml
@@ -689,7 +689,6 @@ quantityValueRange_field: Quantity Value Range
 numeric: Number
 structuredtable_type_number: Number
 objectsMetadata_type_number: Number
-username: Username
 localized_fields: Localized Fields
 field_collections: Field-Collections
 special_settings_tooltip: Special Settings


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/202

It would be easier to copy the translation of `Username` (first letter capital) for lowercase username
Altenratively could change the placeholder
https://github.com/pimcore/admin-ui-classic-bundle/blob/bed29a3cc0321c1065a3ab43af73a32a4627f3af/templates/admin/login/login.html.twig#L18-L19

with `{{ 'Username'|trans([], 'admin_ext') }}` or auto fallback with `{{ 'Username'|trans }}`