### PR TITLE
Fix 2FA authentication for firewalls other than admin

### DIFF
--- a/src/Security/PimcoreUserTwoFactorCondition.php
+++ b/src/Security/PimcoreUserTwoFactorCondition.php
@@ -27,8 +27,9 @@ class PimcoreUserTwoFactorCondition implements TwoFactorConditionInterface
 {
     public function shouldPerformTwoFactorAuthentication(AuthenticationContextInterface $context): bool
     {
+        //return true for performing two factor for firewalls other than admin
         if ($context->getFirewallName() !== 'pimcore_admin') {
-            return false;
+            return true;
         }
 
         $user = $context->getUser();


### PR DESCRIPTION
Steps to reproduce:
1. Setup 2FA for non admin firewall (e.g. simple setup email https://symfony.com/bundles/SchebTwoFactorBundle/6.x/providers/email.html#how-authentication-works)
2. login
3. No 2FA executed