### PR TITLE
[Bug] Avoid multiple save ajax calls

### DIFF
--- a/public/js/pimcore/asset/asset.js
+++ b/public/js/pimcore/asset/asset.js
@@ -365,6 +365,7 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
         }
 
         this.tab.mask();
+        this.saving = true;
 
         const preSaveAsset = new CustomEvent(pimcore.events.preSaveAsset, {
             detail: {
@@ -377,6 +378,7 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
         const isAllowed = document.dispatchEvent(preSaveAsset);
         if (!isAllowed) {
             this.tab.unmask();
+            this.saving = false;
             return false;
         }
 
@@ -385,8 +387,6 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
         if (task) {
             params.task = task
         }
-
-        this.saving = true;
 
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_asset_save'),

--- a/public/js/pimcore/asset/asset.js
+++ b/public/js/pimcore/asset/asset.js
@@ -386,6 +386,8 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
             params.task = task
         }
 
+        this.saving = true;
+
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_asset_save'),
             method: "PUT",
@@ -431,6 +433,9 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
             }.bind(this),
             failure: function () {
                 this.tab.unmask();
+            }.bind(this),
+            callback: function (){
+                this.saving = false;
             }.bind(this),
             params: params
         });

--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -88,7 +88,7 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
         }
 
         if (this.saveInProgress()){
-            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '');
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info");
             return;
         }
 

--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -87,6 +87,11 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
             return;
         }
 
+        if (this.isSaving()){
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 300);
+            return;
+        }
+
         if(typeof task !== 'string') {
             task = '';
         }
@@ -112,9 +117,12 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                 cancelable: true
             });
 
+            this.saving = true;
+
             const isAllowed = document.dispatchEvent(preSaveDocument);
             if (!isAllowed) {
                 this.tab.unmask();
+                this.saving = false;
                 return false;
             }
 
@@ -187,6 +195,9 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                 }.bind(this),
                 failure: function () {
                     this.tab.unmask();
+                }.bind(this),
+                callback: function (){
+                    this.saving = false;
                 }.bind(this),
             });
         } else {

--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -88,7 +88,7 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
         }
 
         if (this.saveInProgress()){
-            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 300);
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '');
             return;
         }
 

--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -87,7 +87,7 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
             return;
         }
 
-        if (this.isSaving()){
+        if (this.saveInProgress()){
             pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 300);
             return;
         }

--- a/public/js/pimcore/element/abstract.js
+++ b/public/js/pimcore/element/abstract.js
@@ -245,7 +245,7 @@ pimcore.element.abstract = Class.create({
         }
     },
 
-    isSaving: function(){
+    saveInProgress: function(){
         return this.saving;
     },
 

--- a/public/js/pimcore/element/abstract.js
+++ b/public/js/pimcore/element/abstract.js
@@ -18,6 +18,7 @@ pimcore.registerNS("pimcore.element.abstract");
 pimcore.element.abstract = Class.create({
 
     dirty: false,
+    saving: false,
 
     /**
      * if allowDirtyClose is true, a tab can be closed whether
@@ -242,6 +243,10 @@ pimcore.element.abstract = Class.create({
         } else if (typeof callback === 'function') {
             callback();
         }
+    },
+
+    isSaving: function(){
+        return this.saving;
     },
 
     setAddToHistory: function (addToHistory) {

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -589,6 +589,7 @@ pimcore.helpers.showNotification = function (title, text, type, detailText, hide
             maxWidth: 350,
             closeable: true,
             align: "br",
+            autoCloseDelay: hideDelay || 3000,
             anchor: Ext.get(tabsBody),
             paddingX: 5,
             paddingY: paddingY

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -589,7 +589,6 @@ pimcore.helpers.showNotification = function (title, text, type, detailText, hide
             maxWidth: 350,
             closeable: true,
             align: "br",
-            autoCloseDelay: hideDelay || 3000,
             anchor: Ext.get(tabsBody),
             paddingX: 5,
             paddingY: paddingY

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -765,7 +765,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
     },
 
     save: function (task, only, callback, successCallback) {
-
         var omitMandatoryCheck = false;
 
         // unpublish and save version is possible without checking mandatory fields
@@ -774,6 +773,10 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         }
 
         if (this.tab.disabled || (this.tab.isMasked() && task != 'autoSave')) {
+            return;
+        }
+        if (this.isSaving()){
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 100);
             return;
         }
 
@@ -800,6 +803,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 return false;
             }
 
+            this.saving = true;
             Ext.Ajax.request({
                 url: Routing.generate('pimcore_admin_dataobject_dataobject_save', {task: task}),
                 method: "PUT",
@@ -882,6 +886,10 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 }.bind(this),
                 failure: function (response) {
                     this.tab.unmask();
+                }.bind(this),
+                callback: function (){
+                    this.saving = false;
+                    console.log(this.isSaving());
                 }.bind(this)
             });
 

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -775,7 +775,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
         if (this.tab.disabled || (this.tab.isMasked() && task != 'autoSave')) {
             return;
         }
-        if (this.isSaving()){
+        if (this.saveInProgress()){
             pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 300);
             return;
         }

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -776,7 +776,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             return;
         }
         if (this.saveInProgress()){
-            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 300);
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '');
             return;
         }
 

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -776,7 +776,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             return;
         }
         if (this.isSaving()){
-            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 100);
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '', 300);
             return;
         }
 

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -889,7 +889,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 }.bind(this),
                 callback: function (){
                     this.saving = false;
-                    console.log(this.isSaving());
                 }.bind(this)
             });
 

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -800,6 +800,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             const isAllowed = document.dispatchEvent(preSaveObject);
             if (!isAllowed) {
                 this.tab.unmask();
+                this.saving = false;
                 return false;
             }
 

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -776,7 +776,7 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
             return;
         }
         if (this.saveInProgress()){
-            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info", '');
+            pimcore.helpers.showNotification(t("warning"), t("Another saving process is in progress, please wait and retry again"), "info");
             return;
         }
 


### PR DESCRIPTION
Potentially resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/346

The reasons is that the tab is not being masked during the whole auto-saving process https://github.com/pimcore/admin-ui-classic-bundle/blob/a0b64ffcf41f6bceb8a96297f804fd6c91819ce5/public/js/pimcore/object/object.js#L783-L785 since we cannot mask it on autosave (otherwise it may interrupt editor's work on regular intervals), we briefly notify the user that another save is in progress and to retry later instead, IF, they press the save button or hotkey, exactly during an autosave.

Maybe can refactor be more specific (`isSaving` to `isAutosaving`) that an autosave is in progress, because under normal circumstances without auto-save, the save button and shortcut cannot be spammed.


~`pimcore.helpers.showNotification` parameter `hideDelay` was unused and is also fixed.~
