### PR TITLE
[DataObjects] Do not set general settings data back to object on save

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1381,21 +1381,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             }
         }
 
-        // general settings
-        // @TODO: IS THIS STILL NECESSARY?
-        if ($request->get('general')) {
-            $general = $this->decodeJson($request->get('general'));
-
-            // do not allow all values to be set, will cause problems (eg. icon)
-            if (is_array($general) && count($general) > 0) {
-                foreach ($general as $key => $value) {
-                    if (!in_array($key, ['id', 'classId', 'className', 'type', 'icon', 'userOwner', 'userModification', 'modificationDate'])) {
-                        $object->setValue($key, $value);
-                    }
-                }
-            }
-        }
-
         $this->assignPropertiesFromEditmode($request, $object);
         $this->applySchedulerDataToElement($request, $object);
 


### PR DESCRIPTION
Resolves #351

## Additional Info
As per debugging, it set the values to object from general settings which are already set.

Also, Object created from API should be same the one created from Admin UI