### PR TITLE
[Task]: Deprecate date editable format fallback

### DIFF
--- a/public/js/pimcore/document/editables/date.js
+++ b/public/js/pimcore/document/editables/date.js
@@ -30,11 +30,6 @@ pimcore.document.editables.date = Class.create(pimcore.document.editable, {
     render: function () {
         this.setupWrapper();
 
-        if (this.config.format) {
-            // replace any % prefixed parts from strftime format
-            this.config.format = this.config.format.replace(/%([a-zA-Z])/g, '$1');
-        }
-
         if(this.data) {
             this.config.value = this.data;
         }

--- a/public/js/pimcore/document/editables/date.js
+++ b/public/js/pimcore/document/editables/date.js
@@ -31,7 +31,7 @@ pimcore.document.editables.date = Class.create(pimcore.document.editable, {
         this.setupWrapper();
         
         if (this.config.format && this.config.format.includes('%')) {
-            console.warn('Deprecated: Date format contains % symbols which is used for strftime, please the use parameters format according Carbon isoFormat instead.');
+            console.warn('Deprecated: Date format contains % symbols which is used for strftime, please the use parameters according Ext.Date formatting syntax instead.');
 
             // replace any % prefixed parts from strftime format
             this.config.format = this.config.format.replace(/%([a-zA-Z])/g, '$1');

--- a/public/js/pimcore/document/editables/date.js
+++ b/public/js/pimcore/document/editables/date.js
@@ -29,7 +29,14 @@ pimcore.document.editables.date = Class.create(pimcore.document.editable, {
 
     render: function () {
         this.setupWrapper();
+        
+        if (this.config.format && this.config.format.includes('%')) {
+            console.warn('Deprecated: Date format contains % symbols which is used for strftime, please the use parameters format according Carbon isoFormat instead.');
 
+            // replace any % prefixed parts from strftime format
+            this.config.format = this.config.format.replace(/%([a-zA-Z])/g, '$1');
+        }
+        
         if(this.data) {
             this.config.value = this.data;
         }


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/pull/14431#issuecomment-1441644584

Related https://github.com/pimcore/pimcore/issues/14524
See also https://github.com/pimcore/pimcore/pull/15849


Should be likely removed instead, it's not supported to be passing `strtime` parameters 