### PR TITLE
[Bug] Key 32 translated to Space

### DIFF
--- a/public/js/pimcore/settings/user/user/keyBindings.js
+++ b/public/js/pimcore/settings/user/user/keyBindings.js
@@ -42,6 +42,8 @@ pimcore.settings.user.user.keyBindings = Class.create({
         if (code.key) {
             if (code.key >= 112 && code.key <= 123) {
                 parts.push("F" + (code.key - 111));
+            } else if(code.key === 32) {
+                parts.push(t("Space"));
             } else {
                 parts.push(String.fromCharCode(code.key));
             }


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/358
A Space is not displayed the correct way. 
This replaces the keycode 32 with the Space