### PR TITLE
[Bug]: Add multiselect to avoid `cancel` button clearing selected values

### DIFF
--- a/public/js/pimcore/asset/metadata/grid.js
+++ b/public/js/pimcore/asset/metadata/grid.js
@@ -246,7 +246,7 @@ pimcore.asset.metadata.grid = Class.create({
                         //enable different editors per row
                         editor.editors.each(function (e) {
                             try {
-                                let fieldType = e.fieldInfo?.layout?.fieldtype;
+                                const fieldType = e.fieldInfo?.layout?.fieldtype;
                                 if (fieldType === 'manyToManyRelation' || fieldType === 'multiselect') {
                                     return;
                                 }

--- a/public/js/pimcore/asset/metadata/grid.js
+++ b/public/js/pimcore/asset/metadata/grid.js
@@ -246,7 +246,8 @@ pimcore.asset.metadata.grid = Class.create({
                         //enable different editors per row
                         editor.editors.each(function (e) {
                             try {
-                                if (e.fieldInfo?.layout?.fieldtype === 'manyToManyRelation') {
+                                let fieldType = e.fieldInfo?.layout?.fieldtype;
+                                if (fieldType === 'manyToManyRelation' || fieldType === 'multiselect') {
                                     return;
                                 }
                                 // complete edit, so the value is stored when hopping around with TAB


### PR DESCRIPTION
Followup https://github.com/pimcore/admin-ui-classic-bundle/pull/364, similar problem https://github.com/pimcore/asset-metadata-class-definitions/issues/151 affecting multiselect
noticedd when fixing https://github.com/pimcore/asset-metadata-class-definitions/pull/157