### PR TITLE
Fix: gridview filtering with multiple filters starting with null or empty filter

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -359,9 +359,9 @@ class GridHelperService
                         }
                     }
                 } elseif ($filter['property'] !== 'fullpath') {
-                    $conditionPartsFilters[] =
+                    $conditionPartsFilters[] = "( ".
                         $db->quoteIdentifier($filter['property']) . ' IS NULL OR ' .
-                        $db->quoteIdentifier($filter['property']) . " = ''";
+                        $db->quoteIdentifier($filter['property']) . " = '' )";
                 }
             }
         }

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -359,7 +359,7 @@ class GridHelperService
                         }
                     }
                 } elseif ($filter['property'] !== 'fullpath') {
-                    $conditionPartsFilters[] = "( ".
+                    $conditionPartsFilters[] = "( " .
                         $db->quoteIdentifier($filter['property']) . ' IS NULL OR ' .
                         $db->quoteIdentifier($filter['property']) . " = '' )";
                 }


### PR DESCRIPTION
Code update: (Empty filter or NULL) can always be set in combination with other filters, regardless of the sequence. This is related to the order of execution of the boolean operators.