### PR TITLE
[Bug]: Removes `Filter by relation` from reverse object relation grid view

### DIFF
--- a/public/js/pimcore/object/tags/reverseObjectRelation.js
+++ b/public/js/pimcore/object/tags/reverseObjectRelation.js
@@ -20,7 +20,7 @@ pimcore.object.tags.reverseObjectRelation = Class.create(pimcore.object.tags.man
     pathProperty: "fullpath",
 
     getGridColumnConfig: function ($super, fieldConfig) {
-        let gridColumnConfig = $super(fieldConfig);
+        const gridColumnConfig = $super(fieldConfig);
         delete gridColumnConfig.getRelationFilter;
         return gridColumnConfig;
     },

--- a/public/js/pimcore/object/tags/reverseObjectRelation.js
+++ b/public/js/pimcore/object/tags/reverseObjectRelation.js
@@ -19,6 +19,12 @@ pimcore.object.tags.reverseObjectRelation = Class.create(pimcore.object.tags.man
 
     pathProperty: "fullpath",
 
+    getGridColumnConfig: function ($super, fieldConfig) {
+        let gridColumnConfig = $super(fieldConfig);
+        delete gridColumnConfig.getRelationFilter;
+        return gridColumnConfig;
+    },
+
     removeObject: function (index) {
 
         if (pimcore.globalmanager.exists("object_" + this.getStore().getAt(index).data.id) == false) {


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/16273#issuecomment-1863949815

Removing due to being not supported yet.


The check is on if this function `getRelationFilter` exists
https://github.com/pimcore/admin-ui-classic-bundle/blob/5f9a715c64b8f3e033523b3d07b99930a1689ea2/public/js/pimcore/element/helpers/gridColumnConfig.js#L355