### PR TITLE
Fix broken image editor

### DIFF
--- a/templates/admin/asset/image_editor.html.twig
+++ b/templates/admin/asset/image_editor.html.twig
@@ -80,6 +80,7 @@
 
     /**
     * wait for image editor to be fully available 
+    * before loading image to editor
     */
     async function loadEditor(e) {
         return new Promise(resolve => {

--- a/templates/admin/asset/image_editor.html.twig
+++ b/templates/admin/asset/image_editor.html.twig
@@ -77,7 +77,23 @@
 
 <img style="visibility: hidden" id='image' src="{{ imageUrl }}" />
 <script {{ pimcore_csp.getNonceHtmlAttribute()|raw }}>
-    window.addEventListener('load', function (e) {
+
+    /**
+    * wait for image editor to be fully available 
+    */
+    async function loadEditor(e) {
+        return new Promise(resolve => {
+            var checkInterval = setInterval(() => {
+                if (window.Layers) {
+                    clearInterval(checkInterval);
+                    loadImageToEditor(e);
+                    resolve(true);
+                }
+            }, 300);
+        });
+    }
+
+    function loadImageToEditor(e) {
         var image = document.getElementById('image');
         window.Layers.insert({
             name: "{{ asset.getFilename() }}",
@@ -109,7 +125,16 @@
 
             return false;
         });
+    }
+    
+    window.addEventListener("load", function(e) {
+        loadEditor(e).then(function() {
+            console.log("editor loaded");
+        });
     }, false);
+    
+
+
 </script>
 
 </body>


### PR DESCRIPTION
This PR targets the problem described here: https://github.com/pimcore/pimcore/discussions/16388

Image editing didn't work anymore, because the load event didn't wait for the canvas to be fully loaded. 

