### PR TITLE
[Bugfix] textLayoutPreviewAction does not assign a name to the text element

### DIFF
--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -2076,7 +2076,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $obj = DataObject::getByPath($objPath) ?? new $className();
 
         $textLayout = new DataObject\ClassDefinition\Layout\Text();
-
+        $textLayout->setName('Preview');
         $context = [
           'data' => $request->get('renderingData'),
         ];


### PR DESCRIPTION
To be able to use the preview in the class editor, an object with a name is expected. 
The solution provided is only used for the preview and has no effect on other areas.

Currently, the preview options in the demo systems of Pimcore do not seem to work and throw an error 500