### PR TITLE
[bugfix] Do not call htmlspecialchars with null

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -1807,7 +1807,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     'id' => $asset->getId(),
                     'type' => $asset->getType(),
                     'filename' => $asset->getFilename(),
-                    'filenameDisplay' => htmlspecialchars($filenameDisplay),
+                    'filenameDisplay' => htmlspecialchars($filenameDisplay ?? ''),
                     'url' => $this->elementService->getThumbnailUrl($asset),
                     'idPath' => $data['idPath'] = Element\Service::getIdPath($asset),
                 ];

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -958,7 +958,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 if (!isset($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getKey(),
-                        'text' => htmlspecialchars($item->getGroup() ?? ''),
+                        'text' => htmlspecialchars($item->getGroup()),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,
@@ -1380,7 +1380,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 if (!isset($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getKey(),
-                        'text' => htmlspecialchars($item->getGroup() ?? ''),
+                        'text' => htmlspecialchars($item->getGroup()),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -958,7 +958,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 if (!isset($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getKey(),
-                        'text' => htmlspecialchars($item->getGroup()),
+                        'text' => htmlspecialchars($item->getGroup() ?? ''),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,
@@ -1380,7 +1380,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 if (!isset($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getKey(),
-                        'text' => htmlspecialchars($item->getGroup()),
+                        'text' => htmlspecialchars($item->getGroup() ?? ''),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,
@@ -2220,7 +2220,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
             if (!isset($groups[$group])) {
                 $groups[$group] = [
                     'id' => 'group_' . $id,
-                    'text' => htmlspecialchars($group),
+                    'text' => htmlspecialchars($group ?? ''),
                     'expandable' => true,
                     'leaf' => false,
                     'allowChildren' => true,

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1506,7 +1506,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         foreach ($list as $item) {
             $resultItem = [
                 'id' => $item->getId(),
-                'text' => htmlspecialchars($item->getName(), ENT_QUOTES),
+                'text' => htmlspecialchars($item->getName() ?? '', ENT_QUOTES),
                 'expandable' => false,
                 'leaf' => true,
                 'expanded' => true,

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -833,7 +833,7 @@ class SettingsController extends AdminAbstractController
                 if (empty($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getName(),
-                        'text' => htmlspecialchars($item->getGroup() ?? ''),
+                        'text' => htmlspecialchars($item->getGroup()),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,
@@ -1064,7 +1064,7 @@ class SettingsController extends AdminAbstractController
                 if (empty($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getName(),
-                        'text' => htmlspecialchars($item->getGroup() ?? ''),
+                        'text' => htmlspecialchars($item->getGroup()),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -833,7 +833,7 @@ class SettingsController extends AdminAbstractController
                 if (empty($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getName(),
-                        'text' => htmlspecialchars($item->getGroup()),
+                        'text' => htmlspecialchars($item->getGroup() ?? ''),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,
@@ -1064,7 +1064,7 @@ class SettingsController extends AdminAbstractController
                 if (empty($groups[$item->getGroup()])) {
                     $groups[$item->getGroup()] = [
                         'id' => 'group_' . $item->getName(),
-                        'text' => htmlspecialchars($item->getGroup()),
+                        'text' => htmlspecialchars($item->getGroup() ?? ''),
                         'expandable' => true,
                         'leaf' => false,
                         'allowChildren' => true,

--- a/src/Service/ElementService.php
+++ b/src/Service/ElementService.php
@@ -76,7 +76,7 @@ class ElementService implements ElementServiceInterface
         $tmpNode = [
             'id' => $element->getId(),
             'key' => $element->getKey(),
-            'text' => htmlspecialchars($element->getKey()),
+            'text' => htmlspecialchars($element->getKey() ?? ''),
             'type' => $element->getType(),
             'path' => $element->getRealFullPath(),
             'basePath' => $element->getRealPath(),


### PR DESCRIPTION
En legacy environments stuff can sometimes be null which htmlspecialchars doesn't like. Hence this PR to avoid that.