### PR TITLE
Fix loading login background image from remote

### DIFF
--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /**
@@ -170,7 +171,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         }
 
         return $this->json([
-           'csrfToken' => $csrfProtection->getCsrfToken($request->getSession()),
+            'csrfToken' => $csrfProtection->getCsrfToken($request->getSession()),
         ]);
     }
 

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -125,7 +125,7 @@ class AdminExtension extends AbstractExtension
         }
 
         if (
-            preg_match('@^https?://@', $customImage) === true
+            preg_match('@^https?://@', $customImage) === 1
             || is_file(PIMCORE_WEB_ROOT . '/var/assets' . $customImage) === true
             || is_file(PIMCORE_WEB_ROOT . $customImage) === true
         ) {

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -17,7 +17,10 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\AdminBundle\Twig\Extension;
 
+use Exception;
+use Pimcore\Bundle\AdminBundle\System\AdminConfig;
 use Pimcore\Bundle\AdminBundle\Tool;
+use Pimcore\Config;
 use Pimcore\Http\Request\Resolver\EditmodeResolver;
 use Pimcore\Security\User\UserLoader;
 use Pimcore\Tool\Admin;
@@ -44,6 +47,7 @@ class AdminExtension extends AbstractExtension
             new TwigFunction('pimcore_language_flag', [Tool::class, 'getLanguageFlagFile']),
             new TwigFunction('pimcore_minimize_scripts', [$this, 'minimize']),
             new TwigFunction('pimcore_editmode_admin_language', [$this, 'getAdminLanguage']),
+            new TwigFunction('pimcore_login_background_image', [$this, 'getLoginBackgroundImage']),
         ];
     }
 
@@ -71,9 +75,10 @@ class AdminExtension extends AbstractExtension
         $scriptContents = '';
         foreach ($paths as $path) {
             $found = false;
-            foreach ([PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/js/' . $path,
-                        PIMCORE_WEB_ROOT . $path,
-                    ] as $fullPath) {
+            foreach ([
+                PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/js/' . $path,
+                PIMCORE_WEB_ROOT . $path,
+            ] as $fullPath) {
                 if (is_file($fullPath)) {
                     $scriptContents .= file_get_contents($fullPath) . "\n\n\n";
                     $found = true;
@@ -98,11 +103,59 @@ class AdminExtension extends AbstractExtension
         return '<script src="' . $url . '"></script>' . "\n";
     }
 
+    public function getLoginBackgroundImage(string $fallback = ''): string
+    {
+        $possibleDefaultImages = [
+            '/bundles/pimcoreadmin/img/login/pimconaut-ecommerce.svg',
+            '/bundles/pimcoreadmin/img/login/pimconaut-world.svg',
+            '/bundles/pimcoreadmin/img/login/pimconaut-engineer.svg',
+            '/bundles/pimcoreadmin/img/login/pimconaut-moon.svg',
+            '/bundles/pimcoreadmin/img/login/pimconaut-rocket.svg',
+        ];
+        $backgroundImageUrl = $possibleDefaultImages[array_rand($possibleDefaultImages)];
+
+        if (empty($fallback) === false) {
+            $backgroundImageUrl = $fallback;
+        }
+
+        $customImage = AdminConfig::get()['branding']['login_screen_custom_image'];
+
+        if (empty($customImage) === true) {
+            return $backgroundImageUrl;
+        }
+
+        if (
+            preg_match('@^https?://@', $customImage) === true
+            || is_file(PIMCORE_WEB_ROOT . '/var/assets' . $customImage) === true
+            || is_file(PIMCORE_WEB_ROOT . $customImage) === true
+        ) {
+            return $customImage;
+        }
+
+        $assetSource = Config::getSystemConfiguration('assets')['frontend_prefixes']['source'];
+
+        if (empty($assetSource) === false) {
+            $url = sprintf('%s/%s', $assetSource, $customImage);
+
+            try {
+                // Check if the image exists
+                getimagesize($url);
+
+                return $url;
+            } catch (Exception) {
+                return $backgroundImageUrl;
+            }
+        }
+
+        return $backgroundImageUrl;
+    }
+
     public function inlineIcon(string $icon): string
     {
         $content = file_get_contents($icon);
 
-        return sprintf('<img src="data:%s;base64,%s" title="%s" data-imgpath="%s" />',
+        return sprintf(
+            '<img src="data:%s;base64,%s" title="%s" data-imgpath="%s" />',
             mime_content_type($icon),
             base64_encode($content),
             basename($icon),
@@ -112,7 +165,8 @@ class AdminExtension extends AbstractExtension
 
     public function twemojiVariantIcon(string $icon): string
     {
-        return sprintf('<img title="%s" data-imgpath="%s" />',
+        return sprintf(
+            '<img title="%s" data-imgpath="%s" />',
             basename($icon),
             str_replace(PIMCORE_WEB_ROOT, '', $icon)
         );

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -103,7 +103,7 @@ class AdminExtension extends AbstractExtension
         return '<script src="' . $url . '"></script>' . "\n";
     }
 
-    public function getLoginBackgroundImage(string $fallback = ''): string
+    public function getLoginBackgroundImage(string $overwrite = ''): string
     {
         $possibleDefaultImages = [
             '/bundles/pimcoreadmin/img/login/pimconaut-ecommerce.svg',
@@ -114,8 +114,8 @@ class AdminExtension extends AbstractExtension
         ];
         $backgroundImageUrl = $possibleDefaultImages[array_rand($possibleDefaultImages)];
 
-        if (empty($fallback) === false) {
-            $backgroundImageUrl = $fallback;
+        if (empty($overwrite) === false) {
+            $backgroundImageUrl = $overwrite;
         }
 
         $customImage = AdminConfig::get()['branding']['login_screen_custom_image'];

--- a/templates/admin/login/layout.html.twig
+++ b/templates/admin/login/layout.html.twig
@@ -15,25 +15,9 @@
         {% endfor %}
     </head>
     <body class="pimcore_version_11 {{ adminSettings['branding']['login_screen_invert_colors'] ? 'inverted' : '' }}">
-        {% set backgroundImageUrl = "" %}
-        {% set customImage = adminSettings['branding']['login_screen_custom_image'] %}
-        {# https://github.com/pimcore/pimcore/issues/8016 #}
-        {# https://github.com/pimcore/pimcore/issues/8129 #}
-        {% if customImage matches '@^https?://@' %}
-            {% set backgroundImageUrl = customImage %}
-        {% elseif pimcore_file_exists(constant('PIMCORE_WEB_ROOT') ~ '/var/assets' ~ customImage) %}
-            {% set backgroundImageUrl = customImage %}
-        {% elseif pimcore_file_exists(constant('PIMCORE_WEB_ROOT') ~ customImage) %}
-            {% set backgroundImageUrl = customImage %}
-        {% else %}
-{#            {% set defaultImages = ['pimconaut-ecommerce.svg', 'pimconaut-world.svg', 'pimconaut-engineer.svg', 'pimconaut-moon.svg', 'pimconaut-rocket.svg'] %}#}
-{#            {% set backgroundImageUrl = '/bundles/pimcoreadmin/img/login/' ~ random(defaultImages) %}#}
-            {% set backgroundImageUrl = '/bundles/pimcoreadmin/img/login/pc11.svg' %}
-        {% endif %}
-
         <style>
             #background {
-                background-image: url("{{ backgroundImageUrl }}");
+                background-image: url("{{ pimcore_login_background_image('/bundles/pimcoreadmin/img/login/pc11.svg') }}");
             }
         </style>
 


### PR DESCRIPTION
Fixes pimcore/admin-ui-classic-bundle#491

## Additional information
I moved the whole background image logic from the template to an twig extension to reduce the logic in the template. The random background image logic is the default, but you can overwrite that logic by adding a parameter to the function. This is currently also the default with the Pimcore 11 Image