### PR TITLE
[Task]: Small performance improvement in object grid

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -130,7 +130,7 @@ trait DataObjectActionsTrait
                 } else {
                     $o = DataObject\Service::gridObjectData($object, $allParams['fields'] ?? null, $requestedLanguage,
                         ['csvMode' => $csvMode]);
-                    if ($o['permissions']['list'] == 1) {
+                    if ($o['permissions']['list']) {
                         $objects[] = $o;
                     }
                 }

--- a/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -123,14 +123,16 @@ trait DataObjectActionsTrait
             foreach ($list->getObjects() as $object) {
                 if ($csvMode) {
                     $o = DataObject\Service::getCsvDataForObject($object, $requestedLanguage, $request->get('fields'), DataObject\Service::getHelperDefinitions(), $localeService, 'title', false, $allParams['context']);
+                    // Like for treeGetChildrenByIdAction, so we respect isAllowed method which can be extended (object DI) for custom permissions, so relying only users_workspaces_object is insufficient and could lead security breach
+                    if ($object->isAllowed('list')) {
+                        $objects[] = $o;
+                    }
                 } else {
                     $o = DataObject\Service::gridObjectData($object, $allParams['fields'] ?? null, $requestedLanguage,
                         ['csvMode' => $csvMode]);
-                }
-
-                // Like for treeGetChildrenByIdAction, so we respect isAllowed method which can be extended (object DI) for custom permissions, so relying only users_workspaces_object is insufficient and could lead security breach
-                if ($object->isAllowed('list')) {
-                    $objects[] = $o;
+                    if ($o['permissions']['list'] == 1) {
+                        $objects[] = $o;
+                    }
                 }
             }
 


### PR DESCRIPTION
[DataObject\Service::gridObjectData](https://github.com/pimcore/admin-ui-classic-bundle/pull/403/files#diff-06c01f09b8cb0023fc0509596446ef0d9ed2521a0cc110aeb5f7d276dc9fe8ffR131)  already gets all the permissions https://github.com/pimcore/pimcore/blob/aac116d742cc4815d1f53c5e8417502096cca332/models/DataObject/Service.php#L313
https://github.com/pimcore/pimcore/blob/7ef4ae5ff22bad445cacb7ec38241ca4cd5b1fdb/models/Element/AbstractElement.php#L464-L465
therefore no need to perform a `if ($object->isAllowed('list'))` 

In my local tests, saves around 50-100ms for 200ish elements per page, without breaking or changing the behaviour, at least saves from having this extra query for each item.