### PR TITLE
Add translation for invalid option in multiselect / select

### DIFF
--- a/translations/admin.de.yaml
+++ b/translations/admin.de.yaml
@@ -1132,4 +1132,5 @@ keybinding_users: Users
 keybinding_roles: Roles
 remove_focal_point: Remove Focal Point
 username: Benutzername
+invalid_option: 'Invalide Option Feld [ {field} ]: Bitte valide Option für das Select / Multiselect field [ {field} ] wählen. Aktueller Wert: "{option}"'
 ...

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -1014,3 +1014,4 @@ male: Male
 female: Female
 pdf_js_unsafe: This PDF file contains JavaScript. If you want to view it, please download and open it in your local PDF viewer.
 pdf_scan_in_progress: 'Preview not available: PDF is being scanned. This may take a while.'
+invalid_option: 'Invalid Option field [ {field} ]: Please choose a valid option for select / multiselect field [ {field} ]. Current value: "{option}"'


### PR DESCRIPTION
In a Select/Multiselect were different values available (A, B, C). Option C was chosen for an object but later removed from the option list. Because the select still holds the value C, it triggers an "invalid option" error as C is no longer valid. The Select appears empty, hiding the retained value, and the shown error is meaningless.
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/23357021/a20df85a-8e81-44df-8398-2161f909c8a5)

Added translations for better understanding:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/23357021/50b31c60-142e-4764-b7d8-8270107f1414)
