### PR TITLE
UserNameTrait: Use Required attribute

### DIFF
--- a/src/Controller/Traits/UserNameTrait.php
+++ b/src/Controller/Traits/UserNameTrait.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\AdminBundle\Controller\Traits;
 
 use Pimcore\Model\User;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -26,9 +27,7 @@ trait UserNameTrait
 {
     protected TranslatorInterface $translator;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setTranslator(TranslatorInterface $translator): void
     {
         $this->translator = $translator;


### PR DESCRIPTION
Fix deprecation:
`Since symfony/dependency-injection 6.3: Relying on the "@required" annotation on method "Pimcore\Bundle\AdminBundle\Controller\Admin\Asset\AssetController::setTranslator()" is deprecated, use the "Symfony\Contracts\Service\Attribute\Required" attribute instead.`