### PR TITLE
Fix: Upload dialog of the object video tag

### DIFF
--- a/public/js/pimcore/object/tags/video.js
+++ b/public/js/pimcore/object/tags/video.js
@@ -235,7 +235,6 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
                         this.data.id = data["id"];
                         this.data.type = "asset";
                         this.data.data = data["fullpath"];
-
                         this.data.poster = null;
                         this.data.title = '';
                         this.data.description = '';

--- a/public/js/pimcore/object/tags/video.js
+++ b/public/js/pimcore/object/tags/video.js
@@ -233,6 +233,13 @@ pimcore.object.tags.video = Class.create(pimcore.object.tags.abstract, {
                     var data = Ext.decode(res.response.responseText);
                     if (data["id"] && data["type"] == "video") {
                         this.data.id = data["id"];
+                        this.data.type = "asset";
+                        this.data.data = data["fullpath"];
+
+                        this.data.poster = null;
+                        this.data.title = '';
+                        this.data.description = '';
+
                         this.dirty = true;
                     }
                     this.updateVideo();


### PR DESCRIPTION
Uploading a video directly to the object's video tag using the upload dialog didn't assign data to the object.

<img width="425" alt="image" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/24540799/de29ac2a-8026-40b6-b243-cb3e870aee14">
