### PR TITLE
Fix: quantity values-load base units

### DIFF
--- a/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -179,6 +179,18 @@ pimcore.object.quantityValue.unitsettings = Class.create({
             remoteFilter: true,
             autoSync: true,
             listeners: {
+                "load": function () {
+                    try {
+                        baseUnitStore.reload({
+                            page: this.store.currentPage,
+                            start: 1,
+                            limit: 9999
+                        });
+                        Ext.apply(baseUnitStore, {pageSize: this.pagingtoolbar.pageSize});
+                    }
+                    catch (e) {
+                    }
+                }.bind(this),
                 update: function() {
                     pimcore.helpers.quantityValue.getClassDefinitionStore().reload();
                     baseUnitStore.reload();


### PR DESCRIPTION
BaseUnits were limited to display the first 25 items, combobox seems to not have an infinite scroll capability, I did a little improvement to display all the baseUnits in the dropdown.