### PR TITLE
[Bug]: Fix crash when selecting an empty value in Asset Grid multiselect filters

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -185,7 +185,7 @@ class GridHelperService
                     $operator = '=';
 
                     $filterField = $filter['property'];
-                    $filterOperator = $filter['operator'];
+                    $filterOperator = $filter['operator'];if (empty($value)){ continue; }
 
                     if ($filter['type'] == 'string') {
                         $operator = 'LIKE';
@@ -785,6 +785,7 @@ class GridHelperService
                 if ($operator == 'LIKE') {
                     $value = $db->quote('%' . $value . '%');
                 } elseif ($operator == 'IN') {
+                    if (empty($value)){ continue; }
                     $quoted = array_map(function ($val) use ($db) {
                         return $db->quote($val);
                     }, $value);

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -185,7 +185,7 @@ class GridHelperService
                     $operator = '=';
 
                     $filterField = $filter['property'];
-                    $filterOperator = $filter['operator'];if (empty($value)){ continue; }
+                    $filterOperator = $filter['operator'];
 
                     if ($filter['type'] == 'string') {
                         $operator = 'LIKE';


### PR DESCRIPTION
Can be reproduced in public demo by pressing the checkbox `Filter`(without selecting any value in the dropdown menu) in any column with multi selection (crashing in asset grid list only)
![Screenshot from 2024-02-09 16-00-51](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/2d4cecb6-6beb-4cf6-ae4c-91e532d4c6c0)

Due SQL condition being `type IN ()`
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/8648686f-5522-4de6-8551-3e79ed7cb947)
