### PR TITLE
Add user permission check on updateCompatibleUnitsToolTipContent

### DIFF
--- a/public/js/pimcore/object/tags/quantityValue.js
+++ b/public/js/pimcore/object/tags/quantityValue.js
@@ -82,6 +82,11 @@ pimcore.object.tags.quantityValue = Class.create(pimcore.object.tags.abstract, {
         });
 
         var updateCompatibleUnitsToolTipContent = function() {
+            if(pimcore.globalmanager.get("user").isAllowed('quantityValueUnits') !== true) {
+                compatibleUnitsButton.hide();
+                return false;
+            }
+
             if (this.inputField.value === '' || this.inputField.value === null || !this.unitField.value) {
                 compatibleUnitsButton.hide();
                 return false;


### PR DESCRIPTION
The Backend route 'pimcore_admin_dataobject_quantityvalue_convertall' requests the permission 'quantityValueUnits'. If users are not allowed for the conversion or configuration but for using the Object and the units in it, it runs into an permission Error.