### PR TITLE
Fix default positioning for thumbnailDefinition in Classic UI

### DIFF
--- a/public/js/pimcore/settings/thumbnail/item.js
+++ b/public/js/pimcore/settings/thumbnail/item.js
@@ -676,6 +676,10 @@ pimcore.settings.thumbnail.items = {
         }
         var myId = Ext.id();
 
+        if (typeof data.positioning == "undefined" || data.positioning == "") {
+            data.positioning = "center";
+        }
+
         var item = new Ext.form.FormPanel({
             id: myId,
             style: "margin-top: 10px",


### PR DESCRIPTION
This commit addresses an issue in the Pimcore Admin UI Classic Bundle related to the thumbnail configuration process. Specifically, it fixes a problem where the `positioning` parameter of the `thumbnailDefinition` could be left undefined or empty in the generated YAML file. This situation arises in the frontend component responsible for generating this configuration, leading to potential misconfigurations and unexpected behaviors in thumbnail rendering.

The fix is applied directly to the frontend JavaScript responsible for assembling the thumbnail definition data, at line 676 of `public/js/pimcore/settings/thumbnail/item.js`. The introduced code snippet ensures that if the `positioning` data is either undefined or an empty string, it defaults to "center". This guarantees that every thumbnailDefinition has a valid `positioning` value, thus preventing errors and ensuring consistent rendering behavior across the board.

```javascript
if (typeof data.positioning == "undefined" || data.positioning == "") {
    data.positioning = "center";
}
```

This proactive correction streamlines the thumbnail setup process, ensuring that administrators and users benefit from a more reliable and error-free experience when configuring thumbnails in the Pimcore Admin UI. It emphasizes our commitment to quality and user satisfaction by addressing potential issues at their root, enhancing the overall stability and usability of the Pimcore platform.