### PR TITLE
[BUG]: Send invitation link always hidden

### DIFF
--- a/public/js/pimcore/settings/user/user/settings.js
+++ b/public/js/pimcore/settings/user/user/settings.js
@@ -241,7 +241,7 @@ pimcore.settings.user.user.settings = Class.create({
                     xtype: "button",
                     style: "margin-left: 8px",
                     iconCls: "pimcore_nav_icon_email",
-                    hidden: (this.currentUser.lastLogin > 0) || (user.id == this.currentUser.id),
+                    hidden: (user.id === this.currentUser.id),
                     handler: function () {
                         Ext.Ajax.request({
                             url: Routing.generate('pimcore_admin_user_invitationlink'),


### PR DESCRIPTION
### Steps to reproduce


Login with any user in Pimcore 11.x. Some logic changed after this bugfix => https://github.com/pimcore/pimcore/pull/16131. The user last login field is now set properly, which impact the visibility of the sent invitation link to other users.

### Expected Behavior
Users with the correct access rights should be able to always sent invitation links to other users

### Solution idea
Remove the user lastLogin timestamp check. 