### PR TITLE
Provide fieldname to get-nice-path calls in grid editor

### DIFF
--- a/public/js/pimcore/element/helpers/gridCellEditor.js
+++ b/public/js/pimcore/element/helpers/gridCellEditor.js
@@ -74,7 +74,8 @@ Ext.define('pimcore.element.helpers.gridCellEditor', {
         }
 
         tag.updateContext({
-            cellEditing: true
+            cellEditing: true,
+            fieldname: fieldInfo.key
         });
 
         if (typeof tag["finishSetup"] !== "undefined") {


### PR DESCRIPTION
When opening a relation editor in the grid view the calls to `/admin/element/get-nice-path` currently fail because the `context.fieldname` property is null.

The gridCellEditor sets the fieldname in the related tag when calling `updateContext()` to fix this.

Fixes: pimcore/pimcore#16500