### PR TITLE
Fix csrf token generation in LoginController::loginAction

### DIFF
--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -114,7 +114,10 @@ class LoginController extends AdminAbstractController implements KernelControlle
             return new RedirectResponse($redirectUrl);
         }
 
-        $csrfProtection->regenerateCsrfToken($request->getSession());
+        // check csrf token before generating a new one with force=true
+        if (!$csrfProtection->getCsrfToken($request->getSession())) {
+            $csrfProtection->regenerateCsrfToken($request->getSession());
+        }
 
         $user = $this->getUser();
         if ($user instanceof UserInterface) {


### PR DESCRIPTION
# Problem
While working in admin interface in one browser tab, then opening another one via `/admin/login` or a deeplink `admin/login/deeplink?object_29_object`, the csrf token gets regenerated with `$force = true`. If you switch back to the first browser tab, the csrf token is not valid anymore, you get an `Access denied` error and have to reload the admin interface completely.

## Expected behavior
Working on multiple tabs is possible without reloading the admin interface (some changes might get lost otherwise)

## Actual behavior
In the first browser tab you see the following error, when saving an element (or doing something else)
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/23357021/3b72bdc2-8e69-488a-aae2-a1d5f112f402)
In the logs you see: `[2024-02-23T11:03:43.679029+01:00] security.ERROR: Detected CSRF attack on /admin/object/save {"request":"/admin/object/save"} []`

# Changes in this pull request
First check, if there is already a csrf token set in the session. If no csrf token can be found, then regenerate with `$force = true`in `LoginController::loginAction`