### PR TITLE
Don't use 100% width for grid/cell editor

### DIFF
--- a/public/js/pimcore/asset/metadata/tags/abstract.js
+++ b/public/js/pimcore/asset/metadata/tags/abstract.js
@@ -160,5 +160,14 @@ pimcore.asset.metadata.tags.abstract = Class.create({
 
     handleGridOpenAction:function (grid, rowIndex) {
 
+    },
+
+    initEditorConfig: function (field) {
+        const editorConfig = {};
+        if (field.config && field.config.width && field.config.width !== '100%' && intval(field.config.width) > 10) {
+            editorConfig.width = field.config.width;
+        }
+
+        return editorConfig;
     }
 });

--- a/public/js/pimcore/asset/metadata/tags/input.js
+++ b/public/js/pimcore/asset/metadata/tags/input.js
@@ -30,15 +30,7 @@ pimcore.asset.metadata.tags.input = Class.create(pimcore.asset.metadata.tags.abs
     },
 
     getGridColumnEditor: function(field) {
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
+        const editorConfig = this.initEditorConfig(field);
 
         return new Ext.form.TextField(editorConfig);
     },

--- a/public/js/pimcore/asset/metadata/tags/select.js
+++ b/public/js/pimcore/asset/metadata/tags/select.js
@@ -47,32 +47,24 @@ pimcore.asset.metadata.tags.select = Class.create(pimcore.asset.metadata.tags.ab
     },
 
     getCellEditor: function (field, record) {
-        var key = field.key;
+        const key = field.key;
 
-        var value = record.data[key];
-        var options = record.data[key +  "%options"];
+        const value = record.data[key];
+        let options = record.data[key +  '%options'];
         options = this.prepareStoreDataAndFilterLabels(options);
 
-        var store = new Ext.data.Store({
+        const store = new Ext.data.Store({
             autoDestroy: true,
             fields: ['key', 'value'],
             data: options
         });
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
+        let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {
             store: store,
-            triggerAction: "all",
+            triggerAction: 'all',
             editable: false,
-            mode: "local",
+            mode: 'local',
             valueField: 'value',
             displayField: 'key',
             value: value,
@@ -87,29 +79,19 @@ pimcore.asset.metadata.tags.select = Class.create(pimcore.asset.metadata.tags.ab
     },
 
     getGridColumnEditor: function(field) {
-
-        var storeData = this.prepareStoreDataAndFilterLabels(field.layout.config);
-        var store = new Ext.data.Store({
+        const storeData = this.prepareStoreDataAndFilterLabels(field.layout.config);
+        const store = new Ext.data.Store({
             autoDestroy: true,
             fields: ['key', 'value'],
             data: storeData
         });
-
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
+        let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {
             store: store,
-            triggerAction: "all",
+            triggerAction: 'all',
             editable: false,
-            mode: "local",
+            mode: 'local',
             valueField: 'value',
             displayField: 'key',
             displayTpl: Ext.create('Ext.XTemplate',

--- a/public/js/pimcore/asset/metadata/tags/textarea.js
+++ b/public/js/pimcore/asset/metadata/tags/textarea.js
@@ -37,19 +37,10 @@ pimcore.asset.metadata.tags.textarea = Class.create(pimcore.asset.metadata.tags.
     },
 
     getGridColumnEditor: function(field) {
-        var editorConfig = {};
+        if (field.type == 'textarea') {
+            const editorConfig = this.initEditorConfig(field);
 
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
-
-        // TEXTAREA
-        if (field.type == "textarea") {
-           return new Ext.form.TextArea(editorConfig);
+            return new Ext.form.TextArea(editorConfig);
         }
     },
 

--- a/public/js/pimcore/object/helpers/grid.js
+++ b/public/js/pimcore/object/helpers/grid.js
@@ -429,7 +429,7 @@ pimcore.object.helpers.grid = Class.create({
     getColumnWidth: function(field, defaultValue) {
         if (field.width) {
             return field.width;
-        } else if(field.layout && field.layout.width) {
+        } else if (field.layout && field.layout.width && field.layout.width !== '100%' && intval(field.layout.width) > 10) {
             return field.layout.width;
         } else {
             return defaultValue;

--- a/public/js/pimcore/object/tags/abstract.js
+++ b/public/js/pimcore/object/tags/abstract.js
@@ -311,4 +311,13 @@ pimcore.object.tags.abstract = Class.create({
             this.globalLanguage = pimcore.globalmanager.get('global_language_' + this.getContext().objectId);
         }
     },
+
+    initEditorConfig: function (field) {
+        const editorConfig = {};
+        if (field.config && field.config.width && field.config.width !== '100%' && intval(field.config.width) > 10) {
+            editorConfig.width = field.config.width;
+        }
+
+        return editorConfig;
+    }
 });

--- a/public/js/pimcore/object/tags/booleanSelect.js
+++ b/public/js/pimcore/object/tags/booleanSelect.js
@@ -56,28 +56,22 @@ pimcore.object.tags.booleanSelect = Class.create(pimcore.object.tags.abstract, {
 
     },
 
-    getCellEditor: function ( field, record) {
-        var key = field.key;
-        if(field.layout.noteditable) {
+    getCellEditor: function (field, record) {
+        if (field.layout.noteditable) {
             return null;
         }
 
-        var value = record.data[key];
-        var options = record.data[key +  "%options"];
+        const key = field.key;
+        const value = record.data[key];
+        const options = record.data[key +  "%options"];
 
-        var store = new Ext.data.Store({
+        const store = new Ext.data.Store({
             autoDestroy: true,
             fields: ['key',"value"],
             data: options
         });
 
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                editorConfig.width = field.config.width;
-            }
-        }
+        let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {
             store: store,
@@ -93,11 +87,11 @@ pimcore.object.tags.booleanSelect = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function(field) {
-        if(field.layout.noteditable) {
+        if (field.layout.noteditable) {
             return null;
         }
 
-        var store = new Ext.data.JsonStore({
+        const store = new Ext.data.JsonStore({
             autoDestroy: true,
             proxy: {
                 type: 'memory',
@@ -111,19 +105,13 @@ pimcore.object.tags.booleanSelect = Class.create(pimcore.object.tags.abstract, {
             data: field.layout
         });
 
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                editorConfig.width = field.config.width;
-            }
-        }
+        let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {
             store: store,
-            triggerAction: "all",
+            triggerAction: 'all',
             editable: false,
-            mode: "local",
+            mode: 'local',
             valueField: 'value',
             displayField: 'key'
         });

--- a/public/js/pimcore/object/tags/input.js
+++ b/public/js/pimcore/object/tags/input.js
@@ -42,19 +42,12 @@ pimcore.object.tags.input = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function(field) {
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
-
-        if(field.layout.noteditable) {
+        if (field.layout.noteditable) {
             return null;
         }
+
+        const editorConfig = this.initEditorConfig(field);
+
         return new Ext.form.TextField(editorConfig);
     },
 

--- a/public/js/pimcore/object/tags/numeric.js
+++ b/public/js/pimcore/object/tags/numeric.js
@@ -33,44 +33,32 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function (field) {
-        var editorConfig = {};
-
-        var decimalPrecision = 20;
-
         if (field.layout.noteditable) {
             return null;
         }
 
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
+        if (field.type == 'numeric') {
+            const editorConfig = this.initEditorConfig(field);
+
+            if (field.layout['unsigned']) {
+                editorConfig.minValue = 0;
             }
-        }
 
-        if (field.layout["unsigned"]) {
-            editorConfig.minValue = 0;
-        }
+            if (is_numeric(field.layout['minValue'])) {
+                editorConfig.minValue = field.layout.minValue;
+            }
 
-        if (is_numeric(field.layout["minValue"])) {
-            editorConfig.minValue = field.layout.minValue;
-        }
+            if (is_numeric(field.layout['maxValue'])) {
+                editorConfig.maxValue = field.layout.maxValue;
+            }
 
-        if (is_numeric(field.layout["maxValue"])) {
-            editorConfig.maxValue = field.layout.maxValue;
-        }
-
-        if (field.layout["integer"]) {
-            editorConfig.decimalPrecision = 0;
-        } else if (field.layout["decimalPrecision"]) {
-            editorConfig.decimalPrecision = field.layout["decimalPrecision"];
-        } else {
-            editorConfig.decimalPrecision = 20;
-        }
-
-        if (field.type == "numeric") {
-            editorConfig.decimalPrecision = decimalPrecision;
+            if (field.layout['integer']) {
+                editorConfig.decimalPrecision = 0;
+            } else if (field.layout['decimalPrecision']) {
+                editorConfig.decimalPrecision = field.layout['decimalPrecision'];
+            } else {
+                editorConfig.decimalPrecision = 20;
+            }
 
             // we have to use Number since the spinner trigger don't work in grid -> seems to be a bug of Ext
             return new Ext.form.field.Number(editorConfig);

--- a/public/js/pimcore/object/tags/rgbaColor.js
+++ b/public/js/pimcore/object/tags/rgbaColor.js
@@ -57,17 +57,12 @@ pimcore.object.tags.rgbaColor = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function (field) {
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                editorConfig.width = field.config.width;
-            }
-        }
-
         if (field.layout.noteditable) {
             return null;
         }
+
+        const editorConfig = this.initEditorConfig(field);
+
         return new Ext.form.TextField(editorConfig);
     },
 

--- a/public/js/pimcore/object/tags/select.js
+++ b/public/js/pimcore/object/tags/select.js
@@ -108,36 +108,28 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
     },
 
     getCellEditor: function (field, record) {
-        var key = field.key;
-        if(field.layout.noteditable) {
+        if (field.layout.noteditable) {
             return null;
         }
 
-        var value = record.data[key];
-        var options = record.data[key +  "%options"];
+        const key = field.key;
+        const value = record.data[key];
+        let options = record.data[key +  '%options'];
         options = this.prepareStoreDataAndFilterLabels(options);
 
-        var store = new Ext.data.Store({
+        const store = new Ext.data.Store({
             autoDestroy: true,
             fields: ['key', 'value'],
             data: options
         });
 
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
+        let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {
             store: store,
-            triggerAction: "all",
+            triggerAction: 'all',
             editable: false,
-            mode: "local",
+            mode: 'local',
             valueField: 'value',
             displayField: 'key',
             value: value,
@@ -152,37 +144,29 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function(field) {
-        if(field.layout.noteditable) {
+        if (field.layout.noteditable) {
             return null;
         }
 
-        var storeData = this.prepareStoreDataAndFilterLabels(field.layout.options);
+        const storeData = this.prepareStoreDataAndFilterLabels(field.layout.options);
         
-        if(!field.layout.mandatory) {
-            storeData.unshift({'value': '', 'key': "(" + t("empty") + ")"});
+        if (!field.layout.mandatory) {
+            storeData.unshift({'value': '', 'key': '(' + t('empty') + ')'});
         }
-        
-        var store = new Ext.data.Store({
+
+        const store = new Ext.data.Store({
             autoDestroy: true,
             fields: ['key', 'value'],
             data: storeData
         });
 
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
+        let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {
             store: store,
-            triggerAction: "all",
+            triggerAction: 'all',
             editable: false,
-            mode: "local",
+            mode: 'local',
             valueField: 'value',
             displayField: 'key',
             displayTpl: Ext.create('Ext.XTemplate',

--- a/public/js/pimcore/object/tags/textarea.js
+++ b/public/js/pimcore/object/tags/textarea.js
@@ -26,21 +26,14 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function(field) {
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
-
-        if(field.layout.noteditable) {
+        if (field.layout.noteditable) {
             return null;
         }
+
+        const editorConfig = this.initEditorConfig(field);
+
         // TEXTAREA
-        if (field.type == "textarea") {
+        if (field.type == 'textarea') {
            return new Ext.form.TextArea(editorConfig);
         }
     },

--- a/public/js/pimcore/object/tags/textarea.js
+++ b/public/js/pimcore/object/tags/textarea.js
@@ -30,11 +30,11 @@ pimcore.object.tags.textarea = Class.create(pimcore.object.tags.abstract, {
             return null;
         }
 
-        const editorConfig = this.initEditorConfig(field);
-
         // TEXTAREA
         if (field.type == 'textarea') {
-           return new Ext.form.TextArea(editorConfig);
+            const editorConfig = this.initEditorConfig(field);
+
+            return new Ext.form.TextArea(editorConfig);
         }
     },
 

--- a/public/js/pimcore/object/tags/urlSlug.js
+++ b/public/js/pimcore/object/tags/urlSlug.js
@@ -33,17 +33,12 @@ pimcore.object.tags.urlSlug = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnEditor: function (field) {
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                editorConfig.width = field.config.width;
-            }
-        }
-
         if (field.layout.noteditable) {
             return null;
         }
+
+        const editorConfig = this.initEditorConfig(field);
+
         return new Ext.form.TextField(editorConfig);
     },
 

--- a/public/js/pimcore/object/tags/wysiwyg.js
+++ b/public/js/pimcore/object/tags/wysiwyg.js
@@ -33,21 +33,11 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
      * @extjs since HTMLEditor seems not working properly in grid, this feature is deactivated for now
      */
     /*getGridColumnEditor: function(field) {
-        var editorConfig = {};
-
-        if (field.config) {
-            if (field.config.width) {
-                if (intval(field.config.width) > 10) {
-                    editorConfig.width = field.config.width;
-                }
-            }
-        }
-
-        if(field.layout.noteditable) {
+        if (field.layout.noteditable) {
             return null;
         }
         // WYSIWYG
-        if (field.type == "wysiwyg") {
+        if (field.type == 'wysiwyg') {
             return Ext.create('Ext.form.HtmlEditor', {
                 width: 500,
                 height: 300
@@ -268,4 +258,3 @@ pimcore.object.tags.wysiwyg = Class.create(pimcore.object.tags.abstract, {
         return this.getValue();
     }
 });
-


### PR DESCRIPTION
We can set fields to width 100% with label top. This is really nice for the edit view:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/998558/df19fccd-5278-4f7f-8c9a-aff7b0b8d70e)

But in the grid view this width shouldn't be set. So the grid columns are too wide:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/998558/6e5c06a4-dfbf-43c4-b462-86d703a56c22)
