### PR TITLE
Fix label in string contains operator

### DIFF
--- a/public/js/pimcore/object/gridcolumn/operator/StringContains.js
+++ b/public/js/pimcore/object/gridcolumn/operator/StringContains.js
@@ -134,6 +134,7 @@ pimcore.object.gridcolumn.operator.stringcontains = Class.create(pimcore.object.
 
     commitData: function(params) {
         this.node.set('isOperator', true);
+	this.node.data.configAttributes.label = this.textField.getValue();
         this.node.data.configAttributes.search = this.searchField.getValue();
         this.node.data.configAttributes.insensitive = this.insensitiveField.getValue();
         this.node.set('text', this.textField.getValue());

--- a/public/js/pimcore/object/gridcolumn/operator/StringContains.js
+++ b/public/js/pimcore/object/gridcolumn/operator/StringContains.js
@@ -134,7 +134,7 @@ pimcore.object.gridcolumn.operator.stringcontains = Class.create(pimcore.object.
 
     commitData: function(params) {
         this.node.set('isOperator', true);
-	this.node.data.configAttributes.label = this.textField.getValue();
+        this.node.data.configAttributes.label = this.textField.getValue();
         this.node.data.configAttributes.search = this.searchField.getValue();
         this.node.data.configAttributes.insensitive = this.insensitiveField.getValue();
         this.node.set('text', this.textField.getValue());


### PR DESCRIPTION
## Situation:
- Open the Grid View in an object folder
- Open the Grid View configuration
- Add the "Operator String Contains" operator
- Change the label of the operator
- The operator label is not saved! Is always "Operator String Contains"

## Expected Behavior:
Adoption of the changed label after saving in the Grid View.

## Fix:
Add value from the text field "Label" in the node configAttributes as label.