### PR TITLE
Fix consideration of checked tags with collapsed parent tag

### DIFF
--- a/public/js/pimcore/element/tag/tree.js
+++ b/public/js/pimcore/element/tag/tree.js
@@ -369,11 +369,21 @@ pimcore.element.tag.tree = Class.create({
     getCheckedTagIds: function () {
         var store = this.tree.getStore();
         var checkedTagIds = [];
-        store.each(function (node) {
+
+        function checkNode(node) {
             if (node.data.checked) {
                 checkedTagIds.push(node.id);
             }
-        });
+            if (node.childNodes.length > 0) {
+                node.eachChild(function(childNode) {
+                    checkNode(childNode);
+                });
+            }
+        }
+
+        if (store.data.items.length > 0) {
+            checkNode(store.data.items[0]);
+        }
 
         return checkedTagIds;
     },


### PR DESCRIPTION
## Situation:
- Create two tags, each of which has a parent tag
- Assign a tag to an object
- Assign another tag and the previously added tag to another object of the same type
- Go to the object search
- Open the tag filtering
- First check the tag that only one of the objects has and then collapse the parent tag
- Now tick the second tag that both objects have
- The first object that only has one of the tags is also displayed

## Expected Behavior:
It should be noted that the checked tags are also taken into considered in the filtering, even if the parent tag is collapsed.

##  Fix:
One solution is to iterate over all tags to check if any of them are selected and include them in the list. This way, the checked tags are also considered in the filtering, even if the parent tag is collapsed.