### PR TITLE
Introduce event to handle different object edit lock tasks

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -64,6 +64,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     use DataObjectActionsTrait;
     use UserNameTrait;
 
+    /** On active edit lock answer with editlock response */
+    const TASK_RESPONSE = 'response';
+    /** On active edit lock overwrite with new user */
+    const TASK_OVERWRITE = 'overwrite';
+    /** On active edit lock keep existing entry */
+    const TASK_KEEP = 'keep';
+    
     protected DataObject\Service $_objectService;
 
     private array $objectData = [];
@@ -295,10 +302,25 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         // check for lock
         if ($object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete')) {
             if (Element\Editlock::isLocked($objectId, 'object', $request->getSession()->getId())) {
-                return $this->getEditLockResponse($objectId, 'object');
-            }
+                //Hook for modifying editlock handling - e.g. no editLockResponse but keep old lock
+                $lockData = [
+                    'task' => self::TASK_RESPONSE
+                ];
+                $event = new GenericEvent($this, [
+                    'data' => $lockData,
+                    'object' => $object,
+                ]);
+                $eventDispatcher->dispatch($event, AdminEvents::OBJECT_GET_IS_LOCKED);
+                $lockData = $event->getArgument('data');
 
-            Element\Editlock::lock($request->get('id'), 'object', $request->getSession()->getId());
+                if ($lockData['task'] === self::TASK_RESPONSE) {
+                    return $this->getEditLockResponse($objectId, 'object');
+                } else if ($lockData['task'] === self::TASK_OVERWRITE) {
+                    Element\Editlock::lock($objectId, 'object', $request->getSession()->getId());
+                }
+            } else {
+                Element\Editlock::lock($objectId, 'object', $request->getSession()->getId());
+            }
         }
 
         // we need to know if the latest version is published or not (a version), because of lazy loaded fields in $this->getDataForObject()

--- a/src/Event/AdminEvents.php
+++ b/src/Event/AdminEvents.php
@@ -323,6 +323,20 @@ class AdminEvents
     const DOCUMENT_TREE_GET_CHILDREN_BY_ID_PRE_SEND_DATA = 'pimcore.admin.document.treeGetChildrenById.preSendData';
 
     /**
+     * Fired before the edit lock is handled.
+     *
+     * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController
+     * Arguments:
+     *  - data | array | editLock behaviour, this can be modified
+     *  - object | AbstractObject | the current object
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const OBJECT_GET_IS_LOCKED = 'pimcore.admin.dataobject.get.isLocked';
+
+    /**
      * Fired before the request params are parsed.
      *
      * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController


### PR DESCRIPTION
### About this contribution
According to the contribution rules in pimcore README.md file I made an attempt to ask on [Gitter channel](https://app.gitter.im/#/room/#pimcore_pimcore:gitter.im/$9I4ZmPLGg1hlRSCyLg1UlU3l0_tn8wIZ556qpOOXO-k) last June if this might be an interesting feature - without success. CONTRIBUTING.md on the other hand does not explicitly state how to contribute new feature besides doing a fork for pull requests which I try now 😉

## Current Situation
The current implementation has a fix behavior in case of parallel access of objects by users in admin UI. The first user opens the object and it gets a lock entry. The second user is prompted to take over this lock.

My issue is that I need a more flexible implementation to have the possibility to keep the lock and e.g. offer the object for the second user in read only mode.

## Changes in this pull request  
This PR introduces a new event which is triggered in case of user tries to open a locked object. Based on the event the implementation can decide to

- Offer the dialog as up to now to override the lock
- Keep the existing lock
- Override the lock without asking the user

Additional actions (like ensure read only access) can anyhow be taken at the pre edit event `pimcore.admin.dataobject.get.preSendData`

## Additional info  

New admin event `pimcore.admin.dataobject.get.isLocked` is introduced which supports a parameter `task `with following possible values:

- `TASK_RESPONSE = 'response';`
Default: On active edit lock answer with editlock response as up to now
- `TASK_OVERWRITE = 'overwrite';`
On active edit lock overwrite it with new user
- `TASK_KEEP = 'keep';`
On active edit lock keep existing entry, further actions are up to the implementation

This task will be executed when event returns