### PR TITLE
Thumbnail: Don't create cover item with positioning: null

### DIFF
--- a/public/js/pimcore/settings/thumbnail/item.js
+++ b/public/js/pimcore/settings/thumbnail/item.js
@@ -671,6 +671,9 @@ pimcore.settings.thumbnail.items = {
         if (typeof data == "undefined") {
             data = {};
         }
+        if (!data.positioning) {
+            data.positioning = 'center';
+        }
         var myId = Ext.id();
 
         var item = new Ext.form.FormPanel({


### PR DESCRIPTION
If you create a cover item for a thumbnail configuration, the positioning is null. When you save it without changing it. You get following error, when you want create this thumbnail:
```
TypeError: Pimcore\Image\Adapter::cover(): Argument #3 ($orientation) must be of type array|string, null given in /vendor/pimcore/pimcore/lib/Image/Adapter.php:132
```

See also: https://github.com/pimcore/pimcore/pull/16720