### PR TITLE
[Bug]: Fix attributes->get('_controller') potentially being null causing TypeError in UsageStatisticsListener.php

### DIFF
--- a/src/EventListener/UsageStatisticsListener.php
+++ b/src/EventListener/UsageStatisticsListener.php
@@ -74,7 +74,7 @@ class UsageStatisticsListener implements EventSubscriberInterface
 
         $params = $this->getParams($request);
         $user = $this->userResolver->getUser();
-        $this->logger->info($request->attributes->get('_controller'), [
+        $this->logger->info($request->attributes->get('_controller') ?? '', [
             $user ? $user->getId() : '0',
             $request->attributes->get('_route'),
             $request->attributes->get('_route_params'),

--- a/src/EventListener/UsageStatisticsListener.php
+++ b/src/EventListener/UsageStatisticsListener.php
@@ -74,7 +74,7 @@ class UsageStatisticsListener implements EventSubscriberInterface
 
         $params = $this->getParams($request);
         $user = $this->userResolver->getUser();
-        $this->logger->info($request->attributes->get('_controller') ?? '', [
+        $this->logger->info($request->attributes->get('_controller', ''), [
             $user ? $user->getId() : '0',
             $request->attributes->get('_route'),
             $request->attributes->get('_route_params'),


### PR DESCRIPTION
bugfix, UsageStatisticsListener - do not send null to logger.

Sometimes $request->attributes->get('_controller') returns null which makes the logger throw TypeError.