### PR TITLE
Hide buttons for not editable tables

### DIFF
--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -161,49 +161,54 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {});
 
-        var tbar = [];
+        var tbar = null;
+        
+        if (!this.fieldConfig.noteditable)
+        {
+            var tbar = [];
 
-        if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
+            if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_col pimcore_icon_overlay_add",
+                    handler: this.addColumn.bind(this)
+                });
+            }
+
+            if (!this.fieldConfig.colsFixed || columns.length > this.fieldConfig.cols) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_col pimcore_icon_overlay_delete",
+                    handler: this.deleteColumn.bind(this)
+                });
+            }
+
+            if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
+                    handler: this.deleteRow.bind(this)
+                });
+
+                tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
+                    handler: this.addRow.bind(this)
+                });
+            }
+
             tbar.push({
-                iconCls: "pimcore_icon_table_col pimcore_icon_overlay_add",
-                handler: this.addColumn.bind(this)
+                iconCls: 'pimcore_icon_copy',
+                handler: this.copyFromTable.bind(this)
+            });
+
+            tbar.push({
+                iconCls: "pimcore_icon_paste",
+                handler: this.pasteFromClipboard.bind(this)
+            });
+
+
+            tbar.push({
+                iconCls: "pimcore_icon_empty",
+                handler: this.emptyStore.bind(this)
             });
         }
-
-        if (!this.fieldConfig.colsFixed || columns.length > this.fieldConfig.cols) {
-            tbar.push({
-                iconCls: "pimcore_icon_table_col pimcore_icon_overlay_delete",
-                handler: this.deleteColumn.bind(this)
-            });
-        }
-
-        if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
-            tbar.push({
-                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
-                handler: this.deleteRow.bind(this)
-            });
-
-            tbar.push({
-                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
-                handler: this.addRow.bind(this)
-            });
-        }
-
-        tbar.push({
-            iconCls: 'pimcore_icon_copy',
-            handler: this.copyFromTable.bind(this)
-        });
-
-        tbar.push({
-            iconCls: "pimcore_icon_paste",
-            handler: this.pasteFromClipboard.bind(this)
-        });
-
-
-        tbar.push({
-            iconCls: "pimcore_icon_empty",
-            handler: this.emptyStore.bind(this)
-        });
 
         this.grid = Ext.create('Ext.grid.Panel', {
             store: this.store,

--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -165,7 +165,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
         
         if (!this.fieldConfig.noteditable)
         {
-            var tbar = [];
+            tbar = [];
 
             if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
                 tbar.push({

--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -161,7 +161,7 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {});
 
-        var tbar = null;
+        let tbar = null;
         
         if (!this.fieldConfig.noteditable)
         {


### PR DESCRIPTION
If a table is readonly in Edit tab of an object in Admin UI it does not make sense to show inactive buttons for table modifications. This small change hides the buttons in this case for having UI without non usable buttons (see example below)

### screenshot without change
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/96241555/c42b8da5-81ff-42cf-919a-f64f7e2dcaf1)

### screenshot after modification
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/96241555/5c8f895a-a4ac-4827-b25a-be7e4d901855)
