### PR TITLE
[Docs]: Removed outdated line about deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### v1.4.0
-- [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore` `v12`.
+- [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore:^12`.
 
 #### v1.2.0
  - Bumped `pimcore/pimcore` minimum requirement to `^11.1.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #### v1.4.0
-- [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore:^12`. A visual warning is displayed in the backend, it can be hidden by replacing the value of translation key `(deprecated)`
+- [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore` `v12`.
 
 #### v1.2.0
  - Bumped `pimcore/pimcore` minimum requirement to `^11.1.0`


### PR DESCRIPTION
~Also changed the line about Pimcore 12, since it would be removed once on 12.0.0 sounds better without the caret and implicitly suggest it is removed for whole 12~ nahh, it's fine :D 