### PR TITLE
464 fix filtering objects or variant in grid tab

### DIFF
--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -259,7 +259,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                         this.grid.filters.clearFilters();
                         this.grid.getStore().clearFilter();
 
-                        this.store.getProxy().setExtraParam(selected, true);
+                        this.store.getProxy().setExtraParam("listing", selected);
 
                         this.pagingtoolbar.moveFirst();
 

--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -247,6 +247,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 xtype: "combo",
                 displayField:'name',
                 valueField: "value",
+                hidden: !this.element.data.general.allowInhreitance,
                 store: selectObjectOptions,
                 editable: false,
                 width : 300,

--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -259,7 +259,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                         this.grid.filters.clearFilters();
                         this.grid.getStore().clearFilter();
 
-                        this.store.getProxy().setExtraParam("listing", selected);
+                        this.store.getProxy().setExtraParam("filter_by_object_type", selected);
 
                         this.pagingtoolbar.moveFirst();
 

--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -234,7 +234,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
             var selectObjectOptions = Ext.create('Ext.data.Store', {
                 fields: ['name', 'value'],
                 data: [
-                    [t("empty"), "all_objects"],
+                    [t("all_types"), "all_objects"],
                     [t("only_object"), "only_objects"],
                     [t("only_variant"), "only_variant_objects"],
                 ]

--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -231,6 +231,44 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
 
             this.store.getProxy().setExtraParam("query", this.searchFilter);
 
+            var selectObjectOptions = Ext.create('Ext.data.Store', {
+                fields: ['name', 'value'],
+                data: [
+                    [t("empty"), "all_objects"],
+                    [t("only_object"), "only_objects"],
+                    [t("only_variant"), "only_variant_objects"],
+                ]
+            });
+
+            this.selectObjectType = new Ext.form.ComboBox({
+                fieldLabel: t('select_objects_type'),
+                name: 'objects_type',
+                labelWidth: 120,
+                xtype: "combo",
+                displayField:'name',
+                valueField: "value",
+                store: selectObjectOptions,
+                editable: false,
+                width : 300,
+                triggerAction: 'all',
+                value: 'all_objects',
+                listeners: {
+                    change: function(comboBox,selected){
+                        this.grid.getStore().setRemoteFilter(false);
+                        this.grid.filters.clearFilters();
+                        this.grid.getStore().clearFilter();
+
+                        this.store.getProxy().setExtraParam(selected, true);
+
+                        this.pagingtoolbar.moveFirst();
+
+                        this.grid.getStore().setRemoteFilter(true);
+
+                        this.saveColumnConfigButton.show();
+                    }.bind(this)
+                }
+            });
+
             this.checkboxOnlyDirectChildren = new Ext.form.Checkbox({
                 name: "onlyDirectChildren",
                 style: "margin-bottom: 5px; margin-left: 5px",
@@ -296,6 +334,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 this.languageInfo, "-",
                 this.toolbarFilterInfo,
                 this.clearFilterButton, "->",
+                this.selectObjectType, "-",
                 this.checkboxOnlyDirectChildren, "-",
                 this.exportButton, "-",
                 this.columnConfigButton,

--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -247,7 +247,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 xtype: "combo",
                 displayField:'name',
                 valueField: "value",
-                hidden: !this.element.data.general.allowInhreitance,
+                hidden: !this.element.data.general.allowInheritance,
                 store: selectObjectOptions,
                 editable: false,
                 width : 300,

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -591,18 +591,6 @@ class GridHelperService
             $conditionFilters[] = '(`path` = ' . $quotedPath . ' OR `path` like ' . $quotedWildcardPath . ')';
         }
 
-        if (isset($requestParams['all_objects']) && $requestParams['all_objects'] === 'true') {
-            $conditionFilters[] = "(`type` = 'object' OR `type` = 'variant')";
-        } else {
-            if (isset($requestParams['only_variant_objects']) && $requestParams['only_variant_objects'] === 'true') {
-                $conditionFilters[] = "`type` = 'variant'";
-            } elseif(isset($requestParams['only_objects']) && $requestParams['only_objects'] === 'true') {
-                $conditionFilters[] = "`type` = 'object'";
-            } else {
-                $conditionFilters[] = "(`type` = 'object' OR `type` = 'variant')";
-            }
-        }
-
         if (!$adminUser->isAdmin()) {
             $userIds = $adminUser->getRoles();
             $userIds[] = $adminUser->getId();

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -683,7 +683,13 @@ class GridHelperService
         }
 
         if ($class->getShowVariants()) {
-            $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT]);
+            if (isset($requestParams['listing']) && $requestParams['listing'] == "only_objects") {
+                $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT]); 
+            } elseif(isset($requestParams['listing']) && $requestParams['listing'] == "only_variant_objects") {
+                $list->setObjectTypes([DataObject::OBJECT_TYPE_VARIANT]); 
+            } else {
+                $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT]);
+            }
         }
 
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureAndSlugFilters);

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -592,14 +592,14 @@ class GridHelperService
         }
 
         if (isset($requestParams['all_objects']) && $requestParams['all_objects'] === 'true') {
-            $conditionFilters[] = "`type` = 'object' OR `type` = 'variant'";
+            $conditionFilters[] = "(`type` = 'object' OR `type` = 'variant')";
         } else {
             if (isset($requestParams['only_variant_objects']) && $requestParams['only_variant_objects'] === 'true') {
                 $conditionFilters[] = "`type` = 'variant'";
             } elseif(isset($requestParams['only_objects']) && $requestParams['only_objects'] === 'true') {
                 $conditionFilters[] = "`type` = 'object'";
             } else {
-                $conditionFilters[] = "`type` = 'object' OR `type` = 'variant'";
+                $conditionFilters[] = "(`type` = 'object' OR `type` = 'variant')";
             }
         }
 

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -591,6 +591,18 @@ class GridHelperService
             $conditionFilters[] = '(`path` = ' . $quotedPath . ' OR `path` like ' . $quotedWildcardPath . ')';
         }
 
+        if (isset($requestParams['all_objects']) && $requestParams['all_objects'] === 'true') {
+            $conditionFilters[] = "`type` = 'object' OR `type` = 'variant'";
+        } else {
+            if (isset($requestParams['only_variant_objects']) && $requestParams['only_variant_objects'] === 'true') {
+                $conditionFilters[] = "`type` = 'variant'";
+            } elseif(isset($requestParams['only_objects']) && $requestParams['only_objects'] === 'true') {
+                $conditionFilters[] = "`type` = 'object'";
+            } else {
+                $conditionFilters[] = "`type` = 'object' OR `type` = 'variant'";
+            }
+        }
+
         if (!$adminUser->isAdmin()) {
             $userIds = $adminUser->getRoles();
             $userIds[] = $adminUser->getId();

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -670,16 +670,19 @@ class GridHelperService
             }
         }
 
-        if ($class->getShowVariants()) {
-            if (isset($requestParams['listing']) && $requestParams['listing'] == "only_objects") {
-                $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT]); 
-            } elseif(isset($requestParams['listing']) && $requestParams['listing'] == "only_variant_objects") {
-                $list->setObjectTypes([DataObject::OBJECT_TYPE_VARIANT]); 
-            } else {
+        if ($class->getAllowVariants()) {
+            if ($class->getShowVariants()) {
                 $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT]);
             }
+            if (isset($requestParams['filter_by_object_type'])){
+                if ($requestParams['filter_by_object_type'] === "only_objects") {
+                    $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT]);
+                } elseif($requestParams['filter_by_object_type'] === "only_variant_objects") {
+                    $list->setObjectTypes([DataObject::OBJECT_TYPE_VARIANT]);
+                }
+            }
         }
-
+        
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureAndSlugFilters);
         $this->addSlugJoins($list, $slugJoins, $featureAndSlugFilters);
 

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -432,6 +432,9 @@ system_columns: 'System columns'
 columns: Columns
 children_grid: 'Children Grid'
 only_children: 'just direct children'
+only_object: 'just objects'
+only_variant: 'just variants object'
+select_objects_type: "Object's type to show"
 cut: Cut
 paste_cut_element: 'Paste cut-out element'
 memorize_tabs: 'Memorize open tabs'

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -434,7 +434,7 @@ children_grid: 'Children Grid'
 only_children: 'just direct children'
 only_object: 'just objects'
 only_variant: 'just variants object'
-select_objects_type: "Object's type to show"
+select_objects_type: "Type to show"
 cut: Cut
 paste_cut_element: 'Paste cut-out element'
 memorize_tabs: 'Memorize open tabs'


### PR DESCRIPTION
### ISSUE 464: There is no way to filter objects in grid views based on whether they are of variant type or not
This PR is related to issue #464.

I resolved the issue inserting a select ComboBox in the toolbar of objects grid view. Now you can select what type of objects you can show. 