### PR TITLE
get date with timezone offset

### DIFF
--- a/public/js/pimcore/object/tags/date.js
+++ b/public/js/pimcore/object/tags/date.js
@@ -106,7 +106,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
         if (this.component.getValue()) {
             let value = this.component.getValue();
             if (value && typeof value.getTime == "function") {
-                return value.getTime();
+                return value.getTime() - 60000 * value.getTimezoneOffset();
             } else {
                 return value;
             }


### PR DESCRIPTION
Date field doesn't respect timezone now.
This PR add timezone offset to date value and prevent saving date timestamp for day before.

When setting the date, the time is set to 00:00 and the timezone offset is subtracted and, as a result, the date is set to yesterday