### PR TITLE
[BUGFIX]: Moving objects in alphabetical tree

### DIFF
--- a/public/js/pimcore/object/tree.js
+++ b/public/js/pimcore/object/tree.js
@@ -267,14 +267,16 @@ pimcore.registerNS("pimcore.object.tree");
 
      onTreeNodesDrop: function (node, data, overModel, dropPosition, eOpts) {
          if (typeof this.treeNodeMoveParameter.oldParent.getOwnerTree !== "function") {
+             if (dropPosition == "before" || dropPosition == "after") {
+                 return;
+             }
+
              Ext.Array.each(data.records, function (record) {
                  if (this.onTreeNodeBeforeMove(record, record.parentNode, overModel)) {
                      this.onTreeNodeMove(record, record.parentNode, overModel, 0);
                  }
              }.bind(this));
-         }
 
-         if (typeof this.treeNodeMoveParameter.oldParent.getOwnerTree !== "function") {
              return;
          }
 


### PR DESCRIPTION
### **Steps to reproduce**

- set "Sort children by" to Key (A-Z) (same thing for Z-A) to parent object/folder
- try to move child objects inside parent
- message appears that moving is not possible (this is correct), but after refresh of parent child is moved to nearest sibling to cursor while droping child