### PR TITLE
Add possibility to make languages not mandatory

### DIFF
--- a/public/js/pimcore/object/helpers/edit.js
+++ b/public/js/pimcore/object/helpers/edit.js
@@ -302,6 +302,14 @@ pimcore.object.helpers.edit = {
                 // add asterisk to mandatory field
                 l.titleOriginal = l.title;
                 let icons = '';
+                let wasMandatory = false;
+
+                if (context.containerType == 'localizedfield') {
+                    if (l.mandatory && !in_array(context.language, pimcore.settings.requiredLanguages)) {
+                        l.mandatory = false;
+                        wasMandatory = true;
+                    }
+                }
 
                 if(l.mandatory) {
                     icons += '<span style="color:red;">*</span>';
@@ -456,6 +464,10 @@ pimcore.object.helpers.edit = {
                         console.log(l.name + " event render not supported (tag type: " + l.fieldtype + ")");
                         console.log(e7);
                     }
+                }
+
+                if (wasMandatory) {
+                    l.mandatory = true;
                 }
 
                 return dLayout;

--- a/public/js/pimcore/settings/system.js
+++ b/public/js/pimcore/settings/system.js
@@ -187,6 +187,11 @@ pimcore.settings.system = Class.create({
                                 value: this.getValue("general.valid_languages", true)
                             }, {
                                 xtype: "hidden",
+                                id: "system_settings_general_requiredLanguages",
+                                name: 'general.requiredLanguages',
+                                value: this.getValue("general.required_languages", true)
+                            }, {
+                                xtype: "hidden",
                                 id: "system_settings_general_defaultLanguage",
                                 name: "general.defaultLanguage",
                                 value: this.getValue("general.default_language")
@@ -597,10 +602,37 @@ pimcore.settings.system = Class.create({
                         }.bind(this)
                     }
                 }, {
+                    xtype: "checkbox",
+                    name: "general.requiredLanguage",
+                    boxLabel: t("required_language"),
+                    checked: this.getValue("general.required_languages", true).includes(language),
+                    listeners: {
+                        change: function (el, checked) {
+                            var requiredLanguagesField = Ext.getCmp("system_settings_general_requiredLanguages");
+                            var requiredLanguages = [];
+
+                            if (requiredLanguagesField.getValue() != '') {
+                                requiredLanguages = requiredLanguagesField.getValue().split(",");
+                            }
+
+                            if (checked) {
+                                if (!in_array(language, requiredLanguages)) {
+                                    requiredLanguages.push(language);
+                                }
+                            } else {
+                                if (in_array(language, requiredLanguages)) {
+                                    requiredLanguages.splice(array_search(language, requiredLanguages), 1);
+                                }
+                            }
+
+                            requiredLanguagesField.setValue(requiredLanguages.join(","));
+                        }.bind(this)
+                    }
+                }, {
                     xtype: "button",
                     title: t("delete"),
                     iconCls: "pimcore_icon_delete",
-                    style: "position:absolute; right: 5px; top:12px;",
+                    style: "position:absolute; right: 5px; top:40px;",
                     handler: this.removeLanguage.bind(this, language)
                 }]
             });
@@ -616,6 +648,14 @@ pimcore.settings.system = Class.create({
         if (in_array(language, addedLanguages)) {
             addedLanguages.splice(array_search(language, addedLanguages), 1);
             languageField.setValue(addedLanguages.join(","));
+        }
+
+        // remove the required language out of the hidden field
+        var requiredLanguagesField = Ext.getCmp("system_settings_general_requiredLanguages");
+        var addedRequiredLanguages = requiredLanguagesField.getValue().split(",");
+        if (in_array(language, addedRequiredLanguages)) {
+            addedRequiredLanguages.splice(array_search(language, addedRequiredLanguages), 1);
+            requiredLanguagesField.setValue(addedRequiredLanguages.join(","));
         }
 
         // remove the default language from hidden field

--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -206,6 +206,8 @@ class IndexController extends AdminAbstractController implements KernelResponseE
             $adminEntrypointUrl = null;
         }
 
+        $requiredLangauges = $systemSettings['general']['required_languages'];
+
         $settings = [
             'instanceId'          => $this->getInstanceId(),
             'version'             => Version::getVersion(),
@@ -224,7 +226,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
                 $systemSettings['general']['valid_languages'],
                 true
             ),
-            'requiredLanguages' => $systemSettings['general']['required_languages'],
+            'requiredLanguages' => empty($requiredLangauges) === true ? $systemSettings['general']['valid_languages'] : $requiredLangauges,
 
             // flags
             'showCloseConfirmation'          => true,

--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -206,7 +206,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
             $adminEntrypointUrl = null;
         }
 
-        $requiredLangauges = $systemSettings['general']['required_languages'];
+        $requiredLanguages = $systemSettings['general']['required_languages'];
 
         $settings = [
             'instanceId'          => $this->getInstanceId(),
@@ -226,9 +226,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
                 $systemSettings['general']['valid_languages'],
                 true
             ),
-            'requiredLanguages' => empty($requiredLangauges) === true
-                ? $systemSettings['general']['valid_languages']
-                : $requiredLangauges,
+            'requiredLanguages' => $requiredLanguages ?: $systemSettings['general']['valid_languages'],
 
             // flags
             'showCloseConfirmation'          => true,

--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -226,7 +226,9 @@ class IndexController extends AdminAbstractController implements KernelResponseE
                 $systemSettings['general']['valid_languages'],
                 true
             ),
-            'requiredLanguages' => empty($requiredLangauges) === true ? $systemSettings['general']['valid_languages'] : $requiredLangauges,
+            'requiredLanguages' => empty($requiredLangauges) === true
+                ? $systemSettings['general']['valid_languages']
+                : $requiredLangauges,
 
             // flags
             'showCloseConfirmation'          => true,

--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -196,6 +196,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
         $config = $templateParams['config'];
         $systemSettings = $templateParams['systemSettings'];
         $adminSettings = $templateParams['adminSettings'];
+        $requiredLanguages = $systemSettings['general']['valid_languages'];
         $dashboardHelper = new Dashboard($user);
         $customAdminEntrypoint = $this->getParameter('pimcore_admin.custom_admin_route_name');
 
@@ -206,7 +207,9 @@ class IndexController extends AdminAbstractController implements KernelResponseE
             $adminEntrypointUrl = null;
         }
 
-        $requiredLanguages = $systemSettings['general']['required_languages'];
+        if (array_key_exists('required_languages', $systemSettings['general'])) {
+            $requiredLanguages = $systemSettings['general']['required_languages'];
+        }
 
         $settings = [
             'instanceId'          => $this->getInstanceId(),
@@ -226,7 +229,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
                 $systemSettings['general']['valid_languages'],
                 true
             ),
-            'requiredLanguages' => $requiredLanguages ?: $systemSettings['general']['valid_languages'],
+            'requiredLanguages' => $requiredLanguages,
 
             // flags
             'showCloseConfirmation'          => true,

--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -224,6 +224,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
                 $systemSettings['general']['valid_languages'],
                 true
             ),
+            'requiredLanguages' => $systemSettings['general']['required_languages'],
 
             // flags
             'showCloseConfirmation'          => true,

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -369,6 +369,12 @@ class SettingsController extends AdminAbstractController
         $this->checkPermission('system_settings');
         $config = $config->getSystemSettingsConfig();
 
+        // If required languages is empty it's the same as if all langauges are required. Therefore, we need to overwrite the
+        // value with the valid languages value to have all languages required
+        if (empty($config['general']['required_languages']) === true) {
+            $config['general']['required_languages'] = $config['general']['valid_languages'];
+        }
+
         $valueArray = [
             'general' => $config['general'],
             'documents' => $config['documents'],

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -369,8 +369,8 @@ class SettingsController extends AdminAbstractController
         $this->checkPermission('system_settings');
         $config = $config->getSystemSettingsConfig();
 
-        // If required languages is empty it's the same as if all langauges are required. Therefore, we need to overwrite the
-        // value with the valid languages value to have all languages required
+        // If required languages is empty it's the same as if all langauges are required. Therefore, we
+        // need to overwrite the value with the valid languages value to have all languages required
         if (empty($config['general']['required_languages']) === true) {
             $config['general']['required_languages'] = $config['general']['valid_languages'];
         }

--- a/translations/admin_ext.en.yaml
+++ b/translations/admin_ext.en.yaml
@@ -700,3 +700,4 @@ classificationstore_error_addcollection_msg: Error adding group
 log_search_pid: PID
 log_refresh_seconds: Seconds
 system_requirements_check: System-Requirements Check
+required_language: 'Mandatory language'


### PR DESCRIPTION
## Changes
Resolves pimcore/pimcore#2958

## Additional infos
This uses the logic introduced by pimcore/pimcore#16835 to make languages not mandatory. We add a checkbox in the System Setting where the user can set which languages should be mandatory. In the display logic of the localizedfield fields we update the mandatory state of the fields according to the languages mandatory need. 