### PR TITLE
Revert part of PSDP-244/686e913 to fix an error when uploading a new avatar

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -3294,7 +3294,7 @@ pimcore.helpers.reloadUserImage = function (userId) {
     var image = Routing.generate('pimcore_admin_user_getimage', {id: userId, '_dc': Ext.Date.now()});
 
     if (pimcore.currentuser.id == userId) {
-        Ext.get("pimcore_notification").query('img')[0].src = image;
+        Ext.get("pimcore_avatar").query('img')[0].src = image;
     }
 
     if (Ext.getCmp("pimcore_user_image_" + userId)) {


### PR DESCRIPTION
By uploading a new avatar this happends:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/31919154/eed36de8-03ad-4538-9bf9-f00029405fea)

But it should be:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/31919154/a5e29a57-bf08-465e-9418-5160f55e7f6a)

See https://github.com/pimcore/admin-ui-classic-bundle/commit/686e913fae7523981eb8a9ed682d2e2089627917#diff-efc7c8f1d31756b699ed50c0214db7ca6f13bf9544340e02d33e64624a5d3b84R3231