### PR TITLE
[Bug]: UI Inconsistencies between Advanced Many-to-Many and Many-to-Many data types

### DIFF
--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -41,6 +41,7 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
             {
                 xtype: "button",
                 iconCls: "pimcore_icon_filter",
+                tooltip: t("filter"),
                 cls: "relations_grid_filter_btn",
                 handler: this.showFilterInput.bind(this)
             }

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -600,6 +600,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 toolbarItems.push({
                     xtype: "button",
                     iconCls: "pimcore_icon_delete",
+                    tooltip: t("empty"),
                     handler: function () {
                         pimcore.helpers.deleteConfirm(t('all'), t('relations'), function () {
                             this.empty();
@@ -611,8 +612,9 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             if (this.fieldConfig.assetsAllowed && this.fieldConfig.noteditable == false) {
                 toolbarItems.push({
                     xtype: "button",
-                    cls: "pimcore_inline_upload",
                     iconCls: "pimcore_icon_upload",
+                    tooltip: t("upload"),
+                    cls: "pimcore_inline_upload",
                     handler: this.uploadDialog.bind(this)
                 });
             }
@@ -622,6 +624,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                     {
                         xtype: "button",
                         iconCls: "pimcore_icon_search",
+                        tooltip: t("search"),
                         handler: this.openSearchEditor.bind(this)
                     }
                     //,

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -283,7 +283,6 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
     },
 
     getCreateControl: function () {
-
         var allowedClasses;
         var i;
 
@@ -324,12 +323,14 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 items.push({
                     cls: "pimcore_block_button_plus",
                     iconCls: "pimcore_icon_plus",
+                    tooltip: t("add"),
                     handler: collectionMenu[0].handler
                 });
             } else if (collectionMenu.length > 1) {
                 items.push({
                     cls: "pimcore_block_button_plus",
                     iconCls: "pimcore_icon_plus",
+                    tooltip: t("add"),
                     menu: collectionMenu
                 });
             } else {
@@ -340,10 +341,8 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             }
         }
 
-
         return items[0];
-    }
-    ,
+    },
 
     getVisibleColumns: function () {
         var visibleFields = this.visibleFields || [];
@@ -658,6 +657,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 toolbarItems.push({
                     xtype: "button",
                     iconCls: "pimcore_icon_delete",
+                    tooltip: t("empty"),
                     handler: function () {
                         pimcore.helpers.deleteConfirm(t('all'), t('relations'), function () {
                             this.empty();
@@ -666,15 +666,16 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 });
             }
 
+            toolbarItems = toolbarItems.concat(this.getCreateControl());
+
             if(pimcore.helpers.hasSearchImplementation()) {
                 toolbarItems.push({
                     xtype: "button",
                     iconCls: "pimcore_icon_search",
+                    tooltip: t("search"),
                     handler: this.openSearchEditor.bind(this)
                 });
             }
-
-            toolbarItems = toolbarItems.concat(this.getCreateControl());
         }
 
         return toolbarItems;

--- a/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -227,7 +227,8 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
                 icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                 handler: function (grid, rowIndex) {
                     let data = grid.getStore().getAt(rowIndex);
-                    pimcore.helpers.deleteConfirm(t('relation'), data.data.path, function () {
+
+                    pimcore.helpers.deleteConfirm(t('relation'), data.data.fullpath, function () {
                         grid.getStore().removeAt(rowIndex);
                     }.bind(this));
                 }.bind(this)
@@ -393,6 +394,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             toolbarItems.push({
                 xtype: "button",
                 iconCls: "pimcore_icon_delete",
+                tooltip: t("empty"),
                 handler: function () {
                     pimcore.helpers.deleteConfirm(t('all'), t('relations'), function () {
                         this.empty();
@@ -401,23 +403,25 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             });
         }
 
+        if (this.fieldConfig.assetsAllowed) {
+            toolbarItems.push({
+                xtype: "button",
+                iconCls: "pimcore_icon_upload",
+                tooltip: t("upload"),
+                cls: "pimcore_inline_upload",
+                handler: this.uploadDialog.bind(this)
+            });
+        }
+
         if(pimcore.helpers.hasSearchImplementation()) {
             toolbarItems = toolbarItems.concat([
                 {
                     xtype: "button",
                     iconCls: "pimcore_icon_search",
+                    tooltip: t("search"),
                     handler: this.openSearchEditor.bind(this)
                 }
             ]);
-        }
-
-        if (this.fieldConfig.assetsAllowed) {
-            toolbarItems.push({
-                xtype: "button",
-                cls: "pimcore_inline_upload",
-                iconCls: "pimcore_icon_upload",
-                handler: this.uploadDialog.bind(this)
-            });
         }
 
         return toolbarItems;

--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -215,25 +215,29 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         var items = [this.component, {
             xtype: "button",
             iconCls: "pimcore_icon_open",
+            tooltip: t("open"),
             style: "margin-left: 5px",
             handler: this.openElement.bind(this)
         }];
+
+        if (this.fieldConfig.assetInlineDownloadAllowed) {
+            items.push({
+                xtype: "button",
+                iconCls: "pimcore_icon_download",
+                tooltip: t("download"),
+                cls: "pimcore_inline_download",
+                style: "margin-left: 5px",
+                handler: this.downloadAsset.bind(this)
+            });
+        }
 
         if (this.fieldConfig.allowToClearRelation) {
             items.push({
                 xtype: "button",
                 iconCls: "pimcore_icon_delete",
+                tooltip: t("empty"),
                 style: "margin-left: 5px",
                 handler: this.empty.bind(this)
-            });
-        }
-
-        if(pimcore.helpers.hasSearchImplementation()) {
-            items.push({
-                xtype: "button",
-                iconCls: "pimcore_icon_search",
-                style: "margin-left: 5px",
-                handler: this.openSearchEditor.bind(this)
             });
         }
 
@@ -242,19 +246,20 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             items.push({
                 xtype: "button",
                 iconCls: "pimcore_icon_upload",
+                tooltip: t("upload"),
                 cls: "pimcore_inline_upload",
                 style: "margin-left: 5px",
                 handler: this.uploadDialog.bind(this)
             });
         }
 
-        if (this.fieldConfig.assetInlineDownloadAllowed) {
+        if(pimcore.helpers.hasSearchImplementation()) {
             items.push({
                 xtype: "button",
-                iconCls: "pimcore_icon_download",
-                cls: "pimcore_inline_download",
+                iconCls: "pimcore_icon_search",
+                tooltip: t("search"),
                 style: "margin-left: 5px",
-                handler: this.downloadAsset.bind(this)
+                handler: this.openSearchEditor.bind(this)
             });
         }
 


### PR DESCRIPTION
This PR resolves both tasks in #440

Before:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/31919154/8f586673-823d-4f9a-8e1c-b41f1847b1b2)

Now:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/31919154/1937b64d-924d-42c7-80f9-bb093c092c48)


I also added a tooltip to each button and sort the buttons in this group: "Open | Clear | Assigne"
So the Up & Down clouds for uploading and downloading are now separate - our customers actually get confused about this 😐