### PR TITLE
Fix UX for inherited boolean properties

### DIFF
--- a/public/js/pimcore/element/properties.js
+++ b/public/js/pimcore/element/properties.js
@@ -461,7 +461,7 @@ pimcore.element.properties = Class.create({
             else if (data.inherited == false) {
                 return '<div class="pimcore_property_droptarget">&nbsp;</div>';
             }
-        } else if (type == "bool" && data.inherited == false) {
+        } else if (type == "bool") {
             if (value) {
                 return '<div style="text-align: left"><div role="button" class="x-grid-checkcolumn x-grid-checkcolumn-checked" style=""></div></div>';
             } else {

--- a/public/js/pimcore/element/properties.js
+++ b/public/js/pimcore/element/properties.js
@@ -483,7 +483,7 @@ pimcore.element.properties = Class.create({
         var data = record.data;
         var type = data.type;
 
-        if (type == "bool") {
+        if (type == "bool" && data.inherited == false) {
             record.set("data", !record.data.data);
         }
     },


### PR DESCRIPTION
This PR addresses a UX issue with asset/document properties of boolean type.

# Problem description
## Affected version

- all versions since 2015?
- found it in 11.1.2
- still there in 11.2.2

## Steps to reproduce
- create a property in the root leaf of the asset tree, type boolean, inheritable, checked
- have an asset ("Asset A") somewhere in the tree

## Expected behavior
- "Asset A" displays a checked checkbox
- the checkbox cannot be changed

## Actual behavior
- "Asset A" displays a string "true" (or an empty cell if the root property is not checked)
- the value toggles between "true" and "" when clicked

![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/124272368/fe85ebf8-c8e3-4358-aed9-42ba70496488)
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/124272368/7d9e3592-2b05-4c7f-b8e0-93505e6de1fe)


# Discussion

## Impact on UX

It is confusing to the user because one can change the value, the value appears to have changed, however, saving the changed value does not do anything - in fact, it can only be seen once the tab is reloaded and one navigates to the properties again to see that the value resets to the previous value.

We found that this very behavior only appears for properties of boolean type - which indicates that the behavior is  not intended as is.

## How it came to be this way

### Checkbox not displayed

We did some digging in the code history and found that in July 2018, the change which prevented displaying a checkbox was introduced during a massive directory structure refactoring 2fb5fa76bb3488b406eb99632fe5b0745df610e7. It seems that code has been consolidated from various sources back then (pimcore/static/js/pimcore/settings/metadata/predefined.js, pimcore/static5/js/pimcore/settings/website.js, pimcore/static6/js/pimcore/asset/metadata.js, ...). these sources have been created in 2014 and 2015. Unfortunately, we could not find any hint on why the change was necessary.

### Toggle change for inherited boolean properties

Changing a boolean property, even if inherited, has been moved in 2015 and thus has been created even before. 41b0c816c4a8314503acd6d1f1c5136ec1d1c463