### PR TITLE
Login: Center custom logo

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -123,6 +123,7 @@ a, a:hover, a:visited, a:active {
     left: 90px;
     width: 300px;
     z-index: 200;
+    text-align: center;
 }
 
 #logo img {


### PR DESCRIPTION
I would prefer to center the logo in the login. For logos with a width of less than 300px, it sticks to the left edge.