### PR TITLE
[Bug]: Fix Custom OptionsProvider value reset in Class definition edit mode of DataObject Select field

### DIFF
--- a/public/js/pimcore/object/helpers/selectField.js
+++ b/public/js/pimcore/object/helpers/selectField.js
@@ -47,8 +47,10 @@ pimcore.object.helpers.selectField = {
             store: this.getSelectOptionsStore(),
             listeners: {
                 change: function (comboBox, newValue) {
-                    optionsProviderClass.setValue(pimcore.settings.select_options_provider_class);
-                    optionsProviderData.setValue(newValue);
+                    if (newValue !== null){
+                        optionsProviderClass.setValue(pimcore.settings.select_options_provider_class);
+                        optionsProviderData.setValue(newValue);\
+                    }
                 }
             }
         });


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/16739
