### PR TITLE
[Bug]: Fix "getSaveData is not a function" in Folder context

### DIFF
--- a/.github/ci/files/.env
+++ b/.github/ci/files/.env
@@ -1,0 +1,2 @@
+APP_ENV=test
+APP_DEBUG=true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,34 +1,14 @@
-name: "CLA Assistant"
+name: CLA check
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
-    types: [opened,closed,synchronize]
+    types: [opened, closed, synchronize]
 
 jobs:
-  CLAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: cla-assistant/github-action@v2.1.1-beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/pimcore/pimcore/blob/master/CLA.md' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          allowlist: user1,bot*
-
-         #below are the optional inputs - If the optional inputs are not given, then default values will be taken
-          remote-organization-name: 'pimcore' #enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
-          remote-repository-name: 'cla'
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+  cla-workflow:
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-cla-check.yaml@v1.3.0
+    if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+    secrets:
+      CLA_ACTION_ACCESS_TOKEN: ${{ secrets.CLA_ACTION_ACCESS_TOKEN }}

--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -31,7 +31,7 @@ jobs:
                 include:
                     - { php-version: 8.1, database: "mariadb:10.3", dependencies: lowest, pimcore_version: "", experimental: false }
                     - { php-version: 8.2, database: "mariadb:10.11", dependencies: highest, pimcore_version: "", experimental: false }
-                    - { php-version: 8.2, database: "mariadb:10.11", dependencies: highest, pimcore_version: "11.x-dev as 11.0.0", experimental: true }
+                    - { php-version: 8.3, database: "mariadb:10.11", dependencies: highest, pimcore_version: "11.x-dev as 11.0.0", experimental: true }
         services:
             mariadb:
                 image: "${{ matrix.database }}"

--- a/.github/workflows/poeditor-export.yaml
+++ b/.github/workflows/poeditor-export.yaml
@@ -15,6 +15,7 @@ permissions:
 jobs:
     poeditor:
         runs-on: ubuntu-latest
+        if: ${{ github.repository == 'pimcore/admin-ui-classic-bundle' }}
         steps:
             -   name: Trigger workflow in pimcore/poeditor-export-action
                 env:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
                 include:
                     - { php-version: "8.1", dependencies: "lowest", pimcore_version: "", phpstan_args: "", experimental: false }
                     - { php-version: "8.2", dependencies: "highest", pimcore_version: "", phpstan_args: "", experimental: false }
-                    - { php-version: "8.2", dependencies: "highest", pimcore_version: "11.x-dev as 11.0.0", phpstan_args: "", experimental: true }
+                    - { php-version: "8.3", dependencies: "highest", pimcore_version: "11.x-dev as 11.0.0", phpstan_args: "", experimental: true }
         steps:
             - name: "Checkout code"
               uses: "actions/checkout@v2"

--- a/.github/workflows/sync-changes-scheduled.yml
+++ b/.github/workflows/sync-changes-scheduled.yml
@@ -1,0 +1,27 @@
+name: Sync changes scheduled from CE to EE
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "30 21 * * *"
+
+jobs:
+    sync-branches:
+        uses: pimcore/workflows-collection-public/.github/workflows/reusable-sync-changes.yaml@v1.0.0
+        if: github.repository == 'pimcore/admin-ui-classic-bundle'
+        strategy:
+            fail-fast: false
+            matrix:
+                ref:
+                    [
+                        { "base": "1.x", "destination": "1.x" },
+                        { "base": "1.4", "destination": "1.4" },
+                    ]
+        with:
+            base_ref: ${{ matrix.ref.base }}
+            ref_name: ${{ matrix.ref.destination }}
+            target_repo: "ee-admin-ui-classic-bundle"
+            auto_merge: true
+        secrets:
+            SYNC_TOKEN: ${{ secrets.SYNC_TOKEN }}
+            GIT_NAME: ${{ secrets.GIT_NAME }}
+            GIT_EMAIL: ${{ secrets.GIT_EMAIL }}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     }
   },
   "require": {
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "pimcore/pimcore": "^11.2.0",
     "symfony/webpack-encore-bundle": "^1.13.2"

--- a/public/js/pimcore/object/helpers/gridTabAbstract.js
+++ b/public/js/pimcore/object/helpers/gridTabAbstract.js
@@ -231,6 +231,45 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
 
             this.store.getProxy().setExtraParam("query", this.searchFilter);
 
+            var selectObjectOptions = Ext.create('Ext.data.Store', {
+                fields: ['name', 'value'],
+                data: [
+                    [t("all_types"), "all_objects"],
+                    [t("only_object"), "only_objects"],
+                    [t("only_variant"), "only_variant_objects"],
+                ]
+            });
+
+            this.selectObjectType = new Ext.form.ComboBox({
+                fieldLabel: t('select_objects_type'),
+                name: 'objects_type',
+                labelWidth: 120,
+                xtype: "combo",
+                displayField:'name',
+                valueField: "value",
+                hidden: !this.element.data.general.allowInheritance,
+                store: selectObjectOptions,
+                editable: false,
+                width : 300,
+                triggerAction: 'all',
+                value: 'all_objects',
+                listeners: {
+                    change: function(comboBox,selected){
+                        this.grid.getStore().setRemoteFilter(false);
+                        this.grid.filters.clearFilters();
+                        this.grid.getStore().clearFilter();
+
+                        this.store.getProxy().setExtraParam("filter_by_object_type", selected);
+
+                        this.pagingtoolbar.moveFirst();
+
+                        this.grid.getStore().setRemoteFilter(true);
+
+                        this.saveColumnConfigButton.show();
+                    }.bind(this)
+                }
+            });
+
             this.checkboxOnlyDirectChildren = new Ext.form.Checkbox({
                 name: "onlyDirectChildren",
                 style: "margin-bottom: 5px; margin-left: 5px",
@@ -296,6 +335,7 @@ pimcore.object.helpers.gridTabAbstract = Class.create({
                 this.languageInfo, "-",
                 this.toolbarFilterInfo,
                 this.clearFilterButton, "->",
+                this.selectObjectType, "-",
                 this.checkboxOnlyDirectChildren, "-",
                 this.exportButton, "-",
                 this.columnConfigButton,

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -85,7 +85,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             storeConfig.autoLoad = true;
             storeConfig.listeners = {
                 beforeload: function(store) {
-                    store.getProxy().setExtraParam('unsavedChanges', this.object ? this.object.getSaveData().data : {});
+                    store.getProxy().setExtraParam('unsavedChanges', this.object && typeof this.object.getSaveData === "function" ? this.object.getSaveData().data : {});
                     store.getProxy().setExtraParam('context', JSON.stringify(this.getContext()));
                 }.bind(this)
             };

--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -76,7 +76,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             storeConfig.autoLoad = true;
             storeConfig.listeners = {
                 beforeload: function(store) {
-                    store.getProxy().setExtraParam('unsavedChanges', this.object ? this.object.getSaveData().data : {});
+                    store.getProxy().setExtraParam('unsavedChanges', this.object && typeof this.object.getSaveData === "function" ? this.object.getSaveData().data : {});
                     store.getProxy().setExtraParam('context', JSON.stringify(this.getContext()));
                 }.bind(this)
             };

--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -161,49 +161,54 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {});
 
-        var tbar = [];
+        let tbar = null;
+        
+        if (!this.fieldConfig.noteditable)
+        {
+            tbar = [];
 
-        if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
+            if (!this.fieldConfig.colsFixed || columns.length < this.fieldConfig.cols) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_col pimcore_icon_overlay_add",
+                    handler: this.addColumn.bind(this)
+                });
+            }
+
+            if (!this.fieldConfig.colsFixed || columns.length > this.fieldConfig.cols) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_col pimcore_icon_overlay_delete",
+                    handler: this.deleteColumn.bind(this)
+                });
+            }
+
+            if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
+                tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
+                    handler: this.deleteRow.bind(this)
+                });
+
+                tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
+                    handler: this.addRow.bind(this)
+                });
+            }
+
             tbar.push({
-                iconCls: "pimcore_icon_table_col pimcore_icon_overlay_add",
-                handler: this.addColumn.bind(this)
+                iconCls: 'pimcore_icon_copy',
+                handler: this.copyFromTable.bind(this)
+            });
+
+            tbar.push({
+                iconCls: "pimcore_icon_paste",
+                handler: this.pasteFromClipboard.bind(this)
+            });
+
+
+            tbar.push({
+                iconCls: "pimcore_icon_empty",
+                handler: this.emptyStore.bind(this)
             });
         }
-
-        if (!this.fieldConfig.colsFixed || columns.length > this.fieldConfig.cols) {
-            tbar.push({
-                iconCls: "pimcore_icon_table_col pimcore_icon_overlay_delete",
-                handler: this.deleteColumn.bind(this)
-            });
-        }
-
-        if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
-            tbar.push({
-                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
-                handler: this.deleteRow.bind(this)
-            });
-
-            tbar.push({
-                iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
-                handler: this.addRow.bind(this)
-            });
-        }
-
-        tbar.push({
-            iconCls: 'pimcore_icon_copy',
-            handler: this.copyFromTable.bind(this)
-        });
-
-        tbar.push({
-            iconCls: "pimcore_icon_paste",
-            handler: this.pasteFromClipboard.bind(this)
-        });
-
-
-        tbar.push({
-            iconCls: "pimcore_icon_empty",
-            handler: this.emptyStore.bind(this)
-        });
 
         this.grid = Ext.create('Ext.grid.Panel', {
             store: this.store,

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -64,6 +64,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     use DataObjectActionsTrait;
     use UserNameTrait;
 
+    /** On active edit lock answer with editlock response */
+    const TASK_RESPONSE = 'response';
+    /** On active edit lock overwrite with new user */
+    const TASK_OVERWRITE = 'overwrite';
+    /** On active edit lock keep existing entry */
+    const TASK_KEEP = 'keep';
+    
     protected DataObject\Service $_objectService;
 
     private array $objectData = [];
@@ -295,10 +302,25 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         // check for lock
         if ($object->isAllowed('save') || $object->isAllowed('publish') || $object->isAllowed('unpublish') || $object->isAllowed('delete')) {
             if (Element\Editlock::isLocked($objectId, 'object', $request->getSession()->getId())) {
-                return $this->getEditLockResponse($objectId, 'object');
-            }
+                //Hook for modifying editlock handling - e.g. no editLockResponse but keep old lock
+                $lockData = [
+                    'task' => self::TASK_RESPONSE
+                ];
+                $event = new GenericEvent($this, [
+                    'data' => $lockData,
+                    'object' => $object,
+                ]);
+                $eventDispatcher->dispatch($event, AdminEvents::OBJECT_GET_IS_LOCKED);
+                $lockData = $event->getArgument('data');
 
-            Element\Editlock::lock($request->get('id'), 'object', $request->getSession()->getId());
+                if ($lockData['task'] === self::TASK_RESPONSE) {
+                    return $this->getEditLockResponse($objectId, 'object');
+                } else if ($lockData['task'] === self::TASK_OVERWRITE) {
+                    Element\Editlock::lock($objectId, 'object', $request->getSession()->getId());
+                }
+            } else {
+                Element\Editlock::lock($objectId, 'object', $request->getSession()->getId());
+            }
         }
 
         // we need to know if the latest version is published or not (a version), because of lazy loaded fields in $this->getDataForObject()

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -66,11 +66,13 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
     /** On active edit lock answer with editlock response */
     const TASK_RESPONSE = 'response';
+
     /** On active edit lock overwrite with new user */
     const TASK_OVERWRITE = 'overwrite';
+
     /** On active edit lock keep existing entry */
     const TASK_KEEP = 'keep';
-    
+
     protected DataObject\Service $_objectService;
 
     private array $objectData = [];
@@ -304,7 +306,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             if (Element\Editlock::isLocked($objectId, 'object', $request->getSession()->getId())) {
                 //Hook for modifying editlock handling - e.g. no editLockResponse but keep old lock
                 $lockData = [
-                    'task' => self::TASK_RESPONSE
+                    'task' => self::TASK_RESPONSE,
                 ];
                 $event = new GenericEvent($this, [
                     'data' => $lockData,
@@ -315,7 +317,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
                 if ($lockData['task'] === self::TASK_RESPONSE) {
                     return $this->getEditLockResponse($objectId, 'object');
-                } else if ($lockData['task'] === self::TASK_OVERWRITE) {
+                } elseif ($lockData['task'] === self::TASK_OVERWRITE) {
                     Element\Editlock::lock($objectId, 'object', $request->getSession()->getId());
                 }
             } else {

--- a/src/Event/AdminEvents.php
+++ b/src/Event/AdminEvents.php
@@ -323,6 +323,20 @@ class AdminEvents
     const DOCUMENT_TREE_GET_CHILDREN_BY_ID_PRE_SEND_DATA = 'pimcore.admin.document.treeGetChildrenById.preSendData';
 
     /**
+     * Fired before the edit lock is handled.
+     *
+     * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController
+     * Arguments:
+     *  - data | array | editLock behaviour, this can be modified
+     *  - object | AbstractObject | the current object
+     *
+     * @Event("Symfony\Component\EventDispatcher\GenericEvent")
+     *
+     * @var string
+     */
+    const OBJECT_GET_IS_LOCKED = 'pimcore.admin.dataobject.get.isLocked';
+
+    /**
      * Fired before the request params are parsed.
      *
      * Subject: \Pimcore\Bundle\AdminBundle\Controller\Admin\DataObjectController

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -670,10 +670,19 @@ class GridHelperService
             }
         }
 
-        if ($class->getShowVariants()) {
-            $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT]);
+        if ($class->getAllowVariants()) {
+            if ($class->getShowVariants()) {
+                $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT]);
+            }
+            if (isset($requestParams['filter_by_object_type'])){
+                if ($requestParams['filter_by_object_type'] === "only_objects") {
+                    $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT]);
+                } elseif($requestParams['filter_by_object_type'] === "only_variant_objects") {
+                    $list->setObjectTypes([DataObject::OBJECT_TYPE_VARIANT]);
+                }
+            }
         }
-
+        
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureAndSlugFilters);
         $this->addSlugJoins($list, $slugJoins, $featureAndSlugFilters);
 

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -674,15 +674,15 @@ class GridHelperService
             if ($class->getShowVariants()) {
                 $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT, DataObject::OBJECT_TYPE_VARIANT]);
             }
-            if (isset($requestParams['filter_by_object_type'])){
-                if ($requestParams['filter_by_object_type'] === "only_objects") {
+            if (isset($requestParams['filter_by_object_type'])) {
+                if ($requestParams['filter_by_object_type'] === 'only_objects') {
                     $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT]);
-                } elseif($requestParams['filter_by_object_type'] === "only_variant_objects") {
+                } elseif($requestParams['filter_by_object_type'] === 'only_variant_objects') {
                     $list->setObjectTypes([DataObject::OBJECT_TYPE_VARIANT]);
                 }
             }
         }
-        
+
         $this->addGridFeatureJoins($list, $featureJoins, $class, $featureAndSlugFilters);
         $this->addSlugJoins($list, $slugJoins, $featureAndSlugFilters);
 

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -432,6 +432,9 @@ system_columns: 'System columns'
 columns: Columns
 children_grid: 'Children Grid'
 only_children: 'just direct children'
+only_object: 'just objects'
+only_variant: 'just variants object'
+select_objects_type: "Type to show"
 cut: Cut
 paste_cut_element: 'Paste cut-out element'
 memorize_tabs: 'Memorize open tabs'

--- a/translations/admin_ext.en.yaml
+++ b/translations/admin_ext.en.yaml
@@ -700,3 +700,8 @@ classificationstore_error_addcollection_msg: Error adding group
 log_search_pid: PID
 log_refresh_seconds: Seconds
 system_requirements_check: System-Requirements Check
+rgbaColor: RGBA Color
+booleanSelect: Boolean Select
+quantityValue: Quantity Value
+inputQuantityValue: Input Quantity Value
+calculatedValue: Calculated Value


### PR DESCRIPTION
When Editing Relations in a Folder overview, the beforeLoad listener tried to call this.object.getSaveData
But the Context of this.object in the Folder view is different than in a Object and the getSaveData function doesn't exist

This fixes the error and the rest of the editing works normally again.