### PR TITLE
Fix null to property error in operator text

### DIFF
--- a/public/js/pimcore/object/gridcolumn/operator/Text.js
+++ b/public/js/pimcore/object/gridcolumn/operator/Text.js
@@ -39,7 +39,7 @@ pimcore.object.gridcolumn.operator.text = Class.create(pimcore.object.gridcolumn
         } else {
 
             //For building up operator list
-            var configAttributes = { type: this.type, class: this.class};
+            var configAttributes = { type: this.type, class: this.class, label: this.defaultText};
 
             var node = {
                 draggable: true,
@@ -63,7 +63,7 @@ pimcore.object.gridcolumn.operator.text = Class.create(pimcore.object.gridcolumn
             leaf: true,
             isOperator: true,
             configAttributes: {
-                label: null,
+                label: this.defaultText,
                 type: this.type,
                 class: this.class
             }


### PR DESCRIPTION
## Situation:
- Open Grid View from folder
- In the Grid View configuration, select the "text" operator under "Formatters".
- Now we get the following error:
![grafik](https://github.com/pimcore/admin-ui-classic-bundle/assets/140016987/3c30ff53-056e-4796-8790-1ddc4b8b9164)

## Expected behavior:
That it is possible to use the operator text without getting an error message for which the user is not responsible.

## Workaround:
We simply set the defaultText as the default value for the label instead of `null`.