### PR TITLE
[Bug]: Fix "getSaveData is not a function" in Folder context

### DIFF
--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -85,7 +85,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             storeConfig.autoLoad = true;
             storeConfig.listeners = {
                 beforeload: function(store) {
-                    store.getProxy().setExtraParam('unsavedChanges', this.object ? this.object.getSaveData().data : {});
+                    store.getProxy().setExtraParam('unsavedChanges', this.object && typeof this.object.getSaveData === "function" ? this.object.getSaveData().data : {});
                     store.getProxy().setExtraParam('context', JSON.stringify(this.getContext()));
                 }.bind(this)
             };

--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -76,7 +76,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             storeConfig.autoLoad = true;
             storeConfig.listeners = {
                 beforeload: function(store) {
-                    store.getProxy().setExtraParam('unsavedChanges', this.object ? this.object.getSaveData().data : {});
+                    store.getProxy().setExtraParam('unsavedChanges', this.object && typeof this.object.getSaveData === "function" ? this.object.getSaveData().data : {});
                     store.getProxy().setExtraParam('context', JSON.stringify(this.getContext()));
                 }.bind(this)
             };


### PR DESCRIPTION
When Editing Relations in a Folder overview, the beforeLoad listener tried to call this.object.getSaveData
But the Context of this.object in the Folder view is different than in a Object and the getSaveData function doesn't exist

This fixes the error and the rest of the editing works normally again.


I have read the CLA Document and I hereby sign the CLA