### PR TITLE
[FIX]: Dynamic Text Labels preview

### DIFF
--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1900,6 +1900,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $obj = DataObject::getByPath($objPath) ?? new $className();
 
         $textLayout = new DataObject\ClassDefinition\Layout\Text();
+        $textLayout->setName('textLayoutPreview' . $className);
 
         $context = [
           'data' => $request->get('renderingData'),
@@ -1907,6 +1908,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
         if ($renderingClass = $request->get('renderingClass')) {
             $textLayout->setRenderingClass($renderingClass);
+            $textLayout->setRenderingData($request->get('renderingData', ''));
         }
 
         if ($staticHtml = $request->get('html')) {


### PR DESCRIPTION
When going to the preview of a Dynamic Text Labels we get the following error:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/22234867/58aa183d-eef5-4010-bb5c-3c61ae8f0564)

After fixing this issue, when we use a Custom Renderer Class we get this error:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/22234867/35173b24-b8c4-4986-a125-f225f251c152)

This PR fix this 2 errors.

Also, the first fix is a duplicate of #379 which seems to be inactive
