### PR TITLE
[Bug, EC; LTS]: Parts of main menu disappear when starting download

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -887,6 +887,7 @@ pimcore.helpers.download = function (url) {
     let iframe = document.getElementById('download_helper_iframe');
     if (!iframe) {
         iframe = document.createElement('iframe');
+        iframe.style.display = 'none';
         iframe.setAttribute('id', 'download_helper_iframe');
         document.body.appendChild(iframe);
     }


### PR DESCRIPTION
### Pimcore version

v11.1.5

### Steps to reproduce

Use either demo instance ([demo.pimcore.com](https://demo.pimcore.com/) with light UI or [demo.pimcore.fun](https://demo.pimcore.fun/) with classic dark UI) and execute the following steps:

1. open any Data Object folder
2. select rows in the grid view
3. click on "CSV Export"
4. Click "OK" on Export dialog


### Actual Behavior

As soon as you click the OK button and the dialog disappears you can see that thw bottom part of the main menu disappers (seems like it is moved out of the window, at least partly), see the before and after screenshots
### before
![image](https://github.com/pimcore/pimcore/assets/96241555/93e849e0-5357-4cf0-9ee4-c1b09ca5f94f)
### after
![image](https://github.com/pimcore/pimcore/assets/96241555/8bdade38-8ac7-44d6-86da-9af8c80a5ef9)

I just could locate where the problem actual appears (when `document.body.appendChild(iframe)` is called in `pimcore.helpers.download` function) but have no idea why:
```
pimcore.helpers.download = function (url) {
    pimcore.settings.showCloseConfirmation = false;
    window.setTimeout(function () {
        pimcore.settings.showCloseConfirmation = true;
    }, 1000);

    let iframe = document.getElementById('download_helper_iframe');
    if (!iframe) {
        iframe = document.createElement('iframe');
        iframe.setAttribute('id', 'download_helper_iframe');
        document.body.appendChild(iframe);
    }

```

### Expected Behavior

The main menu should not be influenced by doing a download