### PR TITLE
Fix: Add video service providers to CSP allow list

### DIFF
--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -56,6 +56,11 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
         self::SCRIPT_OPT => [
             'https://buttons.github.io/buttons.js', // GitHub star button on login page
         ],
+        self::FRAME_OPT => [
+            'https://www.youtube-nocookie.com/', // Video preview thumbnail for YouTube
+            'https://www.dailymotion.com/',      // Video preview thumbnail for Dailymotion
+            'https://player.vimeo.com/',         // Video preview thumbnail for Vimeo
+        ],
     ];
 
     public function __construct(protected Config $config, protected array $cspHeaderOptions = [])


### PR DESCRIPTION
This adds the URLs of currently used video services to the CSP allow list for type frame so that video preview thumbnails are shown in backend.

Before this fix the video preview thumbnails are not shown but instead following message is logged to console:
`Refused to frame 'https://www.youtube-nocookie.com/' because it violates the following Content Security Policy directive: "frame-src 'self' data:".`

Fixes pimcore/admin-ui-classic-bundle#526