### PR TITLE
Fix: hide empty toolbar item

### DIFF
--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -302,19 +302,19 @@ pimcore.layout.toolbar = Class.create({
                      handler: this.editTranslations.bind(this, 'messages'),
                      priority: 10
                  }];
-             }
 
-             extrasItems.push({
-                 text: t("translations"),
-                 iconCls: "pimcore_nav_icon_translations",
-                 itemId: 'pimcore_menu_extras_translations',
-                 hideOnClick: false,
-                 menu: {
-                     cls: "pimcore_navigation_flyout",
-                     shadow: false,
-                     items: translationItems
-                 }
-             });
+                 extrasItems.push({
+                     text: t("translations"),
+                     iconCls: "pimcore_nav_icon_translations",
+                     itemId: 'pimcore_menu_extras_translations',
+                     hideOnClick: false,
+                     menu: {
+                         cls: "pimcore_navigation_flyout",
+                         shadow: false,
+                         items: translationItems
+                     }
+                 });
+             }
  
              if (user.isAllowed("recyclebin") && perspectiveCfg.inToolbar("extras.recyclebin")) {
                  extrasItems.push({


### PR DESCRIPTION
![Bildschirmfoto 2024-05-16 um 16 18 00](https://github.com/pimcore/admin-ui-classic-bundle/assets/50575907/c0c4f4d2-9112-4236-bc82-8dc07e92be7a)

Extras Toolbar-Item was displayed with no subitems