### PR TITLE
[Bug]: Fix visual bug that scheduled date is in different format 

### DIFF
--- a/public/js/pimcore/element/scheduler.js
+++ b/public/js/pimcore/element/scheduler.js
@@ -141,7 +141,10 @@ pimcore.element.scheduler = Class.create({
             });
 
             var propertiesColumns = [
-                {text: t("date"), width: 120, sortable: true, dataIndex: 'date', editor: new Ext.form.DateField()                },
+                {text: t("date"), width: 120, sortable: true, dataIndex: 'date', editor: new Ext.form.DateField({
+                        format: "Y-m-d"
+                    })
+                },
                 {text: t("time"), width: 100, sortable: true, dataIndex: 'time', editor: new Ext.form.TimeField({
                         format: "H:i",
                         listeners: {


### PR DESCRIPTION
Resolves a case reported in https://github.com/pimcore/pimcore/issues/14658

Before PR, is 
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/f0b6ffdd-d1d9-42b0-9c8c-e120e74a99fa)
and after clicking/unfocus
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/5f425739-7d36-4d12-b933-d68fe9406c49)

After PR, is the same `Y-m-d` as https://github.com/pimcore/admin-ui-classic-bundle/blob/1976b8f869ad450e1b3d2b9e4aebcc47f3487e7e/public/js/pimcore/element/scheduler.js#L66