### PR TITLE
[BUG] remove checks on quantity value convert actions

### DIFF
--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -236,8 +236,6 @@ class QuantityValueController extends AdminAbstractController
      */
     public function convertAction(Request $request, UnitConversionService $conversionService): JsonResponse
     {
-        $this->checkPermission('quantityValueUnits');
-
         $fromUnitId = $request->get('fromUnit');
         $toUnitId = $request->get('toUnit');
 
@@ -261,8 +259,6 @@ class QuantityValueController extends AdminAbstractController
      */
     public function convertAllAction(Request $request, UnitConversionService $conversionService): JsonResponse
     {
-        $this->checkPermission('quantityValueUnits');
-
         $unitId = $request->get('unit');
 
         $fromUnit = Unit::getById($unitId);

--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -236,6 +236,8 @@ class QuantityValueController extends AdminAbstractController
      */
     public function convertAction(Request $request, UnitConversionService $conversionService): JsonResponse
     {
+        $this->checkPermission('objects');
+
         $fromUnitId = $request->get('fromUnit');
         $toUnitId = $request->get('toUnit');
 
@@ -259,6 +261,8 @@ class QuantityValueController extends AdminAbstractController
      */
     public function convertAllAction(Request $request, UnitConversionService $conversionService): JsonResponse
     {
+        $this->checkPermission('objects');
+
         $unitId = $request->get('unit');
 
         $fromUnit = Unit::getById($unitId);


### PR DESCRIPTION
### Resolves: #434

Remove checkPermission method on specific rights for quantity value convert endpoints.

### Additional info
It seems not necessary to provide specific checks while using convert functions for quanity values. Futhermore if you giving the user the quantityValueUnits access right the user can edit all scale units. That seems not correct at least in our use case where just users with higher level access rights should be able to edit scale units.