### PR TITLE
Fixes problem when post_max_size is set to unlimited but upload_max_filesize has a limit

### DIFF
--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -313,7 +313,7 @@ class IndexController extends AdminAbstractController implements KernelResponseE
         // upload limit
         $max_upload = filesize2bytes(ini_get('upload_max_filesize') . 'B');
         $max_post = filesize2bytes(ini_get('post_max_size') . 'B');
-        $upload_mb = min($max_upload, $max_post);
+        $upload_mb = min($max_upload, $max_post) ?: $max_upload;
 
         $settings['upload_max_filesize'] = (int) $upload_mb;
 


### PR DESCRIPTION
Currently, if you have in your server, lets say 100M limit for file uploads, but post_max_size is set to unlimited (by setting it's value to 0), the bundle will set the upload_max_filesize setting to 0 as it's taking the minimum value between both into account. and it won't let you upload any files as javascript is comparing the size of the file to the value of 0.
This PR changes that so that if the minimum value between post_max_size is set to 0, then it should only take max_upload_filesize into account. If that value is set to 0 as well, then it is correct, as max_upload_filesize does not have an unlimiter.
If none of them are set to 0, then it will take the minimum value between the two as it's supposed to.