### PR TITLE
FieldDefinition: Add missing forbidden names

### DIFF
--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -19,15 +19,16 @@ pimcore.object.classes.data.data = Class.create({
 
     invalidFieldNames: false,
     forbiddenNames: [
-        "apipluginbroker", "byid", "bypath", "cachetag", "cachetags", "childamount", "children", "childrensortby",
-        "childrensortorder", "childs", "class", "classid", "classname", "classtitle", "closestparentofclass",
-        "creationdate", "dao", "data", "definition", "dependencies", "dirtyfields", "dirtylanguages", "fieldname",
-        "fullpath", "haschildren", "hassiblings", "id", "idpath", "index", "key", "language", "latestversion",
-        "lazyloadedfieldnames", "list", "localizedfields", "locked", "modificationdate", "nextparentforinheritance",
-        "object", "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions",
-        "permissionsforuser", "properties", "property", "published", "relationdata", "resource", "scheduledtasks",
-        "siblings", "type", "usermodification", "userowner", "userpermissions", "value", "valueforfieldname",
-        "valuefromparent", "values", "versioncount", "versions",
+        "apipluginbroker", "byid", "bypath", "cachetag", "cachetags", "childamount", "childpermissions", "children",
+        "childrensortby", "childrensortorder", "childs", "class", "classid", "classname", "classtitle",
+        "closestparentofclass", "creationdate", "currentfullpath", "dao", "data", "definition", "dependencies",
+        "dirtyfields", "dirtylanguages", "fieldname", "fullpath", "getinheritedvalues", "haschildren", "hassiblings",
+        "hideunpublished", "id", "idpath", "index", "key", "language", "latestversion", "lazyloadedfieldnames", "list",
+        "localizedfields", "locked", "modificationdate", "nextparentforinheritance", "object", "omitmandatorycheck",
+        "parent", "parentclass", "parentid", "path", "permissions", "permissionsforuser", "properties", "property",
+        "published", "realfullpath", "realpath", "relationdata", "resource", "scheduledtasks", "siblings", "type",
+        "types", "usermodification", "userowner", "userpermissions", "value", "valueforfieldname", "valuefromparent",
+        "values", "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -19,13 +19,15 @@ pimcore.object.classes.data.data = Class.create({
 
     invalidFieldNames: false,
     forbiddenNames: [
-        "id", "key", "path", "type", "index", "classname", "creationdate", "userowner", "value", "class", "list",
-        "fullpath", "childs", "children", "values", "cachetag", "cachetags", "parent", "published", "valuefromparent",
-        "userpermissions", "dependencies", "modificationdate", "usermodification", "byid", "bypath", "data",
-        "versions", "properties", "permissions", "permissionsforuser", "childamount", "apipluginbroker", "resource",
-        "parentClass", "definition", "locked", "language", "omitmandatorycheck", "idpath", "object", "fieldname",
-        "property", "localizedfields", "parentid", "scheduledtasks", "latestVersion", "haschildren", "siblings", "hassiblings",
-        "childrensortby", "childrensortorder", "versioncount", "dirtylanguages", "dirtyfields", "classtitle", "classid"
+        "apipluginbroker", "byid", "bypath", "cachetag", "cachetags", "childamount", "children", "childrensortby",
+        "childrensortorder", "childs", "class", "classid", "classname", "classtitle", "closestparentofclass",
+        "creationdate", "dao", "data", "definition", "dependencies", "dirtyfields", "dirtylanguages", "fieldname",
+        "fullpath", "haschildren", "hassiblings", "id", "idpath", "index", "key", "language", "latestversion",
+        "lazyloadedfieldnames", "list", "localizedfields", "locked", "modificationdate", "nextparentforinheritance",
+        "object", "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions",
+        "permissionsforuser", "properties", "property", "published", "relationdata", "resource", "scheduledtasks",
+        "siblings", "type", "usermodification", "userowner", "userpermissions", "value", "valueforfieldname",
+        "valuefromparent", "values", "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -25,7 +25,7 @@ pimcore.object.classes.data.data = Class.create({
         "versions", "properties", "permissions", "permissionsforuser", "childamount", "apipluginbroker", "resource",
         "parentClass", "definition", "locked", "language", "omitmandatorycheck", "idpath", "object", "fieldname",
         "property", "localizedfields", "parentid", "scheduledtasks", "latestVersion", "haschildren", "siblings", "hassiblings",
-        "childrenSortby", "childrensortorder", "versioncount", "dirtylanguages", "dirtyfields", "classtitle"
+        "childrensortby", "childrensortorder", "versioncount", "dirtylanguages", "dirtyfields", "classtitle", "classid"
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -19,17 +19,17 @@ pimcore.object.classes.data.data = Class.create({
 
     invalidFieldNames: false,
     forbiddenNames: [
-        "apipluginbroker", "byid", "bypath", "cachekey", "cachetag", "cachetags", "childamount", "childpermissions",
-        "children", "childrensortby", "childrensortorder", "childs", "class", "classid", "classname", "classtitle",
-        "closestparentofclass", "creationdate", "currentfullpath", "dao", "data", "definition", "dependencies",
-        "dirtyfields", "dirtylanguages", "fieldname", "fullpath", "getinheritedvalues", "haschildren", "hassiblings",
-        "hideunpublished", "id", "idpath", "index", "key", "language", "latestversion", "lazyloadedfieldnames", "list",
-        "listingcachekey", "localizedfields", "locked", "modelfactory", "modificationdate", "nextparentforinheritance",
-        "object", "objectvar", "objectvars", "omitmandatorycheck", "parent", "parentclass", "parentid", "path",
-        "permissions", "permissionsforuser", "properties", "property", "published", "realfullpath", "realpath",
-        "relationdata", "resource", "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner",
-        "userpermissions", "validtablecolumns", "value", "valueforfieldname", "valuefromparent", "values",
-        "versioncount", "versions",
+        "apipluginbroker", "baseobject", "byid", "bypath", "cachekey", "cachetag", "cachetags", "childamount",
+        "childpermissions", "children", "childrensortby", "childrensortorder", "childs", "class", "classid",
+        "classname", "classtitle", "closestparentofclass", "creationdate", "currentfullpath", "dao", "data",
+        "definition", "dependencies", "dirtyfields", "dirtylanguages", "dodelete", "fieldname", "fullpath",
+        "getinheritedvalues", "haschildren", "hassiblings", "hideunpublished", "id", "idpath", "index", "key",
+        "language", "latestversion", "lazyloadedfieldnames", "list", "listingcachekey", "localizedfields", "locked",
+        "modelfactory", "modificationdate", "nextparentforinheritance", "object", "objectvar", "objectvars",
+        "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions", "permissionsforuser",
+        "properties", "property", "published", "realfullpath", "realpath", "relationdata", "resource",
+        "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner", "userpermissions",
+        "validtablecolumns", "value", "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -24,11 +24,11 @@ pimcore.object.classes.data.data = Class.create({
         "closestparentofclass", "creationdate", "currentfullpath", "dao", "data", "definition", "dependencies",
         "dirtyfields", "dirtylanguages", "fieldname", "fullpath", "getinheritedvalues", "haschildren", "hassiblings",
         "hideunpublished", "id", "idpath", "index", "key", "language", "latestversion", "lazyloadedfieldnames", "list",
-        "listingcachekey", "localizedfields", "locked", "modificationdate", "nextparentforinheritance", "object",
-        "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions", "permissionsforuser",
-        "properties", "property", "published", "realfullpath", "realpath", "relationdata", "resource",
-        "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner", "userpermissions", "value",
-        "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
+        "listingcachekey", "localizedfields", "locked", "modelfactory", "modificationdate", "nextparentforinheritance",
+        "object", "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions",
+        "permissionsforuser", "properties", "property", "published", "realfullpath", "realpath", "relationdata",
+        "resource", "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner", "userpermissions",
+        "value", "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -19,16 +19,16 @@ pimcore.object.classes.data.data = Class.create({
 
     invalidFieldNames: false,
     forbiddenNames: [
-        "apipluginbroker", "byid", "bypath", "cachetag", "cachetags", "childamount", "childpermissions", "children",
-        "childrensortby", "childrensortorder", "childs", "class", "classid", "classname", "classtitle",
+        "apipluginbroker", "byid", "bypath", "cachekey", "cachetag", "cachetags", "childamount", "childpermissions",
+        "children", "childrensortby", "childrensortorder", "childs", "class", "classid", "classname", "classtitle",
         "closestparentofclass", "creationdate", "currentfullpath", "dao", "data", "definition", "dependencies",
         "dirtyfields", "dirtylanguages", "fieldname", "fullpath", "getinheritedvalues", "haschildren", "hassiblings",
         "hideunpublished", "id", "idpath", "index", "key", "language", "latestversion", "lazyloadedfieldnames", "list",
-        "localizedfields", "locked", "modificationdate", "nextparentforinheritance", "object", "omitmandatorycheck",
-        "parent", "parentclass", "parentid", "path", "permissions", "permissionsforuser", "properties", "property",
-        "published", "realfullpath", "realpath", "relationdata", "resource", "scheduledtasks", "siblings", "type",
-        "types", "usermodification", "userowner", "userpermissions", "value", "valueforfieldname", "valuefromparent",
-        "values", "versioncount", "versions",
+        "listingcachekey", "localizedfields", "locked", "modificationdate", "nextparentforinheritance", "object",
+        "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions", "permissionsforuser",
+        "properties", "property", "published", "realfullpath", "realpath", "relationdata", "resource",
+        "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner", "userpermissions", "value",
+        "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -25,10 +25,10 @@ pimcore.object.classes.data.data = Class.create({
         "dirtyfields", "dirtylanguages", "fieldname", "fullpath", "getinheritedvalues", "haschildren", "hassiblings",
         "hideunpublished", "id", "idpath", "index", "key", "language", "latestversion", "lazyloadedfieldnames", "list",
         "listingcachekey", "localizedfields", "locked", "modelfactory", "modificationdate", "nextparentforinheritance",
-        "object", "omitmandatorycheck", "parent", "parentclass", "parentid", "path", "permissions",
-        "permissionsforuser", "properties", "property", "published", "realfullpath", "realpath", "relationdata",
-        "resource", "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner", "userpermissions",
-        "value", "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
+        "object", "objectvar", "objectvars", "omitmandatorycheck", "parent", "parentclass", "parentid", "path",
+        "permissions", "permissionsforuser", "properties", "property", "published", "realfullpath", "realpath",
+        "relationdata", "resource", "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner",
+        "userpermissions", "value", "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/classes/data/data.js
+++ b/public/js/pimcore/object/classes/data/data.js
@@ -28,7 +28,8 @@ pimcore.object.classes.data.data = Class.create({
         "object", "objectvar", "objectvars", "omitmandatorycheck", "parent", "parentclass", "parentid", "path",
         "permissions", "permissionsforuser", "properties", "property", "published", "realfullpath", "realpath",
         "relationdata", "resource", "scheduledtasks", "siblings", "type", "types", "usermodification", "userowner",
-        "userpermissions", "value", "valueforfieldname", "valuefromparent", "values", "versioncount", "versions",
+        "userpermissions", "validtablecolumns", "value", "valueforfieldname", "valuefromparent", "values",
+        "versioncount", "versions",
     ],
 
     /**

--- a/public/js/pimcore/object/fieldcollection.js
+++ b/public/js/pimcore/object/fieldcollection.js
@@ -214,8 +214,12 @@ pimcore.object.fieldcollection = Class.create({
                     this.tree.getStore().load();
 
                     var data = Ext.decode(response.responseText);
-                    if(data && data.success) {
+                    if (data && data.success) {
                         this.openFieldcollection(data.id);
+                    } else if (data && data.message) {
+                        Ext.Msg.alert(t('error'), data.message);
+                    } else {
+                        Ext.Msg.alert(t('error'), t('failed_to_create_new_item'));
                     }
                 }.bind(this)
             });
@@ -224,7 +228,7 @@ pimcore.object.fieldcollection = Class.create({
             return;
         }
         else {
-            Ext.Msg.alert(' ', t('failed_to_create_new_item'));
+            Ext.Msg.alert(t('error'), t('failed_to_create_new_item'));
         }
     },
 

--- a/public/js/pimcore/object/objectbrick.js
+++ b/public/js/pimcore/object/objectbrick.js
@@ -186,8 +186,12 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
                     this.tree.getStore().load();
 
                     var data = Ext.decode(response.responseText);
-                    if(data && data.success) {
+                    if (data && data.success) {
                         this.openBrick(data.id);
+                    } else if (data && data.message) {
+                        Ext.Msg.alert(t('error'), data.message);
+                    } else {
+                        Ext.Msg.alert(t('error'), t('failed_to_create_new_item'));
                     }
                 }.bind(this)
             });
@@ -196,7 +200,7 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
             return;
         }
         else {
-            Ext.Msg.alert(' ', t('failed_to_create_new_item'));
+            Ext.Msg.alert(t('error'), t('failed_to_create_new_item'));
         }
     },
 


### PR DESCRIPTION
`Fatal error: Declaration of Pimcore\Model\DataObject\Test::setClassId(?string $classId) must be compatible with Pimcore\Model\DataObject\Concrete::setClassId($o_classId) in /var/www/html/var/classes/DataObject/Test.php on line 188`

See also https://github.com/pimcore/pimcore/pull/17109