### PR TITLE
Many-to-many object relation / multiselect in tag mode: support drag & drop to change order of assigned items

### DIFF
--- a/public/js/lib/ext-plugins/DragDropTag.js
+++ b/public/js/lib/ext-plugins/DragDropTag.js
@@ -1,0 +1,118 @@
+/**
+ * @author Adam Borowski
+ * @see https://fiddle.sencha.com/#fiddle/i65
+ */
+Ext.define('cas.helper.plugin.DragDropTag', {
+    extend: 'Ext.plugin.Abstract',
+    alias: 'plugin.dragdroptag',
+    requires: [],
+    statics: {},
+    init: function (cmp) {
+        cmp.on('render', this.afterRender, this, { single: true });
+    },
+    afterRender: function () {
+        var me = this.getCmp();
+        me.boundList = me.getPicker();
+        me.dragGroup = me.dropGroup = 'MultiselectDD-' + Ext.id();
+        me.dragZone = Ext.create('Ext.dd.DragZone', me.itemList, {
+            ddGroup: me.dragGroup,
+            dragText: me.dragText,
+            getDragData: function (e) {
+
+                var sourceEl = e.getTarget(me.tagItemSelector, 10);
+                //todo sprawdzić czy w tagfield-item-selected jest ten który jest w source el bo jeśli tak, to przenioś całą zgraję
+                if (sourceEl) {
+                    var d = sourceEl.cloneNode(true);
+                    d.id = Ext.id();
+                    return {
+                        ddel: d,
+                        sourceEl: sourceEl,
+                        repairXY: Ext.fly(sourceEl).getXY(),
+                        sourceStore: me.store,
+                        draggedRecord: me.getRecordByListItemNode(sourceEl)
+                    }
+                }
+            },
+            getRepairXY: function () {
+                return this.dragData.repairXY;
+            }
+        });
+        me.dropZone = Ext.create('Ext.dd.DropZone', me.itemList, {
+            ddGroup: me.dropGroup,
+            getTargetFromEvent: function (e) {
+                var allItems = me.itemList.query(me.tagItemSelector, false);
+                var mouseY = e.getY();
+                var mouseX = e.getX();
+                var itemsOnLine = [];
+                var bestDistance = Infinity, bestIsAfter, bestItem;
+                for (var i = 0; i < allItems.length; i++) {
+                    var item = allItems[i];
+                    var t = item.getY(), l = item.getX();
+                    var b = item.getBottom(), r = item.getRight();
+                    var middle = (l + r) / 2;
+                    if (mouseY > t && mouseY < b) {
+                        //ten element jest na lini kursora
+                        var distance;
+                        if (mouseX <= middle) {
+                            //kursor jest z lewej strony elementu
+                            distance = l - mouseX;
+                            if (distance < bestDistance) {
+                                bestDistance = distance;
+                                bestIsAfter = false;
+                                bestItem = item;
+                            }
+                        } else {
+                            //kursor jest z prawej strony elementu
+                            distance = mouseX - r;
+                            if (distance < bestDistance) {
+                                bestDistance = distance;
+                                bestIsAfter = true;
+                                bestItem = item;
+                                //break;//następne już tylko będą dalej w tej linii
+                            }
+                        }
+                    }
+                }
+                if (bestItem)
+                    return { element: bestItem, after: bestIsAfter };
+            },
+            onNodeEnter: function (target, dd, e, data) {
+                Ext.fly(target.element).addCls('a-tagfield-highlight ' + (target.after ? 'after' : 'before'));
+            },
+            onNodeOut: function (target, dd, e, data) {
+                Ext.fly(target.element).removeCls('a-tagfield-highlight after before');
+            },
+            onNodeOver: function (target, dd, e, data) {
+                return Ext.dd.DropZone.prototype.dropAllowed;
+            },
+            onNodeDrop: function (target, dd, e, data) {
+                //console.info(target.element.dom, target.after ? 'after' : 'before');
+                var sourceIndex = Ext.fly(data.sourceEl).getAttribute('data-selectionindex');
+                var targetIndex = parseInt(target.element.getAttribute('data-selectionindex'));
+                var value = Ext.Array.clone(me.getValue());
+                cas.helper.Array.moveItem(value, sourceIndex, targetIndex, target.after);
+                me.setValue(null);
+                me.setValue(value);
+                return true;
+            }
+        });
+    }
+});
+Ext.define('cas.helper.Array', {
+    singleton: true,
+    /**
+     *
+     * @param array
+     * @param from index
+     * @param to index
+     * @param [after]
+     */
+    moveItem: function (array, from, to, after) {
+        if (after === true) {
+            if (from > to) to++;
+        } else if (after === false) {
+            if (from < to) to--;
+        }
+        array.splice(to, 0, array.splice(from, 1)[0]);
+    }
+});

--- a/public/js/lib/ext-plugins/DragDropTag.js
+++ b/public/js/lib/ext-plugins/DragDropTag.js
@@ -11,7 +11,7 @@ Ext.define('cas.helper.plugin.DragDropTag', {
         cmp.on('render', this.afterRender, this, { single: true });
     },
     afterRender: function () {
-        var me = this.getCmp();
+        let me = this.getCmp();
         me.boundList = me.getPicker();
         me.dragGroup = me.dropGroup = 'MultiselectDD-' + Ext.id();
         me.dragZone = Ext.create('Ext.dd.DragZone', me.itemList, {
@@ -19,10 +19,10 @@ Ext.define('cas.helper.plugin.DragDropTag', {
             dragText: me.dragText,
             getDragData: function (e) {
 
-                var sourceEl = e.getTarget(me.tagItemSelector, 10);
+                let sourceEl = e.getTarget(me.tagItemSelector, 10);
                 //todo sprawdzić czy w tagfield-item-selected jest ten który jest w source el bo jeśli tak, to przenioś całą zgraję
                 if (sourceEl) {
-                    var d = sourceEl.cloneNode(true);
+                    let d = sourceEl.cloneNode(true);
                     d.id = Ext.id();
                     return {
                         ddel: d,
@@ -40,19 +40,19 @@ Ext.define('cas.helper.plugin.DragDropTag', {
         me.dropZone = Ext.create('Ext.dd.DropZone', me.itemList, {
             ddGroup: me.dropGroup,
             getTargetFromEvent: function (e) {
-                var allItems = me.itemList.query(me.tagItemSelector, false);
-                var mouseY = e.getY();
-                var mouseX = e.getX();
-                var itemsOnLine = [];
-                var bestDistance = Infinity, bestIsAfter, bestItem;
-                for (var i = 0; i < allItems.length; i++) {
-                    var item = allItems[i];
-                    var t = item.getY(), l = item.getX();
-                    var b = item.getBottom(), r = item.getRight();
-                    var middle = (l + r) / 2;
+                let allItems = me.itemList.query(me.tagItemSelector, false);
+                let mouseY = e.getY();
+                let mouseX = e.getX();
+                let itemsOnLine = [];
+                let bestDistance = Infinity, bestIsAfter, bestItem;
+                for (let i = 0; i < allItems.length; i++) {
+                    let item = allItems[i];
+                    let t = item.getY(), l = item.getX();
+                    let b = item.getBottom(), r = item.getRight();
+                    let middle = (l + r) / 2;
                     if (mouseY > t && mouseY < b) {
                         //ten element jest na lini kursora
-                        var distance;
+                        let distance;
                         if (mouseX <= middle) {
                             //kursor jest z lewej strony elementu
                             distance = l - mouseX;
@@ -87,9 +87,9 @@ Ext.define('cas.helper.plugin.DragDropTag', {
             },
             onNodeDrop: function (target, dd, e, data) {
                 //console.info(target.element.dom, target.after ? 'after' : 'before');
-                var sourceIndex = Ext.fly(data.sourceEl).getAttribute('data-selectionindex');
-                var targetIndex = parseInt(target.element.getAttribute('data-selectionindex'));
-                var value = Ext.Array.clone(me.getValue());
+                let sourceIndex = Ext.fly(data.sourceEl).getAttribute('data-selectionindex');
+                let targetIndex = parseInt(target.element.getAttribute('data-selectionindex'));
+                let value = Ext.Array.clone(me.getValue());
                 cas.helper.Array.moveItem(value, sourceIndex, targetIndex, target.after);
                 me.setValue(null);
                 me.setValue(value);

--- a/public/js/lib/ext-plugins/DragDropTag.js
+++ b/public/js/lib/ext-plugins/DragDropTag.js
@@ -20,7 +20,7 @@ Ext.define('cas.helper.plugin.DragDropTag', {
             getDragData: function (e) {
 
                 let sourceEl = e.getTarget(me.tagItemSelector, 10);
-                //todo sprawdzić czy w tagfield-item-selected jest ten który jest w source el bo jeśli tak, to przenioś całą zgraję
+
                 if (sourceEl) {
                     let d = sourceEl.cloneNode(true);
                     d.id = Ext.id();
@@ -51,10 +51,10 @@ Ext.define('cas.helper.plugin.DragDropTag', {
                     let b = item.getBottom(), r = item.getRight();
                     let middle = (l + r) / 2;
                     if (mouseY > t && mouseY < b) {
-                        //ten element jest na lini kursora
+                        // cursor currently is at this item
                         let distance;
                         if (mouseX <= middle) {
-                            //kursor jest z lewej strony elementu
+                            // cursor is left of the element
                             distance = l - mouseX;
                             if (distance < bestDistance) {
                                 bestDistance = distance;
@@ -62,13 +62,12 @@ Ext.define('cas.helper.plugin.DragDropTag', {
                                 bestItem = item;
                             }
                         } else {
-                            //kursor jest z prawej strony elementu
+                            // cursor is right of the element
                             distance = mouseX - r;
                             if (distance < bestDistance) {
                                 bestDistance = distance;
                                 bestIsAfter = true;
                                 bestItem = item;
-                                //break;//następne już tylko będą dalej w tej linii
                             }
                         }
                     }
@@ -86,7 +85,6 @@ Ext.define('cas.helper.plugin.DragDropTag', {
                 return Ext.dd.DropZone.prototype.dropAllowed;
             },
             onNodeDrop: function (target, dd, e, data) {
-                //console.info(target.element.dom, target.after ? 'after' : 'before');
                 let sourceIndex = Ext.fly(data.sourceEl).getAttribute('data-selectionindex');
                 let targetIndex = parseInt(target.element.getAttribute('data-selectionindex'));
                 let value = Ext.Array.clone(me.getValue());

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -429,7 +429,8 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                     focus: function() {
                         this.store.getProxy().setExtraParam('data', '');
                     }.bind(this)
-                }
+                },
+                plugins: 'dragdroptag'
             });
         } else {
             let columns = this.getVisibleColumns();

--- a/public/js/pimcore/object/tags/multiselect.js
+++ b/public/js/pimcore/object/tags/multiselect.js
@@ -244,6 +244,7 @@ pimcore.object.tags.multiselect = Class.create(pimcore.object.tags.abstract, {
             if(hasHTMLContent) {
                 options.labelTpl = '{[Ext.util.Format.stripTags(values.text)]}';
             }
+            options.plugins = 'dragdroptag';
             this.component = Ext.create('Ext.form.field.Tag', options);
         } else {
             this.component = Ext.create('Ext.ux.form.MultiSelect', options);

--- a/templates/admin/index/index.html.twig
+++ b/templates/admin/index/index.html.twig
@@ -200,7 +200,7 @@
     "lib/ext-plugins/portlet/PortalPanel.js",
     "lib/ext-plugins/DragDropTag.js",
     "../build/admin/ace-builds/src-min-noconflict/ace.js",
-    "../build/admin/ace-builds/src-min-noconflict/ext-modelist.js",
+    "../build/admin/ace-builds/src-min-noconflict/ext-modelist.js"
 ] %}
 {% if pimcore_file_exists(constant('PIMCORE_WEB_ROOT') ~ '/bundles/pimcoreadmin/js/lib/ext-locale/locale-' ~ language ~ '.js') %}
     {% set scriptLibs = scriptLibs|merge(['lib/ext-locale/locale-' ~ language ~ '.js']) %}

--- a/templates/admin/index/index.html.twig
+++ b/templates/admin/index/index.html.twig
@@ -198,8 +198,9 @@
     "lib/ext-plugins/portlet/Portlet.js",
     "lib/ext-plugins/portlet/PortalColumn.js",
     "lib/ext-plugins/portlet/PortalPanel.js",
+    "lib/ext-plugins/DragDropTag.js",
     "../build/admin/ace-builds/src-min-noconflict/ace.js",
-    "../build/admin/ace-builds/src-min-noconflict/ext-modelist.js"
+    "../build/admin/ace-builds/src-min-noconflict/ext-modelist.js",
 ] %}
 {% if pimcore_file_exists(constant('PIMCORE_WEB_ROOT') ~ '/bundles/pimcoreadmin/js/lib/ext-locale/locale-' ~ language ~ '.js') %}
     {% set scriptLibs = scriptLibs|merge(['lib/ext-locale/locale-' ~ language ~ '.js']) %}


### PR DESCRIPTION
Assume we have a many-to-many object relation in display mode = tag field.

When assigning new objects, everything works great but sometimes the order of the assigned items matters and you want to insert an item in between or change the order of already assigned items.
So if you have assigned objects `/one` and `/three` and now want to insert `/two` in between, then you have to currently
1. delete assignment for`/three` 
2. assign `/two`
3. assign `/three`

This is quite complicated. And depending on number of assigned elements, this is can be even more work.

This PR adds drag & drop support for the assigned items. It works like in https://fiddle.sencha.com/fiddle/i65/preview
With this you can change the order of assigned objects afterwards.

The same functionality has also been applied to multiselect fields in tag mode.