### PR TITLE
Improve logic for classification store in diff_versions in data objects

### DIFF
--- a/templates/admin/data_object/data_object/diff_versions.html.twig
+++ b/templates/admin/data_object/data_object/diff_versions.html.twig
@@ -125,7 +125,7 @@
                 {% endif %}
 
                 {% for activeGroupId, enabled in existingGroups %}
-                    {% if activeGroups1[activeGroupId] is defined and activeGroups2[activeGroupId] is defined %}
+                    {% if activeGroups1[activeGroupId] is defined or activeGroups2[activeGroupId] is defined %}
                         {% set groupDefinition = pimcore_object_classificationstore_group(activeGroupId) %}
                         {% if groupDefinition is not empty %}
                             {% set keyGroupRelations = groupDefinition.getRelations() %}
@@ -146,7 +146,8 @@
                                             {% if isImportPreview is not defined or isNew is not defined %}
                                                 <td>{{ preview1 | raw }}</td>
                                             {% endif %}
-                                            {% set fieldIsEqual = keyDef is instanceof('\\Pimcore\\Model\\DataObject\\ClassDefinition\\Data\\EqualComparisonInterface') and not keyDef.isEqual(keyData1, keyData2) ? 'modified' : '' %}
+                                            {% set isActiveInOneVersionOnly = activeGroups1[activeGroupId] is not defined or activeGroups2[activeGroupId] is not defined %}
+                                            {% set fieldIsEqual = keyDef is instanceof('\\Pimcore\\Model\\DataObject\\ClassDefinition\\Data\\EqualComparisonInterface') and not keyDef.isEqual(keyData1, keyData2) or isActiveInOneVersionOnly ? 'modified' : '' %}
                                             <td class="{{ fieldIsEqual }}">{{ preview2 }}</td>
                                         </tr>
                                     {% endfor %}


### PR DESCRIPTION
### Changes in this pull request
Improve logic for classification store in diff_versions. Changes logic from "and" to "or", and check if the group is only active in one version.
It should be possible to get a difference between two versions, even if a classification store group was added / removed in one version and is not present in den previous version.
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/23357021/cefab356-cac5-4e03-a81a-f210899f03cd)


### How to reproduce
1. Create Class with Classification Store
2. create object and save
3. Add classfication store group to object, add content to some fields and save
4. select the two versions for comparison
5. the new added classification store group is now visible as change (before nothing was shown)