### PR TITLE
Replace Flysystem for grid-export with native filesystem operations to reduce IOPS

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1283,6 +1283,7 @@ class DataObjectHelperController extends AdminAbstractController
 
         // We don't use flysystem here because we need to append to the file
         $stream = null;
+
         try {
             $newData = [];
             $csvFile = $this->getCsvFile($fileHandle);


### PR DESCRIPTION
## Summary
This merge request replaces Flysystem with native filesystem operations to address the issue of excessively high IOPS during export processes, especially when exporting big datasets. 

## Background
During routine monitoring, we identified that the CSV export functionality was generating an unexpectedly high IOPS, approximately 4.5 TB, for a relatively modest file size of 255 MB. This level of IOPS was significantly impacting system performance and increasing operational costs (~200$ on AWS EFS).

## Investigation
Detailed analysis revealed that the use of Flysystem for handling file operations in the export process was contributing to the high IOPS. Flysystem, while providing a convenient abstraction for file handling across different storage systems, was not efficient for our use case involving large data manipulations and frequent file writes, as for appending new data, the whole file was first read, extended and then fully written back.

## Changes Made
- **Direct File Operations**: We have switched to using PHP's native file handling functions (`fopen`, `fwrite`, `fclose`) to be able to use the possibility of appending data to the temporary export file instead of overwriting it over and over again.
