### PR TITLE
Fix date filters and storage when client timezone differs from server timezone

### DIFF
--- a/public/js/pimcore/asset/metadata/tags/date.js
+++ b/public/js/pimcore/asset/metadata/tags/date.js
@@ -53,7 +53,7 @@ pimcore.asset.metadata.tags.date = Class.create(pimcore.asset.metadata.tags.abst
     },
 
     getGridColumnFilter:function (field) {
-        return {type:'date', dataIndex:field.key, dateFormat: 'm/d/Y'};
+        return {type:'date', dataIndex:field.key, dateFormat: 'c'};
     },
 
     getLayoutEdit:function () {

--- a/public/js/pimcore/object/tags/date.js
+++ b/public/js/pimcore/object/tags/date.js
@@ -60,7 +60,7 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnFilter:function (field) {
-        return {type:'date', dataIndex:field.key, dateFormat: 'm/d/Y'};
+        return {type:'date', dataIndex:field.key, dateFormat: field.layout.columnType === "date" ? 'm/d/Y' : "c"};
     },
 
     getLayoutEdit:function () {
@@ -105,6 +105,9 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
     getValue:function () {
         if (this.component.getValue()) {
             let value = this.component.getValue();
+            if(value && this.fieldConfig.columnType === "date") {
+                return Ext.Date.format(value, "Y-m-d");
+            }
             if (value && typeof value.getTime == "function") {
                 return value.getTime();
             } else {

--- a/public/js/pimcore/object/tags/datetime.js
+++ b/public/js/pimcore/object/tags/datetime.js
@@ -60,7 +60,7 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
     },
 
     getGridColumnFilter:function (field) {
-        return {type:'date', dataIndex:field.key, dateFormat: 'm/d/Y'};
+        return {type:'date', dataIndex:field.key, dateFormat: 'c'};
     },
 
     getLayoutEdit:function () {


### PR DESCRIPTION
When the user's timezone differs from the server timezone we have 2 bugs regarding date attributes:

1. Filtering does not work correctly
2. Data object date attributes with column type "Date" are not saved corretly. For the "Date" column type it's not possible to respect the user's timezone, therefore the date is now transfered to the server as string instead of timestamp (int). In the case of the "bigint" column type it stays like before with respected user timezone, but now the date format for the filter respects the timezone and therefore the filter works correctly.

Depends on https://github.com/pimcore/pimcore/pull/17135.

(Part of https://github.com/pimcore/pimcore/issues/16184)