### PR TITLE
Fix issue with "Undefined array key 0" when bulk importing custom layouts

### DIFF
--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1546,7 +1546,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
 
                     $layoutDefinition = null;
                     if ($layoutList) {
-                        $layoutDefinition = $layoutList[0];
+                        $layoutDefinition = array_values($layoutList)[0];
                     }
 
                     if (!$layoutDefinition) {


### PR DESCRIPTION
Issue: When bulk importing Custom Layouts, there is an error thrown due to an undefined array key "0".
How to replicate: 

1. Go to Settings > DataObjects >Bulk Import
2. Try to import one or more custom layout from a bulk export json file
3. Get the below error:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/169244938/692e7c3f-6e46-449b-aca1-e542184a7d87)

This is because on line 1549 of the ClassController.php, we assume the first element of the array will always have the index of 0:

ClassController.php (lines 1547 to 1550)
`
$layoutDefinition = null;
if ($layoutList) {
   $layoutDefinition = $layoutList[0];
}
`



However this isn't always the case, as you can see from the example below, there only 1 item in the array, but the index is not 0:
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/169244938/318f261f-021e-45be-8bab-88cdb26dbd33)

Solution: Since we only want to get the values of the first element of the array, the index/key should not matter, and therefore we should instead do an array_values and then get the element in the 0 position:
