### PR TITLE
Field type "Table": add button to clone row

### DIFF
--- a/public/css/icons.css
+++ b/public/css/icons.css
@@ -126,6 +126,16 @@
     background: url(/bundles/pimcoreadmin/img/flat-color-icons/overlay-google.svg) center center no-repeat !important;
 }
 
+.pimcore_icon_overlay_clone:before {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    bottom: 0px;
+    right: 0px;
+    content: "";
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/copy.svg) center center no-repeat !important;
+}
+
 .pimcore_main_nav_icon_file {
     background: url(/bundles/pimcoreadmin/img/material-icons/outline-file-24px.svg) center center no-repeat !important;
 }

--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -183,13 +183,18 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
             if (!this.fieldConfig.rowsFixed || data.length != this.fieldConfig.rows) {
                 tbar.push({
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
+                    handler: this.addRow.bind(this)
+                });
+
+                tbar.push({
                     iconCls: "pimcore_icon_table_row pimcore_icon_overlay_delete",
                     handler: this.deleteRow.bind(this)
                 });
 
                 tbar.push({
-                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_add",
-                    handler: this.addRow.bind(this)
+                    iconCls: "pimcore_icon_table_row pimcore_icon_overlay_clone",
+                    handler: this.cloneSelectedRow.bind(this)
                 });
             }
 
@@ -202,7 +207,6 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
                 iconCls: "pimcore_icon_paste",
                 handler: this.pasteFromClipboard.bind(this)
             });
-
 
             tbar.push({
                 iconCls: "pimcore_icon_empty",
@@ -282,6 +286,26 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
 
         this.store.add(initData);
         this.dirty = true;
+    },
+
+    cloneSelectedRow: function () {
+        var selected = this.grid.getSelectionModel();
+        if (selected.selection) {
+            var selectedIndex = selected.selection.rowIdx;
+            var selectedRecord = this.store.getAt(selectedIndex);
+
+            var initData = {};
+            var columnnManager = this.grid.getColumnManager();
+            var columns = columnnManager.getColumns();
+
+            for (var o = 0; o < columns.length; o++) {
+                initData[columns[o].dataIndex] = selectedRecord.get(columns[o].dataIndex);
+            }
+
+            this.store.insert(selectedIndex + 1, initData);
+            this.dirty = true;
+
+        }
     },
 
     deleteRow: function () {


### PR DESCRIPTION
The field type `Table` has 2 buttons to "copy" and paste but this cannot be used to copy/clone a row. You can copy the table data but in the paste dialog, the dialog window immediately closes after pasting, so you cannot duplicate a row (only if you copy table content, paste it in an external editor, duplicae the desired row and then use paste button - usability nightmare ;-) ).

This PR adds a button to clone the selected row.

Alternatively / additionally we could change current behaviour of immediately closing the paste dialog box after pasting. But still cloning a row with one button click would be a better UX.

And this PR cleans up the add / delete buttons to be in the same order for columns and rows - before it was 
| Add column | Delete column | Delete row | Add row |
|---|---|---|---|

Now it is
| Add column | Delete column | Add row | Delete row |
|---|---|---|---|