### PR TITLE
Add options to enable or disable timezone support for date attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 #### v1.5.0
 - [Assets] Metadata can be now displayed as a read-only tab when the user is granted `view` permissions to the asset.
 - [Composer] Added `phpoffice/phpspreadsheet` requirement (which got moved out from `pimcore/pimcore`) and extended support to `v2`.
-- [Date & date/time fields] Date & ate/time fields are now configured with `date` and `datetime` column type by default.
+- [Date & date/time fields] Date & date/time fields are now configured with `date` and `datetime` column type by default.
 - [Date/time fields] Date/time fields now support the usage without timezone support.
   
 #### v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 #### v1.5.0
 - [Assets] Metadata can be now displayed as a read-only tab when the user is granted `view` permissions to the asset.
 - [Composer] Added `phpoffice/phpspreadsheet` requirement (which got moved out from `pimcore/pimcore`) and extended support to `v2`.
+- [Date & date/time fields] Date & ate/time fields are now configured with `date` and `datetime` column type by default.
+- [Date/time fields] Date/time fields now support the usage without timezone support.
   
 #### v1.4.0
 - [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore:^12`.

--- a/public/js/pimcore/functions.js
+++ b/public/js/pimcore/functions.js
@@ -1793,3 +1793,15 @@ function htmlspecialchars (string, quoteStyle, charset, doubleEncode) {
 
     return string
 }
+
+function dateToUTC(date) {
+
+    let utcDate = new Date(date.toLocaleString('en-US', {
+        timeZone: 'UTC'
+    }));
+
+    let diff = date.getTime() - utcDate.getTime();
+
+    return new Date(date.getTime() - diff);
+
+}

--- a/public/js/pimcore/object/classes/data/date.js
+++ b/public/js/pimcore/object/classes/data/date.js
@@ -124,7 +124,7 @@ pimcore.object.classes.data.date = Class.create(pimcore.object.classes.data.data
 
         if (!inEncryptedField) {
 
-            var columnTypeData = [["bigint(20)", "BIGINT"], ["date", "DATE"]];
+            var columnTypeData = [["date", "DATE"],["bigint(20)", "BIGINT"]];
 
             var columnTypeField = new Ext.form.ComboBox({
                 name: "columnType",
@@ -133,7 +133,7 @@ pimcore.object.classes.data.date = Class.create(pimcore.object.classes.data.data
                 forceSelection: true,
                 editable: false,
                 fieldLabel: t("column_type"),
-                value: datax.columnType != "bigint(20)" && datax.columnType != "date" ? 'bigint(20)' : datax.columnType,
+                value: datax.columnType != "bigint(20)" && datax.columnType != "date" ? 'date' : datax.columnType,
                 store: new Ext.data.ArrayStore({
                     fields: [
                         'id',

--- a/public/js/pimcore/object/classes/data/datetime.js
+++ b/public/js/pimcore/object/classes/data/datetime.js
@@ -121,7 +121,10 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
             cls:"object_field"
         });
 
-        var columnTypeData = [["bigint(20)", "BIGINT"], ["datetime", "DATETIME"]];
+        var columnTypeData = [["datetime", "DATETIME"],["bigint(20)", "BIGINT"]];
+
+        // do not check for newly created fields but for existing ones without a respectTimezone value
+        let isRespectTimezone = (datax.respectTimezone !== false && Boolean(datax.name)) || datax.columnType === "bigint(20)";
 
         var columnTypeField = new Ext.form.ComboBox({
             name: "columnType",
@@ -130,7 +133,8 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
             forceSelection: true,
             editable: false,
             fieldLabel: t("column_type"),
-            value: datax.columnType != "bigint(20)" && datax.columnType != "datetime" ? 'bigint(20)' : datax.columnType ,
+            value: datax.columnType != "bigint(20)" && datax.columnType != "datetime" ? 'datetime' : datax.columnType ,
+            readOnly: !isRespectTimezone,
             store: new Ext.data.ArrayStore({
                 fields: [
                     'id',
@@ -143,7 +147,7 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
             displayField: 'label'
         });
 
-
+console.log({isRespectTimezone: isRespectTimezone, datax: datax});
         specificItems = specificItems.concat(
             [
                 defaultComponent,
@@ -164,6 +168,16 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
                     disabled: this.isInCustomLayoutEditor(),
                     listeners:{
                         change:this.toggleDefaultDate.bind(this, defaultValue, datefield, timefield)
+                    }
+                },
+                {
+                    xtype:"checkbox",
+                    fieldLabel:t("respect_timezone"),
+                    name:"respectTimezone",
+                    checked:isRespectTimezone,
+                    disabled: this.isInCustomLayoutEditor(),
+                    listeners:{
+                        change:this.toggleColumnType.bind(this, columnTypeField)
                     }
                 }, {
                 xtype: "displayfield",
@@ -211,6 +225,14 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
 
     },
 
+    toggleColumnType: function (columnTypeField, checkbox, checked) {
+        if (!checked) {
+            columnTypeField.setValue("datetime");
+        }
+
+        columnTypeField.setReadOnly(!checked);
+    },
+
     applyData: function ($super) {
         $super();
         this.datax.queryColumnType = this.datax.columnType;
@@ -225,6 +247,7 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
                 {
                     defaultValue: source.datax.defaultValue,
                     useCurrentDate: source.datax.useCurrentDate,
+                    respectTimezone: source.datax.respectTimezone,
                     defaultValueGenerator: source.datax.defaultValueGenerator,
                     columnType: source.datax.columnType
                 });

--- a/public/js/pimcore/object/classes/data/datetime.js
+++ b/public/js/pimcore/object/classes/data/datetime.js
@@ -147,7 +147,7 @@ pimcore.object.classes.data.datetime = Class.create(pimcore.object.classes.data.
             displayField: 'label'
         });
 
-console.log({isRespectTimezone: isRespectTimezone, datax: datax});
+
         specificItems = specificItems.concat(
             [
                 defaultComponent,

--- a/public/js/pimcore/object/tags/date.js
+++ b/public/js/pimcore/object/tags/date.js
@@ -50,8 +50,13 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
                 }
 
                 if (value) {
-                    var timestamp = intval(value) * 1000;
-                    var date = new Date(timestamp);
+                    let date;
+                    if (typeof value === "string" && value.match(/-/)) {
+                        date = new Date(value);
+                    } else {
+                        let timestamp = intval(value) * 1000;
+                        date = new Date(timestamp);
+                    }
 
                     return Ext.Date.format(date, "Y-m-d");
                 }
@@ -118,6 +123,9 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
     },
 
     getCellEditValue: function () {
+        if (this.fieldConfig.columnType === "date") {
+            return this.getValue();
+        }
         return this.getValue() / 1000;
     },
 


### PR DESCRIPTION
Dependent on https://github.com/pimcore/pimcore/pull/17151

Part of https://github.com/pimcore/pimcore/issues/16184

Take a look at the edited docs in this PR and in the related pimcore/pimcore PR (https://github.com/pimcore/pimcore/pull/17151) for details. In addition to the timezone support topic the `date` and  `datetime` column types are now the default when adding new date fields.