### PR TITLE
Fix date attributes without timezone support when server timezone is configured

### DIFF
--- a/public/js/pimcore/functions.js
+++ b/public/js/pimcore/functions.js
@@ -1794,10 +1794,10 @@ function htmlspecialchars (string, quoteStyle, charset, doubleEncode) {
     return string
 }
 
-function dateToUTC(date) {
+function dateToServerTimezone(date) {
 
     let utcDate = new Date(date.toLocaleString('en-US', {
-        timeZone: 'UTC'
+        timeZone: pimcore.settings.timezone ?? 'UTC'
     }));
 
     let diff = date.getTime() - utcDate.getTime();

--- a/public/js/pimcore/object/tags/date.js
+++ b/public/js/pimcore/object/tags/date.js
@@ -56,6 +56,10 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
                     } else {
                         let timestamp = intval(value) * 1000;
                         date = new Date(timestamp);
+
+                        if (!this.isRespectTimezone()) {
+                            date = dateToServerTimezone(date);
+                        }
                     }
 
                     return Ext.Date.format(date, "Y-m-d");
@@ -92,6 +96,11 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
 
         if (this.data) {
             var tmpDate = new Date(intval(this.data) * 1000);
+
+            if (!this.isRespectTimezone()) {
+                tmpDate = dateToServerTimezone(tmpDate);
+            }
+
             date.value = tmpDate;
         }
 
@@ -157,6 +166,10 @@ pimcore.object.tags.date = Class.create(pimcore.object.tags.abstract, {
         }
 
         return false;
+    },
+
+    isRespectTimezone: function() {
+        return this.fieldConfig.columnType !== "date";
     }
 
 });

--- a/public/js/pimcore/object/tags/datetime.js
+++ b/public/js/pimcore/object/tags/datetime.js
@@ -59,7 +59,7 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
                                 date = new Date(timestamp);
 
                                 if (!this.isRespectTimezone()) {
-                                    date = dateToUTC(date);
+                                    date = dateToServerTimezone(date);
                                 }
                             }
 
@@ -90,8 +90,7 @@ pimcore.object.tags.datetime = Class.create(pimcore.object.tags.abstract, {
             var tmpDate = new Date(intval(this.data) * 1000);
 
             if (!this.isRespectTimezone()) {
-                debugger;
-                tmpDate = dateToUTC(tmpDate);
+                tmpDate = dateToServerTimezone(tmpDate);
             }
 
             date.value = tmpDate;


### PR DESCRIPTION
Converts timestamps to the server timezone instead of UTC.

Depends on https://github.com/pimcore/pimcore/pull/17166
Part of #16184