### PR TITLE
Field type Table: Support autoSize columns

### DIFF
--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -217,8 +217,6 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
             columnLines: true,
             bodyCls: "pimcore_editable_grid",
             autoHeight: true,
-            width: this.fieldConfig.width,
-            height: this.fieldConfig.height,
             selModel: Ext.create('Ext.selection.CellModel'),
             hideHeaders: !this.fieldConfig.columnConfigActivated,
             plugins: [

--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -217,6 +217,8 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
             columnLines: true,
             bodyCls: "pimcore_editable_grid",
             autoHeight: true,
+            width: this.fieldConfig.width,
+            height: this.fieldConfig.height,
             selModel: Ext.create('Ext.selection.CellModel'),
             hideHeaders: !this.fieldConfig.columnConfigActivated,
             plugins: [
@@ -225,7 +227,16 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
             tbar: tbar,
             viewConfig: {
                 markDirty: false,
-                forceFit: true
+                forceFit: true,
+                listeners: {
+                    refresh: function (dataview) {
+                        Ext.suspendLayouts();
+                        Ext.each(dataview.panel.columns, function (column) {
+                            column.autoSize();
+                        });
+                        Ext.resumeLayouts(true);
+                    }
+                }
             }
         });
         this.component.add(this.grid);


### PR DESCRIPTION
In contrast to "Structured table", the field type table does not support configuring the "label width" (which for structured table gets used for the column widths. As columns do not have any width, they are displayed very small:
<img width="920" alt="Bildschirmfoto 2024-06-13 um 10 03 59" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/8749138/fc40c188-abf5-49ee-95c4-8e0f30d10488">

This PR uses ExtJS's `autoSize` feature for the columns, so that the width gets automatically adjusted to their content (or column headings):
<img width="920" alt="Bildschirmfoto 2024-06-13 um 10 10 29" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/8749138/b0a5a9c7-8322-4b15-896b-55e1303ced1d">
