### PR TITLE
[Improvement] Split icon library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - [Composer] Added `phpoffice/phpspreadsheet` requirement (which got moved out from `pimcore/pimcore`) and extended support to `v2`.
 - [Date & date/time fields] Date & date/time fields are now configured with `date` and `datetime` column type by default.
 - [Date/time fields] Date/time fields now support the usage without timezone support.
-  
+- [Icons] Overhauled Icon library and icon dropdown selector in class definition editor.
+
 #### v1.4.0
 - [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore:^12`.
 

--- a/public/js/pimcore/iconlibrary.js
+++ b/public/js/pimcore/iconlibrary.js
@@ -62,7 +62,7 @@ pimcore.iconlibrary.panel = Class.create({
             });
 
             this.panel = new Ext.Panel({
-                id: "pimcore_icon_library_panel",
+                id: "pimcore_iconlibrary_panel",
                 title: t("icon_library"),
                 iconCls: "pimcore_icon_icons",
                 border: false,

--- a/public/js/pimcore/iconlibrary.js
+++ b/public/js/pimcore/iconlibrary.js
@@ -33,30 +33,25 @@ pimcore.iconlibrary.panel = Class.create({
                 region: 'center',
                 deferredRender: true,
                 id: "pimcore_icon_library_tabs",
-                enableTabScroll: true,
-                hideMode: "offsets",
+                hideMode: "display",
                 cls: "tab_panel",
                 height: "100%",
                 items: [
                     {
                         title: t('color_icons'),
                         html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'color'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                        collapsible: true
                     },
                     {
                         title: t('white_icons'),
                         html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'white'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                        collapsible: true
                     },
                     {
                         title: t('twemoji'),
                         html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'twemoji'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                        collapsible: true
                     },
                     {
                         title: t('flags'),
                         html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'flags'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                        collapsible: true
                     }
                 ]
             });

--- a/public/js/pimcore/iconlibrary.js
+++ b/public/js/pimcore/iconlibrary.js
@@ -23,7 +23,7 @@ pimcore.iconlibrary.panel = Class.create({
     },
 
     activate: function () {
-        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+        const tabPanel = Ext.getCmp("pimcore_panel_tabs");
         tabPanel.setActiveItem("pimcore_iconlibrary_panel");
     },
 
@@ -74,7 +74,7 @@ pimcore.iconlibrary.panel = Class.create({
 
             this.panel.on("destroy", function () {
                 pimcore.globalmanager.remove("iconlibrary");
-            }.bind(this));
+            });
 
             pimcore.layout.refresh();
         }

--- a/public/js/pimcore/iconlibrary.js
+++ b/public/js/pimcore/iconlibrary.js
@@ -1,0 +1,92 @@
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+pimcore.registerNS("pimcore.iconlibrary.panel");
+
+/**
+ * @private
+ */
+pimcore.iconlibrary.panel = Class.create({
+
+    initialize: function () {
+        this.getTabPanel();
+    },
+
+    activate: function () {
+        var tabPanel = Ext.getCmp("pimcore_panel_tabs");
+        tabPanel.setActiveItem("pimcore_iconlibrary_panel");
+    },
+
+    getTabPanel: function () {
+        if (!this.panel) {
+            const iconLibraryTab = Ext.create('Ext.tab.Panel', {
+                region: 'center',
+                deferredRender: true,
+                id: "pimcore_icon_library_tabs",
+                enableTabScroll: true,
+                hideMode: "offsets",
+                cls: "tab_panel",
+                height: "100%",
+                items: [
+                    {
+                        title: t('color_icons'),
+                        html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'color'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                        collapsible: true
+                    },
+                    {
+                        title: t('white_icons'),
+                        html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'white'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                        collapsible: true
+                    },
+                    {
+                        title: t('twemoji'),
+                        html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'twemoji'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                        collapsible: true
+                    },
+                    {
+                        title: t('flags'),
+                        html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'flags'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                        collapsible: true
+                    }
+                ]
+            });
+
+            this.panel = new Ext.Panel({
+                id: "pimcore_icon_library_panel",
+                title: t("icon_library"),
+                iconCls: "pimcore_icon_icons",
+                border: false,
+                layout: 'border',
+                closable: true,
+                items: [
+                    iconLibraryTab
+                ],
+            });
+
+            const tabPanel = Ext.getCmp("pimcore_panel_tabs");
+            tabPanel.add(this.panel);
+
+
+            this.panel.on("destroy", function () {
+                pimcore.globalmanager.remove("iconlibrary");
+            }.bind(this));
+
+            pimcore.layout.refresh();
+        }
+
+        return this.panel;
+    },
+});
+
+
+

--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -812,54 +812,7 @@ pimcore.layout.toolbar = Class.create({
                      iconCls: "pimcore_nav_icon_icons",
                      itemId: 'pimcore_menu_settings_icon_library',
                      text: t('icon_library'),
-                     handler: function() {
-                         const iconLibraryTab = Ext.create('Ext.tab.Panel', {
-                             region: 'center',
-                             deferredRender: true,
-                             id: "pimcore_icon_library_tabs",
-                             enableTabScroll: true,
-                             hideMode: "offsets",
-                             cls: "tab_panel",
-                             height: "100%",
-                             items: [
-                                 {
-                                     title: t('color_icons'),
-                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'color'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                                     collapsible: true
-                                 },
-                                 {
-                                     title: t('white_icons'),
-                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'white'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                                     collapsible: true
-                                 },
-                                 {
-                                     title: t('twemoji'),
-                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'twemoji'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                                     collapsible: true
-                                 },
-                                 {
-                                     title: t('flags'),
-                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'flags'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
-                                     collapsible: true
-                                 }
-                             ]
-                         });
-
-                         this.panel = new Ext.Panel({
-                             id: "pimcore_icon_library_panel",
-                             title: t("icon_library"),
-                             iconCls: "pimcore_icon_icons",
-                             border: false,
-                             layout: 'border',
-                             closable: true,
-                             items: [
-                                 iconLibraryTab
-                             ],
-                         });
-
-                         const tabPanel = Ext.getCmp("pimcore_panel_tabs");
-                         tabPanel.add(this.panel);
-                     }
+                     handler: this.showIconLibrary.bind(this)
                  });
              }
  
@@ -1411,6 +1364,15 @@ pimcore.layout.toolbar = Class.create({
          }
  
          pimcore.globalmanager.add("new_notifications", new pimcore.notification.modal());
-     }
+     },
+
+    showIconLibrary: function () {
+        try {
+            pimcore.globalmanager.get("iconlibrary").activate();
+        }
+        catch (e) {
+            pimcore.globalmanager.add("iconlibrary", new pimcore.iconlibrary.panel());
+        }
+    }
  });
  

--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -1372,6 +1372,7 @@ pimcore.layout.toolbar = Class.create({
         }
         catch (e) {
             pimcore.globalmanager.add("iconlibrary", new pimcore.iconlibrary.panel());
+            pimcore.globalmanager.get("iconlibrary").activate();
         }
     }
  });

--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -813,7 +813,6 @@ pimcore.layout.toolbar = Class.create({
                      itemId: 'pimcore_menu_settings_icon_library',
                      text: t('icon_library'),
                      handler: function() {
-
                          const iconLibraryTab = Ext.create('Ext.tab.Panel', {
                              region: 'center',
                              deferredRender: true,

--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -808,12 +808,59 @@ pimcore.layout.toolbar = Class.create({
              }
  
              if (user.admin) {
+
                  settingsItems.push({
                      iconCls: "pimcore_nav_icon_icons",
                      itemId: 'pimcore_menu_settings_icon_library',
                      text: t('icon_library'),
                      handler: function() {
-                         pimcore.helpers.openGenericIframeWindow("icon-library", Routing.generate('pimcore_admin_misc_iconlist'), "pimcore_icon_icons", t("icon_library"));
+
+                         const iconLibraryTab = Ext.create('Ext.tab.Panel', {
+                             region: 'center',
+                             deferredRender: true,
+                             id: "pimcore_icon_library_tabs",
+                             enableTabScroll: true,
+                             hideMode: "offsets",
+                             cls: "tab_panel",
+                             height: "100%",
+                             items: [
+                                 {
+                                     title: t('color_icons'),
+                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'color'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                                     collapsible: true
+                                 },
+                                 {
+                                     title: t('white_icons'),
+                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'white'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                                     collapsible: true
+                                 },
+                                 {
+                                     title: t('twemoji'),
+                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'twemoji'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                                     collapsible: true
+                                 },
+                                 {
+                                     title: t('flags'),
+                                     html: '<iframe src="' + Routing.generate('pimcore_admin_misc_iconlist', {type: 'flags'}) + '" frameborder="0" style="width:100%; height:100%" ></iframe>',
+                                     collapsible: true
+                                 }
+                             ]
+                         });
+
+                         this.panel = new Ext.Panel({
+                             id: "pimcore_icon_library_panel",
+                             title: t("icon_library"),
+                             iconCls: "pimcore_icon_icons",
+                             border: false,
+                             layout: 'border',
+                             closable: true,
+                             items: [
+                                 iconLibraryTab
+                             ],
+                         });
+
+                         const tabPanel = Ext.getCmp("pimcore_panel_tabs");
+                         tabPanel.add(this.panel);
                      }
                  });
              }

--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -808,7 +808,6 @@ pimcore.layout.toolbar = Class.create({
              }
  
              if (user.admin) {
-
                  settingsItems.push({
                      iconCls: "pimcore_nav_icon_icons",
                      itemId: 'pimcore_menu_settings_icon_library',

--- a/public/js/pimcore/object/classes/class.js
+++ b/public/js/pimcore/object/classes/class.js
@@ -701,7 +701,36 @@ pimcore.object.classes.klass = Class.create({
             return "Pimcore\\Model\\DataObject\\" + ucfirst(name);
         };
 
-        var iconStore = new Ext.data.ArrayStore({
+        const iconTypes = Ext.create('Ext.data.Store', {
+            fields: ['text', 'value'],
+            data: [
+                { "text": t('color_icons'), "value": 'color' },
+                { "text": t('white_icons'), "value": 'white' },
+                { "text": t('twemoji') + ' (1/3)', "value": 'twemoji-1' },
+                { "text": t('twemoji') + ' (2/3)', "value": 'twemoji-2' },
+                { "text": t('twemoji') + ' (3/3)', "value": 'twemoji-3' },
+                { "text": t('twemoji_variants'), "value": 'twemoji_variants' },
+            ]
+        });
+
+        const iconTypeBox = Ext.create('Ext.form.ComboBox', {
+            store: iconTypes,
+            width: 150,
+            displayField: 'text',
+            valueField: 'value',
+            emptyText: t('type'),
+            listeners: {
+                change: function (elem) {
+                    iconStore.proxy.extraParams = {
+                       'type' : elem.value,
+                        classId: this.getId(),
+                    };
+                    iconStore.load();
+                }.bind(this)
+            }
+        });
+
+        const iconStore = new Ext.data.ArrayStore({
             proxy: {
                 url: Routing.generate('pimcore_admin_dataobject_class_geticons'),
                 type: 'ajax',
@@ -709,7 +738,7 @@ pimcore.object.classes.klass = Class.create({
                     type: 'json'
                 },
                 extraParams: {
-                    classId: this.getId()
+                    classId: this.getId(),
                 }
             },
             fields: ["text", "value"]
@@ -723,7 +752,7 @@ pimcore.object.classes.klass = Class.create({
             value: this.data.icon,
             listeners: {
                 "afterrender": function (el) {
-                    el.inputEl.applyStyles("background:url(" + el.getValue() + ") right center no-repeat;");
+                    el.inputEl.applyStyles("background:url(" + el.getValue() + ") left center no-repeat; text-indent: 19px;");
                 }
             }
         });
@@ -872,19 +901,30 @@ pimcore.object.classes.klass = Class.create({
                         labelWidth: 200
                     },
                     items: [
-                        iconField,
+                        iconField
+                    ]
+                },
+                {
+                    xtype: "fieldcontainer",
+                    layout: "hbox",
+                    fieldLabel: t("icon_tools"),
+                    defaults: {
+                        labelWidth: 200
+                    },
+                    items: [
+                        iconTypeBox,
                         {
                             xtype: "combobox",
                             store: iconStore,
-                            width: 50,
+                            width: 100,
                             valueField: 'value',
                             displayField: 'text',
                             listeners: {
                                 select: function (ele, rec, idx) {
-                                    var icon = ele.container.down("#iconfield-" + this.getId());
-                                    var newValue = rec.data.value;
-                                    icon.component.setValue(newValue);
-                                    icon.component.inputEl.applyStyles("background:url(" + newValue + ") right center no-repeat;");
+                                    const icon = Ext.getCmp("iconfield-" + this.getId());
+                                    const newValue = rec.data.value;
+                                    icon.setValue(newValue);
+                                    icon.inputEl.applyStyles("background:url(" + newValue + ") left center no-repeat; text-indent: 19px;");
                                     return newValue;
                                 }.bind(this)
                             }

--- a/public/js/pimcore/object/classes/class.js
+++ b/public/js/pimcore/object/classes/class.js
@@ -902,7 +902,7 @@ pimcore.object.classes.klass = Class.create({
                             iconCls: "pimcore_icon_icons",
                             text: t('icon_library'),
                             handler: function () {
-                                pimcore.helpers.openGenericIframeWindow("icon-library", Routing.generate('pimcore_admin_misc_iconlist'), "pimcore_icon_icons", t("icon_library"));
+                                pimcore.globalmanager.get("layout_toolbar").showIconLibrary();
                             }
                         }
                     ]

--- a/public/js/pimcore/object/classes/class.js
+++ b/public/js/pimcore/object/classes/class.js
@@ -722,7 +722,7 @@ pimcore.object.classes.klass = Class.create({
             valueField: 'value',
             emptyText: t('type'),
             listeners: {
-                change: function (elem) {
+                select: function (elem) {
                     iconStore.proxy.extraParams = {
                        'type' : elem.value,
                         classId: this.getId(),

--- a/public/js/pimcore/object/classes/class.js
+++ b/public/js/pimcore/object/classes/class.js
@@ -22,7 +22,7 @@ pimcore.object.classes.klass = Class.create({
     context: "class",
     uploadRoute: 'pimcore_admin_dataobject_class_importclass',
     exportRoute: 'pimcore_admin_dataobject_class_exportclass',
-
+    iconCss: ' left center no-repeat; text-indent: 20px',
     initialize: function (data, parentPanel, reopen, editorPrefix) {
         this.parentPanel = parentPanel;
         this.data = data;
@@ -752,8 +752,8 @@ pimcore.object.classes.klass = Class.create({
             value: this.data.icon,
             listeners: {
                 "afterrender": function (el) {
-                    el.inputEl.applyStyles("background:url(" + el.getValue() + ") left center no-repeat; text-indent: 19px;");
-                }
+                    el.inputEl.applyStyles("background:url(" + el.getValue() + ")" + this.iconCss);
+                }.bind(this)
             }
         });
 
@@ -916,15 +916,16 @@ pimcore.object.classes.klass = Class.create({
                         {
                             xtype: "combobox",
                             store: iconStore,
-                            width: 100,
+                            width: 105,
                             valueField: 'value',
                             displayField: 'text',
+                            emptyText: t('select_type_first'),
                             listeners: {
                                 select: function (ele, rec, idx) {
                                     const icon = Ext.getCmp("iconfield-" + this.getId());
                                     const newValue = rec.data.value;
                                     icon.setValue(newValue);
-                                    icon.inputEl.applyStyles("background:url(" + newValue + ") left center no-repeat; text-indent: 19px;");
+                                    icon.inputEl.applyStyles("background:url(" + newValue + ")" + this.iconCss);
                                     return newValue;
                                 }.bind(this)
                             }
@@ -934,7 +935,7 @@ pimcore.object.classes.klass = Class.create({
                             xtype: "button",
                             tooltip: t("refresh"),
                             handler: function(iconField) {
-                                iconField.inputEl.applyStyles("background:url(" + iconField.getValue() + ") right center no-repeat;");
+                                iconField.inputEl.applyStyles("background:url(" + iconField.getValue() + ")" + this.iconCss);
                             }.bind(this, iconField)
                         },
                         {

--- a/public/js/pimcore/object/classes/class.js
+++ b/public/js/pimcore/object/classes/class.js
@@ -709,13 +709,15 @@ pimcore.object.classes.klass = Class.create({
                 { "text": t('twemoji') + ' (1/3)', "value": 'twemoji-1' },
                 { "text": t('twemoji') + ' (2/3)', "value": 'twemoji-2' },
                 { "text": t('twemoji') + ' (3/3)', "value": 'twemoji-3' },
-                { "text": t('twemoji_variants'), "value": 'twemoji_variants' },
+                { "text": t('twemoji_variants') + ' (1/3)', "value": 'twemoji_variants-1' },
+                { "text": t('twemoji_variants') + ' (2/3)', "value": 'twemoji_variants-2' },
+                { "text": t('twemoji_variants') + ' (3/3)', "value": 'twemoji_variants-3' },
             ]
         });
 
         const iconTypeBox = Ext.create('Ext.form.ComboBox', {
             store: iconTypes,
-            width: 150,
+            width: 180,
             displayField: 'text',
             valueField: 'value',
             emptyText: t('type'),
@@ -738,7 +740,7 @@ pimcore.object.classes.klass = Class.create({
                     type: 'json'
                 },
                 extraParams: {
-                    classId: this.getId(),
+                    classId: this.getId()
                 }
             },
             fields: ["text", "value"]
@@ -916,7 +918,7 @@ pimcore.object.classes.klass = Class.create({
                         {
                             xtype: "combobox",
                             store: iconStore,
-                            width: 105,
+                            width: 75,
                             valueField: 'value',
                             displayField: 'text',
                             emptyText: t('select_type_first'),

--- a/public/js/pimcore/object/classes/layout/layout.js
+++ b/public/js/pimcore/object/classes/layout/layout.js
@@ -293,7 +293,7 @@ pimcore.object.classes.layout.layout = Class.create({
                     iconCls: "pimcore_icon_icons",
                     text: t('icon_library'),
                     handler: function () {
-                        pimcore.helpers.openGenericIframeWindow("icon-library", Routing.generate('pimcore_admin_misc_iconlist'), "pimcore_icon_icons", t("icon_library"));
+                        pimcore.globalmanager.get("layout_toolbar").showIconLibrary();
                     }
                 }
             ]

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1810,14 +1810,21 @@ class ClassController extends AdminAbstractController implements KernelControlle
     public function getIconsAction(Request $request, EventDispatcherInterface $eventDispatcher): Response
     {
         $classId = $request->get('classId');
+        $type = $request->get('type');
 
         $iconDir = PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img';
-        $classIcons = rscandir($iconDir . '/object-icons/');
-        $colorIcons = rscandir($iconDir . '/flat-color-icons/');
-        $twemoji = rscandir($iconDir . '/twemoji/');
 
-        $icons = array_merge($classIcons, $colorIcons, $twemoji);
+        $icons = match($type) {
+            'color' => rscandir($iconDir . '/flat-color-icons/'),
+            'white' => rscandir($iconDir . '/flat-white-icons/'),
+            'twemoji-1', 'twemoji-2', 'twemoji-3', 'twemoji_variants' => rscandir($iconDir . '/twemoji/'),
+            default => []
+        };
 
+        $style = '';
+        if ($type === 'white'){
+            $style = 'background-color:#000';
+        }
         foreach ($icons as &$icon) {
             $icon = str_replace(PIMCORE_WEB_ROOT, '', $icon);
         }
@@ -1829,14 +1836,49 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $eventDispatcher->dispatch($event, AdminEvents::CLASS_OBJECT_ICONS_PRE_SEND_DATA);
         $icons = $event->getArgument('icons');
 
+        $startIndex = 0;
         $result = [];
-        foreach ($icons as $icon) {
+
+        if (str_starts_with($type,'twemoji')){
+            foreach ($icons as $index => $twemojiIcon) {
+                $iconBase = basename($twemojiIcon);
+
+                // All the variants (like skin color) have 3 hyphens in their base name
+                // Here we remove/unset wheter if the selected icon type is the variant list
+                $countHyphen = substr_count($iconBase, '-');
+                if (
+                    ($type != 'twemoji_variants' && $countHyphen > 3) ||
+                    ($type == 'twemoji_variants' && $countHyphen < 3)
+                ) {
+                    unset($icons[$index]);
+                }
+            }
+
+            $icons = array_values($icons);
+            $limit = count($icons);
+
+            if ($type === 'twemoji-1'){
+                $limit = floor($limit / 3);
+            }
+            if ($type === 'twemoji-2'){
+                $startIndex = floor($limit / 3);
+                $limit = floor($limit / 3 * 2);
+            }
+            if ($type === 'twemoji-3'){
+                $startIndex = floor($limit / 3 * 2);
+            }
+        }else{
+            $limit = count($icons);
+        }
+
+        for ($i = $startIndex; $i < $limit; $i++) {
+            $icon = $icons[$i];
             $content = file_get_contents(PIMCORE_WEB_ROOT . $icon);
             $result[] = [
-                'text' => sprintf('<img src="data:%s;base64,%s"/>', mime_content_type(PIMCORE_WEB_ROOT . $icon), base64_encode($content)),
+                'text' => sprintf('<img style="%s" src="data:%s;base64,%s"/>', $style, mime_content_type(PIMCORE_WEB_ROOT . $icon), base64_encode($content)),
                 'value' => $icon,
             ];
-        }
+        };
 
         return $this->adminJson($result);
     }

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1821,7 +1821,9 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $icons = match($type) {
             'color' => rscandir($iconDir . '/flat-color-icons/'),
             'white' => rscandir($iconDir . '/flat-white-icons/'),
-            'twemoji-1', 'twemoji-2', 'twemoji-3', 'twemoji_variants' => rscandir($iconDir . '/twemoji/'),
+            'twemoji-1', 'twemoji-2', 'twemoji-3',
+            'twemoji_variants-1', 'twemoji_variants-2', 'twemoji_variants-3'
+            => rscandir($iconDir . '/twemoji/'),
             default => []
         };
 
@@ -1847,12 +1849,12 @@ class ClassController extends AdminAbstractController implements KernelControlle
             foreach ($icons as $index => $twemojiIcon) {
                 $iconBase = basename($twemojiIcon);
 
-                // All the variants (like skin color) have 3 hyphens in their base name
+                // All the variants (like skin color) have a hyphen in their base name
                 // Here we remove/unset wheter if the selected icon type is the variant list
-                $countHyphen = substr_count($iconBase, '-');
+                $explodeByHyphen = explode('-', $iconBase);
                 if (
-                    ($type != 'twemoji_variants' && $countHyphen > 3) ||
-                    ($type == 'twemoji_variants' && $countHyphen < 3)
+                    (!str_starts_with($type, 'twemoji_variants') && isset($explodeByHyphen[1])) ||
+                    (str_starts_with($type, 'twemoji_variants')  && !isset($explodeByHyphen[1]))
                 ) {
                     unset($icons[$index]);
                 }
@@ -1861,14 +1863,14 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $icons = array_values($icons);
             $limit = count($icons);
 
-            if ($type === 'twemoji-1') {
+            if (str_ends_with($type,'-1')) {
                 $limit = floor($limit / 3);
             }
-            if ($type === 'twemoji-2') {
+            if (str_ends_with($type,'-2')) {
                 $startIndex = floor($limit / 3);
                 $limit = floor($limit / 3 * 2);
             }
-            if ($type === 'twemoji-3') {
+            if (str_ends_with($type,'-3')) {
                 $startIndex = floor($limit / 3 * 2);
             }
         } else {

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1812,7 +1812,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $classId = $request->get('classId');
         $type = $request->get('type');
 
-        if (!$type){
+        if (!$type) {
             return $this->adminJson([]);
         }
 

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1863,14 +1863,14 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $icons = array_values($icons);
             $limit = count($icons);
 
-            if (str_ends_with($type,'-1')) {
+            if (str_ends_with($type, '-1')) {
                 $limit = floor($limit / 3);
             }
-            if (str_ends_with($type,'-2')) {
+            if (str_ends_with($type, '-2')) {
                 $startIndex = floor($limit / 3);
                 $limit = floor($limit / 3 * 2);
             }
-            if (str_ends_with($type,'-3')) {
+            if (str_ends_with($type, '-3')) {
                 $startIndex = floor($limit / 3 * 2);
             }
         } else {

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1881,7 +1881,12 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $icon = $icons[$i];
             $content = file_get_contents(PIMCORE_WEB_ROOT . $icon);
             $result[] = [
-                'text' => sprintf('<img style="%s" src="data:%s;base64,%s"/>', $style, mime_content_type(PIMCORE_WEB_ROOT . $icon), base64_encode($content)),
+                'text' => sprintf(
+                    '<img style="%s" src="data:%s;base64,%s"/>',
+                    $style,
+                    mime_content_type(PIMCORE_WEB_ROOT . $icon),
+                    base64_encode($content)
+                ),
                 'value' => $icon,
             ];
         }

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1822,7 +1822,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         };
 
         $style = '';
-        if ($type === 'white'){
+        if ($type === 'white') {
             $style = 'background-color:#000';
         }
         foreach ($icons as &$icon) {
@@ -1839,7 +1839,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $startIndex = 0;
         $result = [];
 
-        if (str_starts_with($type,'twemoji')){
+        if (str_starts_with($type, 'twemoji')) {
             foreach ($icons as $index => $twemojiIcon) {
                 $iconBase = basename($twemojiIcon);
 
@@ -1857,17 +1857,17 @@ class ClassController extends AdminAbstractController implements KernelControlle
             $icons = array_values($icons);
             $limit = count($icons);
 
-            if ($type === 'twemoji-1'){
+            if ($type === 'twemoji-1') {
                 $limit = floor($limit / 3);
             }
-            if ($type === 'twemoji-2'){
+            if ($type === 'twemoji-2') {
                 $startIndex = floor($limit / 3);
                 $limit = floor($limit / 3 * 2);
             }
-            if ($type === 'twemoji-3'){
+            if ($type === 'twemoji-3') {
                 $startIndex = floor($limit / 3 * 2);
             }
-        }else{
+        } else {
             $limit = count($icons);
         }
 
@@ -1878,7 +1878,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 'text' => sprintf('<img style="%s" src="data:%s;base64,%s"/>', $style, mime_content_type(PIMCORE_WEB_ROOT . $icon), base64_encode($content)),
                 'value' => $icon,
             ];
-        };
+        }
 
         return $this->adminJson($result);
     }

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1812,6 +1812,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $classId = $request->get('classId');
         $type = $request->get('type');
 
+        if (!$type){
+            return $this->adminJson([]);
+        }
+
         $iconDir = PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img';
 
         $icons = match($type) {

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -308,11 +308,14 @@ class MiscController extends AdminAbstractController
         $languageOptions = [];
         foreach ($locales as $short => $translation) {
             if (!empty($short)) {
-                $languageOptions[] = [
-                    'language' => $short,
-                    'display' => $translation . " ($short)",
-                    'flag' => AdminTool::getLanguageFlagFile($short, true),
-                ];
+                $flag = AdminTool::getLanguageFlagFile($short, true, false);
+                if ($flag) {
+                    $languageOptions[] = [
+                        'language' => $short,
+                        'display' => $translation . " ($short)",
+                        'flag' => $flag,
+                    ];
+                }
             }
         }
 

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -302,7 +302,7 @@ class MiscController extends AdminAbstractController
         $iconDir = $publicDir . '/img';
         $extraInfo = null;
 
-        $icons = match($type) {
+        $icons = match ($type) {
             'color' => rscandir($iconDir . '/flat-color-icons/'),
             'white' => rscandir($iconDir . '/flat-white-icons/'),
             'twemoji' => rscandir($iconDir . '/twemoji/'),
@@ -310,14 +310,17 @@ class MiscController extends AdminAbstractController
             default => []
         };
 
-        $source = match($type) {
-            'color' => 'based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a>',
-            'white' => 'based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a>',
-            'twemoji' => 'based on the <a href="https://github.com/twitter/twemoji/blob/master/LICENSE" target="_blank">Twemoji icons</a>',
+        $source = match ($type) {
+            'color', 'white' =>
+                'based on the ' .
+                '<a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a>',
+            'twemoji' =>
+                'based on the ' .
+                '<a href="https://github.com/twitter/twemoji/blob/master/LICENSE" target="_blank">Twemoji icons</a>',
             default => ''
         };
 
-        if ($type ==='twemoji') {
+        if ($type === 'twemoji') {
             $extraInfo = 'ℹ Click on icon with green border to display all its related variants. Click on the letter to display flags with the clicked initial';
         }
 

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -302,14 +302,14 @@ class MiscController extends AdminAbstractController
 
         $type = $request->get('type');
 
-        $icons = match($type){
+        $icons = match($type) {
             'color' => rscandir($iconDir . '/flat-color-icons/'),
             'white' => rscandir($iconDir . '/flat-white-icons/'),
             'twemoji' => rscandir($iconDir . '/twemoji/'),
             'flags' => $this->getFlags(),
         };
 
-        $source = match($type){
+        $source = match($type) {
             'color' => 'based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a>',
             'white' => 'based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a>',
             'twemoji' => 'based on the <a href="https://github.com/twitter/twemoji/blob/master/LICENSE" target="_blank">Twemoji icons</a>',
@@ -327,7 +327,7 @@ class MiscController extends AdminAbstractController
             'iconsCss' => $iconsCss,
             'type' => $type,
             'extraInfo' => $extraInfo,
-            'source' => $source
+            'source' => $source,
         ]);
     }
 
@@ -349,6 +349,7 @@ class MiscController extends AdminAbstractController
 
         return $languageOptions;
     }
+
     /**
      * @Route("/test", name="pimcore_admin_misc_test")
      */

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -302,7 +302,6 @@ class MiscController extends AdminAbstractController
         $iconDir = $publicDir . '/img';
         $extraInfo = null;
 
-
         $icons = match($type) {
             'color' => rscandir($iconDir . '/flat-color-icons/'),
             'white' => rscandir($iconDir . '/flat-white-icons/'),

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -296,11 +296,12 @@ class MiscController extends AdminAbstractController
         if ($profiler) {
             $profiler->disable();
         }
+
+        $type = $request->get('type');
         $publicDir = PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin';
         $iconDir = $publicDir . '/img';
         $extraInfo = null;
 
-        $type = $request->get('type');
 
         $icons = match($type) {
             'color' => rscandir($iconDir . '/flat-color-icons/'),

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -307,6 +307,7 @@ class MiscController extends AdminAbstractController
             'white' => rscandir($iconDir . '/flat-white-icons/'),
             'twemoji' => rscandir($iconDir . '/twemoji/'),
             'flags' => $this->getFlags(),
+            default => []
         };
 
         $source = match($type) {

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -21,7 +21,7 @@ final class Tool
     /**
      * @internal
      */
-    public static function getLanguageFlagFile(string $language, bool $absolutePath = true): string
+    public static function getLanguageFlagFile(string $language, bool $absolutePath = true, $includeUnknown = true): string
     {
         $basePath = '/bundles/pimcoreadmin/img/flags';
         $iconFsBasePath = PIMCORE_WEB_ROOT . $basePath;
@@ -45,7 +45,10 @@ final class Tool
         $countryFsPath = $iconFsBasePath . '/countries/' . $countryCode . '.svg';
         $fallbackFsLanguagePath = $iconFsBasePath . '/languages/' . $fallbackLanguageCode . '.svg';
 
-        $iconPath = ($absolutePath === true ? $iconFsBasePath : $basePath) . '/countries/_unknown.svg';
+        $iconPath = '';
+        if ($includeUnknown) {
+            $iconPath = ($absolutePath === true ? $iconFsBasePath : $basePath) . '/countries/_unknown.svg';
+        }
 
         $languageCountryMapping = [
             'aa' => 'er', 'af' => 'za', 'am' => 'et', 'as' => 'in', 'ast' => 'es', 'asa' => 'tz',

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -21,7 +21,7 @@ final class Tool
     /**
      * @internal
      */
-    public static function getLanguageFlagFile(string $language, bool $absolutePath = true, $includeUnknown = true): string
+    public static function getLanguageFlagFile(string $language, bool $absolutePath = true, bool $includeUnknown = true): string
     {
         $basePath = '/bundles/pimcoreadmin/img/flags';
         $iconFsBasePath = PIMCORE_WEB_ROOT . $basePath;

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -167,7 +167,7 @@ class AdminExtension extends AbstractExtension
     public function lazyIcon(string $icon): string
     {
         return sprintf(
-            '<img class="lazy-load" title="%s" data-lazyimgpath="%s" />',
+            '<div class="lazy-load" title="%s" data-lazyimgpath="%s" /></div>',
             basename($icon),
             str_replace(PIMCORE_WEB_ROOT, '', $icon)
         );

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -167,7 +167,8 @@ class AdminExtension extends AbstractExtension
     public function lazyIcon(string $icon): string
     {
         return sprintf(
-            '<div class="lazy-load" title="%s" data-lazyimgpath="%s" /></div>',
+            '<img src="%s" loading="lazy" class="lazy-load" title="%s" data-imgpath="%s" />',
+            str_replace(PIMCORE_WEB_ROOT, '', $icon),
             basename($icon),
             str_replace(PIMCORE_WEB_ROOT, '', $icon)
         );

--- a/src/Twig/Extension/AdminExtension.php
+++ b/src/Twig/Extension/AdminExtension.php
@@ -55,6 +55,7 @@ class AdminExtension extends AbstractExtension
     {
         return [
             new TwigFilter('pimcore_inline_icon', [$this, 'inlineIcon']),
+            new TwigFilter('pimcore_lazy_icon', [$this, 'lazyIcon']),
             new TwigFilter('pimcore_twemoji_variant_icon', [$this, 'twemojiVariantIcon']),
         ];
     }
@@ -158,6 +159,15 @@ class AdminExtension extends AbstractExtension
             '<img src="data:%s;base64,%s" title="%s" data-imgpath="%s" />',
             mime_content_type($icon),
             base64_encode($content),
+            basename($icon),
+            str_replace(PIMCORE_WEB_ROOT, '', $icon)
+        );
+    }
+
+    public function lazyIcon(string $icon): string
+    {
+        return sprintf(
+            '<img class="lazy-load" title="%s" data-lazyimgpath="%s" />',
             basename($icon),
             str_replace(PIMCORE_WEB_ROOT, '', $icon)
         );

--- a/templates/admin/index/index.html.twig
+++ b/templates/admin/index/index.html.twig
@@ -216,7 +216,7 @@
     "pimcore/helpers.js",
     "pimcore/error.js",
     "pimcore/events.js",
-
+    "pimcore/iconlibrary.js",
     "pimcore/treenodelocator.js",
     "pimcore/helpers/generic-grid.js",
     "pimcore/helpers/quantityValue.js",

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -47,10 +47,8 @@
 
         .info {
             text-align: center;
-            margin-bottom: 30px;
             clear: both;
             font-size: 22px;
-            padding-top: 50px;
         }
 
         .info small {

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -13,8 +13,9 @@
         }
 
         .icons {
-            width:1200px;
             margin: 0 auto;
+            display:inline-block;
+            padding-top: 20px;
         }
 
         .icon {
@@ -25,9 +26,11 @@
             float: left;
             font-size: 10px;
             word-wrap: break-word;
-            cursor: copy;
             padding-top: 5px;
             box-sizing: border-box;
+        }
+        .icon img:hover{
+            cursor: copy;
         }
 
         .icon.black {
@@ -66,110 +69,206 @@
             display: none;
             background-color: #eee;
         }
+
+        /*-------------------------------------*/
+
+        .accordion_item {
+            margin: 5px auto;
+        }
+        .accordion_item .accordion_title {
+            position: relative;
+            display: block;
+            padding: 13px 60px 15px 13px;
+            margin-bottom: 2px;
+            color: #202020;
+            font-size: 28px;
+            text-decoration: none;
+            background-color: #eaeaea;
+            border-radius: 3px;
+            -webkit-transition: background-color 0.2s;
+            transition: background-color 0.2s;
+            cursor: pointer;
+        }
+        .accordion_item .accordion_title:hover {
+            background-color: #e5e4e4;
+            transition: all 0.5s ease-out;
+        }
+        .accordion_item .accordion-active {
+            background-color: #e5e4e4;
+        }
+        .accordion_item .accordion_title .accordion_arrow {
+            position: absolute;
+            top: 13px; right: 10px;
+            display: inline-block;
+            vertical-align: middle;
+            width: 30px;
+            height: 30px;
+            text-align: center;
+            color: #fff;
+            line-height: 30px;
+            font-size: 20px;
+            font-weight: 700;
+            margin-right: 5px;
+            background-color: #c9c9c9;
+            border-radius: 50%;
+            -webkit-transition: all 0.2s ease-out;
+            transition: all 0.2s ease-out;
+        }
+        .accordion_item .accordion_rotate {
+            transform: rotate(225deg);
+        }
+        .accordion_item .accordion_content {
+            padding: 30px;
+            margin-bottom: 2px;
+            font-size: 14px;
+            display: none;
+            background-color: #f3f3f3;
+        }
+        .accordion_item .accordion_arrow-item {
+            font-weight: 700;
+        }
+        /*-------------------------------------*/
+
     </style>
 </head>
 <body>
 
-<div class="info">
-    <a target="_blank">Color Icons</a>
-    <br>
-    <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
-</div>
 
-<div id="color_icons" class="icons">
-    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
-    {% for icon in colorIcons %}
-        {% set iconPath = icon|replace({(webRoot): ''}) %}
-        <div class="icon">
-            {{ icon | pimcore_inline_icon | raw }}
-            <div class="label">
-                {{ iconPath in iconsCss  ? '*' : '' }}
-                {{ iconPath|basename }}
+<div class="accordion">
+    <div class="accordion_item">
+        <div class="accordion_title">
+            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
+            <span class="accordion_title-text">Color Icons</span>
+        </div>
+        <div class="accordion_content">
+            <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
+            <div id="color_icons" class="icons">
+                <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
+                {% for icon in colorIcons %}
+                    {% set iconPath = icon|replace({(webRoot): ''}) %}
+                    <div class="icon">
+                        {{ icon | pimcore_inline_icon | raw }}
+                        <div class="label">
+                            {{ iconPath in iconsCss  ? '*' : '' }}
+                            {{ iconPath|basename }}
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
         </div>
-    {% endfor %}
-</div>
-
-<div class="info">
-    <a target="_blank">White Icons</a>
-    <br>
-    <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
-</div>
-
-<div id="white_icons" class="icons">
-    {% for icon in whiteIcons %}
-        {% set iconPath = icon|replace({(webRoot): ''}) %}
-        <div class="icon black">
-            {{ icon | pimcore_inline_icon | raw }}
-            <div class="label">
-                {{ iconPath in iconsCss  ? '*' : '' }}
-                {{ iconPath|basename }}
+    </div>
+    <div class="accordion_item">
+        <div class="accordion_title">
+            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
+            <span class="accordion_title-text">White Icons</span>
+        </div>
+        <div class="accordion_content">
+            <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
+            <div id="white_icons" class="icons">
+                {% for icon in whiteIcons %}
+                    {% set iconPath = icon|replace({(webRoot): ''}) %}
+                    <div class="icon black">
+                        {{ icon | pimcore_lazy_icon | raw }}
+                        <div class="label">
+                            {{ iconPath in iconsCss  ? '*' : '' }}
+                            {{ iconPath|basename }}
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
         </div>
-    {% endfor %}
-</div>
+    </div>
+    <div class="accordion_item">
+        <div class="accordion_title">
+            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
+            <span class="accordion_title-text">Twemoji</span>
+        </div>
+        <div class="accordion_content">
+            <small>Source: <a href="https://github.com/twitter/twemoji" target="_blank">(Twemoji)</a></small>
+            <div id="twemoji" class="icons">
+                <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
+                <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon with green border to display all its related variants. Click on the letter to display flags with the clicked initial</div>
+                {% for icon in twemoji %}
+                    {% set iconPath = icon|replace({(webRoot): ''}) %}
 
-<div class="info">
-    <a href="https://github.com/twitter/twemoji" target="_blank">Source (Twemoji)</a>
-</div>
+{#                    Any icon with basename that has a dash will be considered as a variant to avoid recurisvely searching for "parent" icon.#}
+{#                    It happens that all icon that have variants have at least a prefix of 4-5 characters.#}
 
-<div id="twemoji" class="icons">
-    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
-    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon with green border to display all its related variants. Click on the letter to display flags with the clicked initial</div>
-    {% for icon in twemoji %}
-        {% set iconPath = icon|replace({(webRoot): ''}) %}
-        {#
-            Any icon with basename that has a dash will be considered as a variant to avoid recurisvely searching for "parent" icon.
-            It happens that all icon that have variants have at least a prefix of 4-5 characters.
-        #}
-        {% if '-' in iconPath and iconPath|basename|split('-')[0]|length > 3 %}
-            <div class="icon variant">
-                {{ icon | pimcore_twemoji_variant_icon | raw }}
-                <div class="label">{{ iconPath|basename }}</div>
+                    {% if '-' in iconPath and iconPath|basename|split('-')[0]|length > 3 %}
+                        <div class="icon variant">
+                            {{ icon | pimcore_twemoji_variant_icon | raw }}
+                            <div class="label">{{ iconPath|basename }}</div>
+                        </div>
+                    {% else %}
+                        <div class="icon">
+                            {{ icon | pimcore_lazy_icon | raw }}
+                            <div class="label">{{ iconPath|basename }}</div>
+                        </div>
+                    {% endif %}
+                {% endfor %}
             </div>
-        {% else %}
-            <div class="icon">
-                {{ icon | pimcore_inline_icon | raw }}
-                <div class="label">{{ iconPath|basename }}</div>
+        </div>
+    </div>
+    <div class="accordion_item">
+        <div class="accordion_title">
+            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
+            <span class="accordion_title-text">Flags</span>
+        </div>
+        <div class="accordion_content">
+
+            <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
+            <div id="flags" class="icons">
+                {% for langOpt in languageOptions %}
+                    <div class="icon">
+                        {{ langOpt['display'] }} <br>
+                        {{ langOpt['flag'] | pimcore_lazy_icon | raw }}
+                        <div class="label">
+                            {% set iconPath = langOpt['flag']|replace({(webRoot): ''}) %}
+                            {{ iconPath|basename }}
+                        </div>
+                    </div>
+                {% endfor %}
             </div>
-        {% endif %}
-    {% endfor %}
+        </div>
+    </div>
 </div>
 
-<div class="info">
-    Flags
-</div>
-
-<table>
-    <tr>
-        <th>Flag</th>
-        <th>Code</th>
-        <th>Name</th>
-    </tr>
-    {% for langOpt in languageOptions %}
-        <tr>
-            <td class="language-icon">{{ langOpt['flag'] | pimcore_inline_icon | raw }}</td>
-            <td>{{ langOpt['language'] }}</td>
-            <td>{{ langOpt['display'] }}</td>
-        </tr>
-    {% endfor %}
-</table>
 
 <script
-    src="https://code.jquery.com/jquery-3.7.0.slim.js"
-    integrity="sha256-7GO+jepT9gJe9LB4XFf8snVOjX3iYNb0FHYr5LI1N5c="
-    crossorigin="anonymous"
-    {{ pimcore_csp.getNonceHtmlAttribute()|raw }}></script>
+    src="https://code.jquery.com/jquery-3.7.1.min.js"
+    integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+    crossorigin="anonymous"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/common.js"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/functions.js"></script>
 <script src="/bundles/pimcoreadmin/js/pimcore/helpers.js"></script>
 
 <script {{ pimcore_csp.getNonceHtmlAttribute()|raw }}>
     $( document ).ready(function() {
+
+        // Init accordion
+        $(".accordion_title").on("click", function(e) {
+
+            e.preventDefault();
+            let $this = $(this);
+
+            if (!$this.hasClass("accordion-active")) {
+                $(".accordion_content").slideUp(400);
+                $(".accordion_title").removeClass("accordion-active");
+                $('.accordion_arrow').removeClass('accordion_rotate');
+            }
+
+            $this.toggleClass("accordion-active");
+            $this.next().slideToggle();
+            $('.accordion_arrow',this).toggleClass('accordion_rotate');
+        });
+
+        // Open the first one by default
+        $('.accordion_title').first().click();
+
         // Add click event to copy icon path on all icons
         $('img').each(function () {
             $(this).click(function () {
-                pimcore.helpers.copyStringToClipboard($(this).data('imgpath'));
+                pimcore.helpers.copyStringToClipboard($(this).data('imgpath') ?? $(this).data('lazyimgpath'));
             });
         });
         // Twimoji only: clicking on icon with green border displays all its variants
@@ -185,6 +284,12 @@
                 });
             });
         });
+
+        // Lazy Load the hidden ones
+        $('img.lazy-load').each(function (index) {
+            $(this).delay(500 * (index/100)).attr('src', $(this).data('lazyimgpath'));
+        });
+
     });
 </script>
 

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -17,7 +17,6 @@
             display:inline-block;
             padding-top: 20px;
         }
-
         .icon {
             text-align: center;
             width:100px;
@@ -29,16 +28,21 @@
             padding-top: 5px;
             box-sizing: border-box;
         }
-        .icon img:hover{
+
+        .icon img:hover, div.lazy-load:hover {
             cursor: copy;
         }
 
-        .icon.black {
+        #white .icon {
             background-color: #0C0F12;
         }
 
-        .icon.black .label {
+        #white .icon .label {
             color: #fff;
+        }
+
+        #flags .icon{
+            height: 100px;
         }
 
         .info {
@@ -69,228 +73,136 @@
             display: none;
             background-color: #eee;
         }
-
-        /*-------------------------------------*/
-
-        .accordion_item {
-            margin: 5px auto;
-        }
-        .accordion_item .accordion_title {
-            position: relative;
-            display: block;
-            padding: 13px 60px 15px 13px;
-            margin-bottom: 2px;
-            color: #202020;
-            font-size: 28px;
-            text-decoration: none;
-            background-color: #eaeaea;
-            border-radius: 3px;
-            -webkit-transition: background-color 0.2s;
-            transition: background-color 0.2s;
-            cursor: pointer;
-        }
-        .accordion_item .accordion_title:hover {
-            background-color: #e5e4e4;
-            transition: all 0.5s ease-out;
-        }
-        .accordion_item .accordion-active {
-            background-color: #e5e4e4;
-        }
-        .accordion_item .accordion_title .accordion_arrow {
-            position: absolute;
-            top: 13px; right: 10px;
+        .lazy-load{
+            background-size: contain;
+            background-repeat: no-repeat;
+            height: 50px;
+            width: 50px;
             display: inline-block;
-            vertical-align: middle;
-            width: 30px;
-            height: 30px;
-            text-align: center;
-            color: #fff;
-            line-height: 30px;
-            font-size: 20px;
-            font-weight: 700;
-            margin-right: 5px;
-            background-color: #c9c9c9;
-            border-radius: 50%;
-            -webkit-transition: all 0.2s ease-out;
-            transition: all 0.2s ease-out;
         }
-        .accordion_item .accordion_rotate {
-            transform: rotate(225deg);
-        }
-        .accordion_item .accordion_content {
-            padding: 30px;
-            margin-bottom: 2px;
-            font-size: 14px;
-            display: none;
-            background-color: #f3f3f3;
-        }
-        .accordion_item .accordion_arrow-item {
-            font-weight: 700;
-        }
-        /*-------------------------------------*/
 
     </style>
 </head>
 <body>
 
-
-<div class="accordion">
-    <div class="accordion_item">
-        <div class="accordion_title">
-            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
-            <span class="accordion_title-text">Color Icons</span>
-        </div>
-        <div class="accordion_content">
-            <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
-            <div id="color_icons" class="icons">
-                <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
-                {% for icon in colorIcons %}
-                    {% set iconPath = icon|replace({(webRoot): ''}) %}
-                    <div class="icon">
-                        {{ icon | pimcore_inline_icon | raw }}
-                        <div class="label">
-                            {{ iconPath in iconsCss  ? '*' : '' }}
-                            {{ iconPath|basename }}
-                        </div>
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
-    </div>
-    <div class="accordion_item">
-        <div class="accordion_title">
-            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
-            <span class="accordion_title-text">White Icons</span>
-        </div>
-        <div class="accordion_content">
-            <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
-            <div id="white_icons" class="icons">
-                {% for icon in whiteIcons %}
-                    {% set iconPath = icon|replace({(webRoot): ''}) %}
-                    <div class="icon black">
-                        {{ icon | pimcore_lazy_icon | raw }}
-                        <div class="label">
-                            {{ iconPath in iconsCss  ? '*' : '' }}
-                            {{ iconPath|basename }}
-                        </div>
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
-    </div>
-    <div class="accordion_item">
-        <div class="accordion_title">
-            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
-            <span class="accordion_title-text">Twemoji</span>
-        </div>
-        <div class="accordion_content">
-            <small>Source: <a href="https://github.com/twitter/twemoji" target="_blank">(Twemoji)</a></small>
-            <div id="twemoji" class="icons">
-                <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
-                <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon with green border to display all its related variants. Click on the letter to display flags with the clicked initial</div>
-                {% for icon in twemoji %}
-                    {% set iconPath = icon|replace({(webRoot): ''}) %}
-
-{#                    Any icon with basename that has a dash will be considered as a variant to avoid recurisvely searching for "parent" icon.#}
-{#                    It happens that all icon that have variants have at least a prefix of 4-5 characters.#}
-
-                    {% if '-' in iconPath and iconPath|basename|split('-')[0]|length > 3 %}
-                        <div class="icon variant">
-                            {{ icon | pimcore_twemoji_variant_icon | raw }}
-                            <div class="label">{{ iconPath|basename }}</div>
-                        </div>
-                    {% else %}
-                        <div class="icon">
-                            {{ icon | pimcore_lazy_icon | raw }}
-                            <div class="label">{{ iconPath|basename }}</div>
-                        </div>
-                    {% endif %}
-                {% endfor %}
-            </div>
-        </div>
-    </div>
-    <div class="accordion_item">
-        <div class="accordion_title">
-            <div class="accordion_arrow"><span class="accordion_arrow-item ">+</span></div>
-            <span class="accordion_title-text">Flags</span>
-        </div>
-        <div class="accordion_content">
-
-            <small>based on the <a href="https://github.com/google/material-design-icons/blob/master/LICENSE" target="_blank">Material Design Icons</a></small>
-            <div id="flags" class="icons">
-                {% for langOpt in languageOptions %}
-                    <div class="icon">
-                        {{ langOpt['display'] }} <br>
-                        {{ langOpt['flag'] | pimcore_lazy_icon | raw }}
-                        <div class="label">
-                            {% set iconPath = langOpt['flag']|replace({(webRoot): ''}) %}
-                            {{ iconPath|basename }}
-                        </div>
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
-    </div>
+<div class="info">
+    {% if source is defined %}
+        <small>{{ source|raw }}</small>
+    {% endif %}
 </div>
 
+<div id="{{ type }}" class="icons">
+    <div style="margin-bottom: 20px; text-align: left">ℹ Click on icon to copy path to clipboard.</div>
+
+    {% if extraInfo is defined %}
+        <div style="margin-bottom: 20px; text-align: left">{{ extraInfo }}</div>
+    {% endif %}
+
+    {% for icon in icons %}
+        {% set iconPath = icon|replace({(webRoot): ''}) %}
+        {% if ('-' in iconPath and iconPath|basename|split('-')[0]|length > 3) and (type =='twemoji') %}
+            <div class="icon variant">
+                {{ icon | pimcore_twemoji_variant_icon | raw }}
+                <div class="label">{{ iconPath|basename }}</div>
+            </div>
+        {% else %}
+            <div class="icon">
+
+                {% if type == 'flags' %}
+                    {% set country = iconPath|basename|replace({'.svg': ''}) %}
+                    <div class="country_name" data-isocode="{{ country }}"></div>
+                {% endif %}
+
+                {% if loop.index < 200 %}
+                    {{ icon | pimcore_inline_icon | raw }}
+                {% else %}
+                    {{ icon | pimcore_lazy_icon | raw }}
+                {% endif %}
+
+                <div class="label">
+                    {{ iconPath in iconsCss  ? '*' : '' }}
+                    {{ iconPath|basename }}
+                </div>
+            </div>
+        {% endif %}
+    {% endfor %}
+</div>
 
 <script
     src="https://code.jquery.com/jquery-3.7.1.min.js"
     integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
     crossorigin="anonymous"></script>
-<script src="/bundles/pimcoreadmin/js/pimcore/common.js"></script>
-<script src="/bundles/pimcoreadmin/js/pimcore/functions.js"></script>
-<script src="/bundles/pimcoreadmin/js/pimcore/helpers.js"></script>
 
 <script {{ pimcore_csp.getNonceHtmlAttribute()|raw }}>
     $( document ).ready(function() {
 
-        // Init accordion
-        $(".accordion_title").on("click", function(e) {
-
-            e.preventDefault();
-            let $this = $(this);
-
-            if (!$this.hasClass("accordion-active")) {
-                $(".accordion_content").slideUp(400);
-                $(".accordion_title").removeClass("accordion-active");
-                $('.accordion_arrow').removeClass('accordion_rotate');
-            }
-
-            $this.toggleClass("accordion-active");
-            $this.next().slideToggle();
-            $('.accordion_arrow',this).toggleClass('accordion_rotate');
-        });
-
-        // Open the first one by default
-        $('.accordion_title').first().click();
-
         // Add click event to copy icon path on all icons
-        $('img').each(function () {
-            $(this).click(function () {
-                pimcore.helpers.copyStringToClipboard($(this).data('imgpath') ?? $(this).data('lazyimgpath'));
+        $('img, div.lazy-load').each(function () {
+            $(this).on('click', function () {
+                copyStringToClipboard($(this).data('imgpath') ?? $(this).data('lazyimgpath'));
             });
         });
+
+        $('div.lazy-load').each(function (index) {
+            $(this).delay(1000 * (index/100)).css('background-image', 'url(' + $(this).data('lazyimgpath') + ')');
+        });
+
+
         // Twimoji only: clicking on icon with green border displays all its variants
         $('.icon:not(.variant)').each(function () {
-            $(this).click(function () {
-                let variants = $(this).prevUntil('div.icon:not(.variant)');
-                variants.each(function () {
-                    if (!$(this).is(':visible')) {
-                        let img = $(this).children('img');
-                        img.attr('src', img.data('imgpath'));
-                        $(this).show();
-                    }
+            let variants = $(this).prevUntil('div.icon:not(.variant)');
+            if (variants.length > 0) {
+                $(this).on('click', function () {
+                    variants.each(function () {
+                        if (!$(this).is(':visible')) {
+                            let img = $(this).children('img');
+                            img.attr('src', img.data('imgpath'));
+                            $(this).show();
+                        }
+                    });
                 });
-            });
+            }
         });
 
-        // Lazy Load the hidden ones
-        $('img.lazy-load').each(function (index) {
-            $(this).delay(500 * (index/100)).attr('src', $(this).data('lazyimgpath'));
-        });
+        // Country name from coutnry code
+        const regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
+        $('.country_name').each(function(){
+            try {
+                let country = regionNames.of($(this).data('isocode').toUpperCase());
+                $(this).text(country);
+            } catch{
+                // quick workaround for the ones that breaks it, eg. Scotland and Wels
+                $(this).text($(this).data('isocode'));
+            }
+        })
 
     });
+
+    const copyStringToClipboard = function (str) {
+        let selection = document.getSelection(),
+            prevSelection = (selection.rangeCount > 0) ? selection.getRangeAt(0) : false,
+            el;
+
+        // create element and insert string
+        el = document.createElement('textarea');
+        el.value = str;
+        el.setAttribute('readonly', '');
+        el.style.position = 'absolute';
+        el.style.left = '-9999px';
+
+        // insert element, select all text and copy
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand('copy');
+        document.body.removeChild(el);
+
+        // restore previous selection
+        if (prevSelection) {
+            selection.removeAllRanges();
+            selection.addRange(prevSelection);
+        }
+    };
+
 </script>
 
 </body>

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -164,7 +164,7 @@
             }
         });
 
-        // Country name from coutnry code
+        // Country name from country ISO code
         const regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
         $('.country_name').each(function(){
             try {

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -134,12 +134,9 @@
 <script {{ pimcore_csp.getNonceHtmlAttribute()|raw }}>
     $( document ).ready(function() {
 
-        // Add click event to copy icon path on all icons
-        $('img, div.lazy-load').each(function () {
-            $(this).on('click', function () {
-                copyStringToClipboard($(this).data('imgpath') ?? $(this).data('lazyimgpath'));
-            });
-        });
+        // Add click event to copy icon path to clipboard
+        $('body').on('click', 'img, div.lazy-load', function () { copyStringToClipboard($(this).data('imgpath') ?? $(this).data('lazyimgpath')); });
+
 
         $('div.lazy-load').each(function (index) {
             $(this).delay(300 * (index/100)).css('background-image', 'url(' + $(this).data('lazyimgpath') + ')');

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -111,7 +111,7 @@
                     <div class="country_name" data-isocode="{{ country }}"></div>
                 {% endif %}
 
-                {% if loop.index < 200 %}
+                {% if loop.index < 300 %}
                     {{ icon | pimcore_inline_icon | raw }}
                 {% else %}
                     {{ icon | pimcore_lazy_icon | raw }}
@@ -142,7 +142,7 @@
         });
 
         $('div.lazy-load').each(function (index) {
-            $(this).delay(1000 * (index/100)).css('background-image', 'url(' + $(this).data('lazyimgpath') + ')');
+            $(this).delay(300 * (index/100)).css('background-image', 'url(' + $(this).data('lazyimgpath') + ')');
         });
 
 

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -29,7 +29,7 @@
             box-sizing: border-box;
         }
 
-        .icon img:hover, div.lazy-load:hover {
+        .icon img:hover {
             cursor: copy;
         }
 
@@ -71,13 +71,6 @@
             display: none;
             background-color: #eee;
         }
-        .lazy-load{
-            background-size: contain;
-            background-repeat: no-repeat;
-            height: 50px;
-            width: 50px;
-            display: inline-block;
-        }
 
     </style>
 </head>
@@ -115,7 +108,7 @@
                     <div class="country_name" data-isocode="{{ country }}"></div>
                 {% endif %}
 
-                {% if loop.index < 300 %}
+                {% if loop.index < 100 %}
                     {{ icon | pimcore_inline_icon | raw }}
                 {% else %}
                     {{ icon | pimcore_lazy_icon | raw }}
@@ -139,13 +132,7 @@
     $( document ).ready(function() {
 
         // Add click event to copy icon path to clipboard
-        $('body').on('click', 'img, div.lazy-load', function () { copyStringToClipboard($(this).data('imgpath') ?? $(this).data('lazyimgpath')); });
-
-
-        $('div.lazy-load').each(function (index) {
-            $(this).delay(300 * (index/100)).css('background-image', 'url(' + $(this).data('lazyimgpath') + ')');
-        });
-
+        $('body').on('click', 'img', function () { copyStringToClipboard($(this).data('imgpath')); });
 
         // Twimoji only: clicking on icon with green border displays all its variants
         $('.icon:not(.variant)').each(function () {

--- a/templates/admin/misc/icon_list.html.twig
+++ b/templates/admin/misc/icon_list.html.twig
@@ -98,6 +98,10 @@
 
     {% for icon in icons %}
         {% set iconPath = icon|replace({(webRoot): ''}) %}
+        {#
+            Any icon with basename that has a dash will be considered as a variant to avoid recurisvely searching for "parent" icon.
+            It happens that all icon that have variants have at least a prefix of 4-5 characters.
+        #}
         {% if ('-' in iconPath and iconPath|basename|split('-')[0]|length > 3) and (type =='twemoji') %}
             <div class="icon variant">
                 {{ icon | pimcore_twemoji_variant_icon | raw }}

--- a/translations/admin_ext.en.yaml
+++ b/translations/admin_ext.en.yaml
@@ -18,6 +18,9 @@ icon_library: Icon Library
 color_icons: Color Icons
 white_icons: White Icons
 twemoji: Twemoji
+twemoji_variants: Twemoji variants
+select_type_first: Please select a type first
+icon_tools: Icon Tools
 flags: Flags
 system_performance_stability_warning: >-
     Please do not perform this action unless you are sure what you are doing.<br

--- a/translations/admin_ext.en.yaml
+++ b/translations/admin_ext.en.yaml
@@ -15,6 +15,10 @@ controller_action: Controller & Action
 admin_interface: Admin Interface
 admin_interface_background: Admin Interface Background
 icon_library: Icon Library
+color_icons: Color Icons
+white_icons: White Icons
+twemoji: Twemoji
+flags: Flags
 system_performance_stability_warning: >-
     Please do not perform this action unless you are sure what you are doing.<br
     /><b style='color:red'>This action can have a major impact onto the stability


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/257

### Additional info
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/8d28ca53-abd5-4ea3-9bfe-cae8e61c4e3a)

- Split in different tabs
- Flags decreased the flags from 800 to 248
   - it was considering the language and all the variants, so multiple country flag were appearing multiple times because of their language variants
   - removed the unknown from the list as the icon would be blank
   - displaying the country name, instead of the language, sort by iso code
- Replaced `.click()` with `on('click')`  [see](https://elijahmanor.com/blog/differences-between-jquery-bind-vs-live-vs-delegate-vs-on)
- added lazy loading html attribute
- load by background image seems helping DOM to avoid refreshing (due to new image size recalculations)

##### Data Object class 
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/e9a5ea8f-98d0-4460-bc36-d655efd6e177)
- moved in 2 rows (icon tools)
- added a combobox for selecting/filtering the icon type/style
- splitted the twemoji in 3 parts, as `(1/3)`
- moved the icon to be shown on the right with some indent, so that overflowing long text(icon url) doesn't overlap with the icon on the left
![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/d8a535b2-104d-447d-a1fb-abbcfedccb9d)
