### PR TITLE
[Bug]: Fix potential bug in grid view options

### DIFF
--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -1029,7 +1029,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                 foreach ($classDefs as $classDef) {
                     if ($classDef['classname'] == $class->getName()) {
                         $fieldName = $classDef['fieldname'];
-                        if ($filteredFieldDefinition && !$filteredFieldDefinition[$fieldName]) {
+                        if (isset($filteredFieldDefinition[$fieldName]) && !$filteredFieldDefinition[$fieldName]) {
                             continue;
                         }
 


### PR DESCRIPTION
https://pimcore.atlassian.net/browse/PEES-372

When a user is limited to a Custom Layout that does not include an Object Brick, they maz receive a “Undefined Array Key” error.

![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/6014195/708a0257-99d2-4505-803e-b5dfb52d247c)

With this PR should be avoiding this error