### PR TITLE
Check if searchField is present

### DIFF
--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -416,7 +416,7 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
         var config = $super();
         config.onlyDirectChildren = this.onlyDirectChildren;
         config.pageSize = this.pagingtoolbar.pageSize;
-        config.searchFilter = this.searchField.getValue();
+        config.searchFilter = this.searchField ? this.searchField.getValue() : '';
         config.onlyDirectChildren = this.checkboxOnlyDirectChildren.getValue();
         config.filter = this.filter;
         return config;


### PR DESCRIPTION
When the search field is not present, it's not possible to open the grid options or to make a CSV/XLSX export. 
This is fixed by checking if `searchField` is present. 

<img width="938" alt="image" src="https://github.com/pimcore/admin-ui-classic-bundle/assets/40859521/330d3ade-02f5-4ace-baa0-168479d803f3">
