### PR TITLE
composer.json: use pimcore/pimcore: ^11.3.0-RC1 to still allow 11.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "phpoffice/phpspreadsheet": "^1.24 || ^2.1",
-    "pimcore/pimcore": "^11.3.0",
+    "pimcore/pimcore": "^11.3.0-RC1",
     "symfony/webpack-encore-bundle": "^1.13.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,13 @@
       "*": "dist"
     }
   },
+  "prefer-stable": true,
+  "minimum-stability": "dev",
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "phpoffice/phpspreadsheet": "^1.24 || ^2.1",
-    "pimcore/pimcore": "^11.3.0-RC1",
+    "pimcore/pimcore": "^11.3.0",
     "symfony/webpack-encore-bundle": "^1.13.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "phpoffice/phpspreadsheet": "^1.24 || ^2.1",
-    "pimcore/pimcore": "^11.3.0-RC1",
+    "pimcore/pimcore": "^11.3.0",
     "symfony/webpack-encore-bundle": "^1.13.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "phpoffice/phpspreadsheet": "^1.24 || ^2.1",
-    "pimcore/pimcore": "11.3.0-RC1",
+    "pimcore/pimcore": "^11.3.0-RC1",
     "symfony/webpack-encore-bundle": "^1.13.2"
   },
   "require-dev": {


### PR DESCRIPTION
When having a fixed contraint to `11.3.0-RC1` it blocks all "newer" branches and tags to install, such as `11.x`-dev. 