### PR TITLE
Fix: Usage of explode() on an empty string

### DIFF
--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -757,7 +757,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     {
         $domains = $request->get('domains');
         $domains = str_replace(' ', '', $domains);
-        $domains = explode("\n", $domains);
+        $domains = $domains ? explode("\n", $domains) : [];
 
         if (!$site = Site::getByRootId((int)$request->get('id'))) {
             $site = Site::create([

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -755,7 +755,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
      */
     public function updateSiteAction(Request $request): JsonResponse
     {
-        $domains = $request->request->get('domains', '');
+        $domains = $request->request->getString('domains');
         $domains = str_replace(' ', '', $domains);
         $domains = $domains ? explode("\n", $domains) : [];
 
@@ -778,8 +778,8 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
 
         $site->setDomains($domains);
-        $site->setMainDomain($request->request->get('mainDomain', ''));
-        $site->setErrorDocument($request->request->get('errorDocument', ''));
+        $site->setMainDomain($request->request->getString('mainDomain'));
+        $site->setErrorDocument($request->request->getString('errorDocument'));
         $site->setLocalizedErrorDocuments($localizedErrorDocuments);
         $site->setRedirectToMainDomain($request->request->getBoolean('redirectToMainDomain'));
         $site->save();

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -755,13 +755,13 @@ class DocumentController extends ElementControllerBase implements KernelControll
      */
     public function updateSiteAction(Request $request): JsonResponse
     {
-        $domains = $request->get('domains');
+        $domains = $request->request->get('domains', '');
         $domains = str_replace(' ', '', $domains);
         $domains = $domains ? explode("\n", $domains) : [];
 
-        if (!$site = Site::getByRootId((int)$request->get('id'))) {
+        if (!$site = Site::getByRootId($request->request->getInt('id'))) {
             $site = Site::create([
-                'rootId' => (int)$request->get('id'),
+                'rootId' => $request->request->getInt('id'),
             ]);
         }
 
@@ -770,7 +770,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
         foreach ($validLanguages as $language) {
             // localized error pages
-            $requestValue = $request->get('errorDocument_localized_' . $language);
+            $requestValue = $request->request->get('errorDocument_localized_' . $language);
 
             if (isset($requestValue)) {
                 $localizedErrorDocuments[$language] = $requestValue;
@@ -778,10 +778,10 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
 
         $site->setDomains($domains);
-        $site->setMainDomain($request->get('mainDomain'));
-        $site->setErrorDocument($request->get('errorDocument'));
+        $site->setMainDomain($request->request->get('mainDomain', ''));
+        $site->setErrorDocument($request->request->get('errorDocument', ''));
         $site->setLocalizedErrorDocuments($localizedErrorDocuments);
-        $site->setRedirectToMainDomain(($request->get('redirectToMainDomain') == 'true') ? true : false);
+        $site->setRedirectToMainDomain($request->request->getBoolean('redirectToMainDomain'));
         $site->save();
 
         $site->setRootDocument(null); // do not send the document to the frontend


### PR DESCRIPTION
See https://github.com/pimcore/pimcore/pull/17221

Line 760 creates an array `['']` but should be `[]` when the additional domains textarea was empty.