### PR TITLE
Fix date format parsing in scheduler when localized date format is enabled

### DIFF
--- a/public/js/pimcore/element/scheduler.js
+++ b/public/js/pimcore/element/scheduler.js
@@ -311,12 +311,13 @@ pimcore.element.scheduler = Class.create({
         var value;
         for (var i = 0; i < data.length; i++) {
             let dateString = data[i].data.date;
+            debugger;
             if(data[i].data.time !== undefined) {
                 dateString += " " +  data[i].data.time;
             } else {
                 dateString += " 00:00";
             }
-            let dateTime = new Date(dateString);
+            let dateTime = Ext.Date.parseDate(dateString, pimcore.globalmanager.get('localeDateTime').getShortDateTimeFormat());
             value = {
                 date:  Math.floor(dateTime / 1000),
                 action: data[i].data.action,

--- a/public/js/pimcore/element/scheduler.js
+++ b/public/js/pimcore/element/scheduler.js
@@ -311,7 +311,6 @@ pimcore.element.scheduler = Class.create({
         var value;
         for (var i = 0; i < data.length; i++) {
             let dateString = data[i].data.date;
-            debugger;
             if(data[i].data.time !== undefined) {
                 dateString += " " +  data[i].data.time;
             } else {


### PR DESCRIPTION
This is a follow-up to #554.

It was not possible to save scheduled entries when the configured date format was not parseable by the `new Date(dateString)` constructor. Therefore the date is now parsed with the explicitly configured date format.