### PR TITLE
Respect user timezone for creation/modification dates in version previews

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -61,6 +61,8 @@ use Symfony\Component\Process\Process;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
+use Twig\Extension\CoreExtension;
 
 /**
  * @Route("/asset")
@@ -918,7 +920,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     /**
      * @Route("/show-version", name="pimcore_admin_asset_showversion", methods={"GET"})
      */
-    public function showVersionAction(Request $request): Response
+    public function showVersionAction(Request $request, Environment $twig): Response
     {
         $id = (int)$request->get('id');
         $version = Model\Version::getById($id);
@@ -939,6 +941,10 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
 
         Tool\UserTimezone::setUserTimezone($request->query->get('userTimezone'));
+
+        if ($timezone = Tool\UserTimezone::getUserTimezone()) {
+            $twig->getExtension(CoreExtension::class)->setTimezone($timezone);
+        }
 
         $loader = \Pimcore::getContainer()->get('pimcore.implementation_loader.asset.metadata.data');
 

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -50,6 +50,8 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+use Twig\Extension\CoreExtension;
 
 /**
  * @Route("/object", name="pimcore_admin_dataobject_dataobject_")
@@ -1587,7 +1589,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
      *
      * @throws \Exception
      */
-    public function previewVersionAction(Request $request): Response
+    public function previewVersionAction(Request $request, Environment $twig): Response
     {
         DataObject::setDoNotRestoreKeyAndPath(true);
 
@@ -1598,6 +1600,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         if ($object) {
 
             Tool\UserTimezone::setUserTimezone($request->query->get('userTimezone'));
+
+            if ($timezone = Tool\UserTimezone::getUserTimezone()) {
+                $twig->getExtension(CoreExtension::class)->setTimezone($timezone);
+            }
 
             if (method_exists($object, 'getLocalizedFields')) {
                 /** @var DataObject\Localizedfield $localizedFields */
@@ -1627,7 +1633,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
      *
      * @throws \Exception
      */
-    public function diffVersionsAction(Request $request, int $from, int $to): Response
+    public function diffVersionsAction(Request $request, Environment $twig, int $from, int $to): Response
     {
         DataObject::setDoNotRestoreKeyAndPath(true);
 
@@ -1655,6 +1661,10 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
 
         Tool\UserTimezone::setUserTimezone($request->query->get('userTimezone'));
+
+        if ($timezone = Tool\UserTimezone::getUserTimezone()) {
+            $twig->getExtension(CoreExtension::class)->setTimezone($timezone);
+        }
 
         if (method_exists($object2, 'getLocalizedFields')) {
             /** @var DataObject\Localizedfield $localizedFields2 */


### PR DESCRIPTION
The version previews and comparisons didn't respect the user timezone:

![image](https://github.com/pimcore/admin-ui-classic-bundle/assets/4639428/b0a49c06-b551-4338-b533-6e4463d99156)

