### PR TITLE
Change pimcore/pimcore requirements to allow future core versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "phpoffice/phpspreadsheet": "^1.24 || ^2.1",
-    "pimcore/pimcore": ^11.3.0",
+    "pimcore/pimcore": "^11.3.0",
     "symfony/webpack-encore-bundle": "^1.13.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "cbschuld/browser.php": "^1.9.6",
     "phpoffice/phpspreadsheet": "^1.24 || ^2.1",
-    "pimcore/pimcore": "~11.3.0",
+    "pimcore/pimcore": ^11.3.0",
     "symfony/webpack-encore-bundle": "^1.13.2"
   },
   "require-dev": {


### PR DESCRIPTION
For the test setups of several bundles and Pimcore demos we need to revert this change now as the releases are done:

https://github.com/pimcore/admin-ui-classic-bundle/pull/600