### PR TITLE
[Bug]: Fix Master Admin mode does not work for Field collection 

### DIFF
--- a/public/js/pimcore/object/tags/fieldcollections.js
+++ b/public/js/pimcore/object/tags/fieldcollections.js
@@ -64,12 +64,9 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
             allowedTypes: allowedTypes.join(","),
             object_id: this.object.id,
             field_name: this.fieldConfig.name,
+            layoutId: this.object.data.currentLayoutId,
             forObjectEditor: 1
         };
-
-        if (typeof this.fieldConfig.layoutId !== "undefined") {
-            extraParams.layoutId = this.fieldConfig.layoutId;
-        }
 
         Ext.Ajax.request({
             url: Routing.generate('pimcore_admin_dataobject_class_fieldcollectiontree'),


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/11721

Making it consistent with object bricks which works fine see https://github.com/pimcore/admin-ui-classic-bundle/blob/1.5/public/js/pimcore/object/tags/objectbricks.js#L52