### PR TITLE
correctly dispatch pre set metadata event

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -2330,6 +2330,12 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     }
 
                     if ($dirty) {
+                        $metadataEvent = new GenericEvent($this, [
+                            'id' => $asset->getId(),
+                            'metadata' => $metadata,
+                        ]);
+                        $eventDispatcher->dispatch($metadataEvent, AdminEvents::ASSET_METADATA_PRE_SET);
+                        
                         // $metadata = Asset\Service::minimizeMetadata($metadata, "grid");
                         $asset->setMetadataRaw($metadata);
                         $asset->save();

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -1054,6 +1054,12 @@ class AssetHelperController extends AdminAbstractController
 
                     try {
                         if ($dirty) {
+                            $metadataEvent = new GenericEvent($this, [
+                                'id' => $asset->getId(),
+                                'metadata' => $metadata,
+                            ]);
+                            $eventDispatcher->dispatch($metadataEvent, AdminEvents::ASSET_METADATA_PRE_SET);
+                            
                             // $metadata = Asset\Service::minimizeMetadata($metadata, "grid");
                             $asset->setMetadataRaw($metadata);
                             $asset->save();


### PR DESCRIPTION
Currently the pre set metadata event is only dispatched on a asset save (AssetController::saveAction) but not on grid edits (AssetController:gridProxyAction) or batch (AssetHelperController::batchAction)