### PR TITLE
[Improvement]: Add download button for a asset relation

### DIFF
--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -286,7 +286,7 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
 
         this.composite = Ext.create('Ext.form.FieldContainer', compositeCfg);
 
-        if (this.fieldConfig.assetsAllowed && this.name.endsWith('DataSheet')) {
+        if (this.fieldConfig.assetInlineDownloadAllowed) {
             this.composite.remove(
                 this.composite.items.getAt(4)
             );

--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -286,6 +286,22 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
 
         this.composite = Ext.create('Ext.form.FieldContainer', compositeCfg);
 
+        if (this.fieldConfig.assetsAllowed && this.name.endsWith('DataSheet')) {
+            this.composite.remove(
+                this.composite.items.getAt(4)
+            );
+
+            this.composite.add({
+                xtype: "button",
+                iconCls: "pimcore_icon_download",
+                cls: "pimcore_inline_download",
+                style: "margin-left: 5px",
+                handler: function () {
+                    pimcore.helpers.download(Routing.generate('pimcore_admin_asset_download', {id: this.data.id}));
+                }.bind(this)
+            });
+        }
+
         return this.composite;
     },
 


### PR DESCRIPTION
## Changes in this pull request  

A small feature to download assets faster. A download button is added to a ManyToOneRelation. This button appears, but only if the setting `allow inline download` is activated in the class definition. 

## Additional info

With this function you have the possibility to download the assets faster instead of opening or searching the asset first and then clicking on download.

![image](https://github.com/user-attachments/assets/fdaed202-fd33-4153-983a-7e3806c82bc1)
![image](https://github.com/user-attachments/assets/cd0b0bae-2c53-4c4d-b3d2-143c67e432c0)

