### PR TITLE
fix: search for e-mails does not break with a leading at-sign

### DIFF
--- a/src/Controller/Admin/EmailController.php
+++ b/src/Controller/Admin/EmailController.php
@@ -76,6 +76,10 @@ class EmailController extends AdminAbstractController
                 $filterTerm = implode(' ', $parts);
             }
 
+            if (str_starts_with($filterTerm, '@')) {
+                $filterTerm = str_replace('@', '', $filterTerm);
+            }
+
             $condition = '( MATCH (`from`,`to`,`cc`,`bcc`,`subject`,`params`) AGAINST (' . $list->quote($filterTerm) . ' IN BOOLEAN MODE) )';
 
             if ($request->get('documentId')) {


### PR DESCRIPTION
the (email) search throws an error when searching with a leading at-sign (@)
see pimcore-demo:
![CleanShot 2024-07-17 at 09 21 49@2x](https://github.com/user-attachments/assets/fe586aae-5a43-4893-8acf-19645e3f4021)

this fixes it (removes the @ character, which should return results with the given domain).