### PR TITLE
Data Object: Version preview fix for localized values inside field collections

### DIFF
--- a/templates/admin/data_object/data_object/preview_version.html.twig
+++ b/templates/admin/data_object/data_object/preview_version.html.twig
@@ -160,7 +160,7 @@
                                     <tr {% if loop.index is odd %}class="odd"{% endif %}>
                                         <td>{{ lfd.getTitle()|trans([],'admin') }} ({{ language }})</td>
                                         <td>{{ fieldItem.fieldName }} - {{ lfd.getName() }}/{{ language }}</td>
-                                        <td>{{ fieldItem.Localizedfields.getLocalizedValue(lfd.getName(), language) }}</td>
+                                        <td>{{ lfd.getVersionPreview(fieldItem.Localizedfields.getLocalizedValue(lfd.getName(), language)) | raw }}</td>
                                     </tr>
                                 {% endfor %}
                             {% endfor %}


### PR DESCRIPTION
Localized values inside field collections should also use `getVersionPreview()` and WYSIWYG content should be rendered properly. 

Related to https://github.com/pimcore/pimcore/pull/17365 