### PR TITLE
[Task]: Optmize tags treeGetChildrenByIdAction

### DIFF
--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -154,12 +154,14 @@ class TagsController extends AdminAbstractController
 
     protected function convertTagToArray(Tag $tag, bool $showSelection, array $assignedTagIds, bool $loadChildren = false, bool $recursiveChildren = false): array
     {
+        $hasChildren = $tag->hasChildren();
+
         $tagArray = [
             'id' => $tag->getId(),
             'text' => $tag->getName(),
             'path' => $tag->getNamePath(),
-            'expandable' => $tag->hasChildren(),
-            'leaf' => !$tag->hasChildren(),
+            'expandable' => $hasChildren,
+            'leaf' => !$hasChildren,
             'iconCls' => 'pimcore_icon_element_tags',
             'qtipCfg' => [
                 'title' => 'ID: ' . $tag->getId(),
@@ -170,7 +172,7 @@ class TagsController extends AdminAbstractController
             $tagArray['checked'] = isset($assignedTagIds[$tag->getId()]);
         }
 
-        if ($loadChildren) {
+        if ($hasChildren && $loadChildren) {
             $children = $tag->getChildren();
             $loadChildren = $recursiveChildren;
             foreach ($children as $child) {


### PR DESCRIPTION
Related https://github.com/pimcore/admin-ui-classic-bundle/issues/627

Slightly reduce (at least by 2) how many times will be querying the entire tags listing multiple times via `hasChildren` and `getChildren` when no children are there, see also
https://github.com/pimcore/pimcore/blob/e74e2b4be10bb7abf75f0c95f3591e509f40b273/models/Element/Tag.php#L293-L297
https://github.com/pimcore/pimcore/blob/e74e2b4be10bb7abf75f0c95f3591e509f40b273/models/Element/Tag.php#L320-L323
