### PR TITLE
[PIMCORE-17387] Fix bug with reorder of localized fields in class

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,6 +18,12 @@ services:
         public: true
         tags: ['controller.service_arguments']
 
+    Pimcore\Bundle\AdminBundle\Controller\Admin\IndexController:
+        public: true
+        arguments:
+            $httpClient: '@pimcore.http_client'
+        tags: [ 'controller.service_arguments' ]
+
     #
     # COMMANDS
     #

--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -246,6 +246,19 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                 }
 
                 if (this.toolbarButtons.save && this.toolbarButtons.publish) {
+                    if (this.isAllowed("save")) {
+                        const menuItem = this.toolbarButtons.publish.menu.items.items.find(
+                            element => element.text === t('save_draft')
+                        )
+                        menuItem.setHidden(false)
+                    }
+                    if (this.isAllowed("settings")) {
+                        const menuItem = this.toolbarButtons.publish.menu.items.items.find(
+                            element => element.text === t('save_only_scheduled_tasks')
+                        )
+                        menuItem.setHidden(false)
+                    }
+
                     this.toolbarButtons.publish.show();
                 }
 

--- a/public/js/pimcore/document/page_snippet.js
+++ b/public/js/pimcore/document/page_snippet.js
@@ -38,8 +38,8 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
             height: 49,
         });
 
-        const tabPanel = this.getTabPanel();
         const toolbar = this.getLayoutToolbar();
+        const tabPanel = this.getTabPanel();
 
         if (pimcore.helpers.checkIfNewHeadbarLayoutIsEnabled()) {
             this.tab = new Ext.Panel({

--- a/public/js/pimcore/object/helpers/layout.js
+++ b/public/js/pimcore/object/helpers/layout.js
@@ -34,7 +34,7 @@ pimcore.object.helpers.layout = {
             button: [],
             text: [],
             root: ["panel", "region", "tabpanel", "accordion", "text", "iframe", "button", "fieldcontainer", "fieldset"],
-            localizedfields: ["panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"],
+            localizedfields: ["data", "panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"],
             block: ["panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"]
         };
     },

--- a/public/js/pimcore/startup.js
+++ b/public/js/pimcore/startup.js
@@ -562,19 +562,21 @@ Ext.onReady(function () {
                     request.open('GET', Routing.generate('pimcore_admin_index_statistics'));
                     request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
 
-                    request.onload = function () {
-                        if (this.status >= 200 && this.status < 400) {
-                            var res = Ext.decode(this.response);
+                    if (pimcore.currentuser.admin) {
+                        request.onload = function () {
+                            if (this.status >= 200 && this.status < 400) {
+                                var res = Ext.decode(this.response);
 
-                            var request = new XMLHttpRequest();
-                            request.open('POST', "https://liveupdate.pimcore.org/statistics");
+                                var request = new XMLHttpRequest();
+                                request.open('POST', "https://liveupdate.pimcore.org/statistics");
 
-                            var data = new FormData();
-                            data.append('data', encodeURIComponent(JSON.stringify(res)));
+                                var data = new FormData();
+                                data.append('data', encodeURIComponent(JSON.stringify(res)));
 
-                            request.send(data);
-                        }
-                    };
+                                request.send(data);
+                            }
+                        };
+                    }
                     request.send(data);
                 }
             }

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -542,7 +542,7 @@ class ElementController extends AdminAbstractController
             $idProperty = $request->get('idProperty', 'id');
             $methodName = 'get' . ucfirst($fieldname);
             if ($ownerType == 'object' && method_exists($source, $methodName)) {
-                $data = $source->$methodName();
+                $data = DataObject\Service::useInheritedValues(true, [$source, $methodName]);
                 $editModeData = $fd->getDataForEditmode($data, $source);
                 // Inherited values show as an empty array
                 if (is_array($editModeData) && !empty($editModeData)) {


### PR DESCRIPTION
[#17387](https://github.com/pimcore/pimcore/issues/17387)

Due to last changes in the file `public/js/pimcore/helpers.js` at line 3369 was added method is ComponentAsChildAllowed. This method return false for localizedfields because fields types were not included in `public/js/pimcore/object/helplers/layout.js` in getRawAllowedTypes method. So I overwrited localizedfields key with 'data' type. After this changes localizedfields works correctly.