### PR TITLE
[PIMCORE-17387] Fix bug with reorder of localized fields in class

### DIFF
--- a/public/js/pimcore/object/helpers/layout.js
+++ b/public/js/pimcore/object/helpers/layout.js
@@ -34,7 +34,7 @@ pimcore.object.helpers.layout = {
             button: [],
             text: [],
             root: ["panel", "region", "tabpanel", "accordion", "text", "iframe", "button", "fieldcontainer", "fieldset"],
-            localizedfields: ["panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"],
+            localizedfields: ["data", "panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"],
             block: ["panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"]
         };
     },

--- a/public/js/pimcore/object/helpers/layout.js
+++ b/public/js/pimcore/object/helpers/layout.js
@@ -35,7 +35,7 @@ pimcore.object.helpers.layout = {
             text: [],
             root: ["panel", "region", "tabpanel", "accordion", "text", "iframe", "button", "fieldcontainer", "fieldset"],
             localizedfields: ["data", "panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"],
-            block: ["panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"]
+            block: ["data", "panel", "tabpanel", "accordion", "fieldset", "fieldcontainer", "text", "region", "button", "iframe"]
         };
     },
 


### PR DESCRIPTION
[#17387](https://github.com/pimcore/pimcore/issues/17387)

Due to last changes in the file `public/js/pimcore/helpers.js` at line 3369 was added method is ComponentAsChildAllowed. This method return false for localizedfields because fields types were not included in `public/js/pimcore/object/helplers/layout.js` in getRawAllowedTypes method. So I overwrited localizedfields key with 'data' type. After this changes localizedfields works correctly.