### PR TITLE
Fix ManyToOne relation width with combo display mode

### DIFF
--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -206,7 +206,11 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             }.bind(this));
         }.bind(this));
         this.component.on('afterrender', function (el) {
-            el.inputEl.setWidth(href.width);
+            if (pimcore.helpers.hasSearchImplementation() && this.fieldConfig.displayMode === 'combo') {
+                el.inputEl.setWidth(href.width - 34);
+            } else {
+                el.inputEl.setWidth(href.width);
+            }
             el.inputEl.setStyle({
                 'overflow': 'hidden'
             });

--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -171,6 +171,12 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             href.cls = 'pimcore_droptarget_display_edit';
             href.fieldBodyCls = 'pimcore_droptarget_display x-form-trigger-wrap';
             this.component = new Ext.form.field.Display(href);
+            this.component.on('afterrender', function (el) {
+                el.inputEl.setWidth(href.width);
+                el.inputEl.setStyle({
+                    'overflow': 'hidden'
+                });
+            });
         }
 
         if (this.data.published === false) {
@@ -205,16 +211,6 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
                 pimcore.helpers.openElement(this.data.id, this.data.type, subtype);
             }.bind(this));
         }.bind(this));
-        this.component.on('afterrender', function (el) {
-            if (pimcore.helpers.hasSearchImplementation() && this.fieldConfig.displayMode === 'combo') {
-                el.inputEl.setWidth(href.width - 34);
-            } else {
-                el.inputEl.setWidth(href.width);
-            }
-            el.inputEl.setStyle({
-                'overflow': 'hidden'
-            });
-        });
 
         var items = [this.component, {
             xtype: "button",


### PR DESCRIPTION
Followup to https://github.com/pimcore/admin-ui-classic-bundle/commit/946778db2ecf0334d3696cbddd7ef652b8fc2c4a

The combo box only opens via the arrow, which is difficult to click on as it is half hidden.

Before:
![image](https://github.com/user-attachments/assets/5816faf3-be89-4480-bf6d-be3bcdf66e5b)

After:
![image](https://github.com/user-attachments/assets/57bde10d-14a5-4782-b119-aa86283a4e4b)
