### PR TITLE
Add force parameter to retrieve object directly from database

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -293,7 +293,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function getAction(Request $request, EventDispatcherInterface $eventDispatcher, PreviewGeneratorInterface $defaultPreviewGenerator): JsonResponse
     {
         $objectId = $request->query->getInt('id');
-        $objectFromDatabase = DataObject\Concrete::getById($objectId);
+        $objectFromDatabase = DataObject\Concrete::getById($objectId, ['force' => true]);
         if ($objectFromDatabase === null) {
             return $this->adminJson(['success' => false, 'message' => 'element_not_found'], JsonResponse::HTTP_NOT_FOUND);
         }


### PR DESCRIPTION
The object from the database should be retrieved using the force parameter. Currently, it can be fetched from the cache, which may result in outdated (cached) data.
We encountered a bug where the system returns a draft version of objects instead of the latest saved version. This happens because $objectFromDatabase is compared to a cached previous version, not the actual version from the database. 
Adding the force parameter ensures the object is fetched directly from the database.
![image](https://github.com/user-attachments/assets/b1d0f9a1-8f42-4f59-8d06-9202cf3da855)
