### PR TITLE
[Improvement] Trigger an event before TinyMCE uses the final config for better extendibility

### DIFF
--- a/public/js/pimcore/events.js
+++ b/public/js/pimcore/events.js
@@ -253,6 +253,13 @@ pimcore.events.prepareAffectedNodes = "pimcore.treeNode.prepareAffectedNodes";
 pimcore.events.postMenuBuild = "pimcore.menu.postBuild";
 
 /**
+ *  event for manipulating the wysiwyg config
+ *  use it to change the final config that is passed
+ *  the config and the editor context are passed as parameters
+ */
+pimcore.events.createWysiwygConfig = "pimcore.wysiwyg.createConfig";
+
+/**
  *  start event for the editor to create the config
  *  config and context are passed as parameters
  */


### PR DESCRIPTION
See the [main PR](https://github.com/pimcore/pimcore/pull/17436).