### PR TITLE
Add missing label defaults to numeric control

### DIFF
--- a/public/js/pimcore/object/tags/numeric.js
+++ b/public/js/pimcore/object/tags/numeric.js
@@ -75,7 +75,9 @@ pimcore.object.tags.numeric = Class.create(pimcore.object.tags.abstract, {
             fieldLabel: this.fieldConfig.title,
             name: this.fieldConfig.name,
             componentCls: this.getWrapperClassNames(),
-            mouseWheelEnabled: false
+            mouseWheelEnabled: false,
+            labelWidth: 100,
+            labelAlign: "left"
         };
 
         if (!isNaN(this.data)) {


### PR DESCRIPTION
Without this 0 and missing values lead to invalid CSS. These changes are consistent with input.js
e.g. you get a css width of `calc(80px + undefined)` if the labelWidth in parent is 0 or not specified.