### PR TITLE
Bugfix: support drag & drop for custom field types

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -3379,7 +3379,7 @@ pimcore.helpers.treeDragDropValidate = function (node, oldParent, newParent) {
 pimcore.helpers.isComponentAsChildAllowed = function (parentNode, childNode) {
     const parentType = parentNode.data.editor.type;
     const childType = childNode.data.editor.type;
-    const allowedChildren = pimcore.object.helpers.layout.getRawAllowedTypes();
+    const allowedChildren = pimcore.object.helpers.layout.getAllowedTypes();
 
     if (allowedChildren[parentType] &&
         allowedChildren[parentType].includes(childType) ||


### PR DESCRIPTION
In https://github.com/pimcore/admin-ui-classic-bundle/blob/7554a0fc3fd89d69e6c90fadf62d3f3edaa03d56/public/js/pimcore/helpers.js#L3382 method `getRawAllowedTypes()` gets used. This only returns Pimcore's built-in field types, see
https://github.com/pimcore/admin-ui-classic-bundle/blob/7554a0fc3fd89d69e6c90fadf62d3f3edaa03d56/public/js/pimcore/object/helpers/layout.js#L26-L40

But if the application adds custom field types via `prepareClassLayoutContextMenu` event, the custom field type will be addable because in https://github.com/pimcore/admin-ui-classic-bundle/blob/7554a0fc3fd89d69e6c90fadf62d3f3edaa03d56/public/js/pimcore/object/classes/class.js#L356 `getAllowedTypes()` gets used but it is not possible to drag & drop custom fields because https://github.com/pimcore/admin-ui-classic-bundle/blob/7554a0fc3fd89d69e6c90fadf62d3f3edaa03d56/public/js/pimcore/helpers.js#L3379-L3392 returns `false` when dropping the custom field.