### PR TITLE
[Bug]: Fix print document save error

### DIFF
--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -250,13 +250,13 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                         const menuItem = this.toolbarButtons.publish.menu.items.items.find(
                             element => element.text === t('save_draft')
                         )
-                        menuItem.setHidden(false)
+                        menuItem?.setHidden(false)
                     }
                     if (this.isAllowed("settings")) {
                         const menuItem = this.toolbarButtons.publish.menu.items.items.find(
                             element => element.text === t('save_only_scheduled_tasks')
                         )
-                        menuItem.setHidden(false)
+                        menuItem?.setHidden(false)
                     }
 
                     this.toolbarButtons.publish.show();


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/652
Regression https://github.com/pimcore/admin-ui-classic-bundle/pull/622

A [console.log(e)](https://github.com/pimcore/admin-ui-classic-bundle/blob/7cad2aa699dc350fcdb1d31161adc3661dab91af/public/js/pimcore/document/document.js#L174) here revelead that not every document type has these buttons and could be caught by `try` block and display a false negative save notifcation. The save should be considered successful, so no data loss.

![image](https://github.com/user-attachments/assets/1c9a5208-ad94-41f7-9159-41071da8468e)
