### PR TITLE
Bugfix - Sharing grids to users

### DIFF
--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -604,7 +604,7 @@ class AssetHelperController extends AdminAbstractController
             $sharedUserIds = $metadata['sharedUserIds'];
 
             if ($sharedUserIds) {
-                $sharedUsers = explode(',', $sharedUserIds);
+                $sharedUsers = array_map('intval', explode(',', $sharedUserIds));
             }
         }
 
@@ -620,7 +620,7 @@ class AssetHelperController extends AdminAbstractController
         foreach ($sharedUsers as $id) {
             // Check if the user has already a favourite
             $favourite = GridConfigFavourite::getByOwnerAndClassAndObjectId(
-                (int) $id,
+                $id,
                 $gridConfig->getClassId(),
                 0,
                 $gridConfig->getSearchType()
@@ -636,7 +636,7 @@ class AssetHelperController extends AdminAbstractController
                     }
 
                     // Check if the user is the owner. If that is the case we do not update the favourite
-                    if ((int) $favouriteGridConfig->getOwnerId() === (int) $id) {
+                    if ((int) $favouriteGridConfig->getOwnerId() === $id) {
                         continue;
                     }
                 }

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -636,7 +636,7 @@ class AssetHelperController extends AdminAbstractController
                     }
 
                     // Check if the user is the owner. If that is the case we do not update the favourite
-                    if ((int) $favouriteGridConfig->getOwnerId() === $id) {
+                    if ($favouriteGridConfig->getOwnerId() === $id) {
                         continue;
                     }
                 }

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1042,7 +1042,7 @@ class DataObjectHelperController extends AdminAbstractController
             $favourite->setGridConfigId($gridConfig->getId());
             $favourite->setClassId($gridConfig->getClassId());
             $favourite->setObjectId($objectId);
-            $favourite->setOwnerId($id);
+            $favourite->setOwnerId((int) $id);
             $favourite->setType($gridConfig->getType());
             $favourite->setSearchType($gridConfig->getSearchType());
             $favourite->save();

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -975,7 +975,7 @@ class DataObjectHelperController extends AdminAbstractController
             $sharedUserIds = $metadata['sharedUserIds'];
 
             if ($sharedUserIds) {
-                $sharedUsers = explode(',', $sharedUserIds);
+                $sharedUsers = array_map('intval', explode(',', $sharedUserIds));
             }
         }
 
@@ -991,7 +991,7 @@ class DataObjectHelperController extends AdminAbstractController
         foreach ($sharedUsers as $id) {
             $global    = true;
             $favourite = GridConfigFavourite::getByOwnerAndClassAndObjectId(
-                (int) $id,
+                $id,
                 $gridConfig->getClassId(),
                 $objectId,
                 $gridConfig->getSearchType()
@@ -1008,7 +1008,7 @@ class DataObjectHelperController extends AdminAbstractController
                     }
 
                     // Check if the user is the owner. If that is the case we do not update the favourite
-                    if ((int) $favouriteGridConfig->getOwnerId() === (int) $id) {
+                    if ((int) $favouriteGridConfig->getOwnerId() === $id) {
                         continue;
                     }
                 }
@@ -1016,7 +1016,7 @@ class DataObjectHelperController extends AdminAbstractController
 
             // Check if the user has already a global favourite then we do not save the favourite as global
             $favourite = GridConfigFavourite::getByOwnerAndClassAndObjectId(
-                (int) $id,
+                $id,
                 $gridConfig->getClassId(),
                 0,
                 $gridConfig->getSearchType()
@@ -1032,7 +1032,7 @@ class DataObjectHelperController extends AdminAbstractController
                     }
 
                     // Check if the user is the owner. If that is the case we do not update the global favourite
-                    if ($favouriteGridConfig->getOwnerId() === (int) $id) {
+                    if ($favouriteGridConfig->getOwnerId() === $id) {
                         $global = false;
                     }
                 }
@@ -1042,7 +1042,7 @@ class DataObjectHelperController extends AdminAbstractController
             $favourite->setGridConfigId($gridConfig->getId());
             $favourite->setClassId($gridConfig->getClassId());
             $favourite->setObjectId($objectId);
-            $favourite->setOwnerId((int) $id);
+            $favourite->setOwnerId($id);
             $favourite->setType($gridConfig->getType());
             $favourite->setSearchType($gridConfig->getSearchType());
             $favourite->save();

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1008,7 +1008,7 @@ class DataObjectHelperController extends AdminAbstractController
                     }
 
                     // Check if the user is the owner. If that is the case we do not update the favourite
-                    if ((int) $favouriteGridConfig->getOwnerId() === $id) {
+                    if ($favouriteGridConfig->getOwnerId() === $id) {
                         continue;
                     }
                 }


### PR DESCRIPTION
Bugfix for sharing grid configs to other users and setting as favourite.

Can be replicated on `demo.pimcore.fun`. Steps to recreate:
1. Create grid config, and navigate to 'Save & Share'.
2. Add users. Check set as favourite. Do not set 'Share globally'.
3. Save & Share
