### PR TITLE
Publish for documents "failed"

### DIFF
--- a/public/js/pimcore/document/document.js
+++ b/public/js/pimcore/document/document.js
@@ -250,13 +250,17 @@ pimcore.document.document = Class.create(pimcore.element.abstract, {
                         const menuItem = this.toolbarButtons.publish.menu.items.items.find(
                             element => element.text === t('save_draft')
                         )
-                        menuItem.setHidden(false)
+                        if (menuItem) {
+                            menuItem.setHidden(false)
+                        }
                     }
                     if (this.isAllowed("settings")) {
                         const menuItem = this.toolbarButtons.publish.menu.items.items.find(
                             element => element.text === t('save_only_scheduled_tasks')
                         )
-                        menuItem.setHidden(false)
+                        if (menuItem) {
+                            menuItem.setHidden(false)
+                        }
                     }
 
                     this.toolbarButtons.publish.show();


### PR DESCRIPTION
If menuItem is null setHidden will fail and only the error message "saving_failed" will be shown.