### PR TITLE
[Bug, EC]: Saving a grid view makes read-only columns visually editable

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -360,12 +360,9 @@ class DataObjectHelperController extends AdminAbstractController
                             'key' => $key,
                             'type' => 'system',
                             'label' => $key,
-                            'locked' => $sc['locked'] ?? null,
                             'position' => $sc['position'],
                         ];
-                        if (isset($sc['width'])) {
-                            $colConfig['width'] = $sc['width'];
-                        }
+                        $this->injectCustomLayoutValues($colConfig, $sc);
                         $availableFields[] = $colConfig;
                     } else {
                         $keyParts = explode('~', $key);
@@ -387,9 +384,7 @@ class DataObjectHelperController extends AdminAbstractController
                                         if ($fieldConfig) {
                                             $fieldConfig['key'] = $key;
                                             $fieldConfig['label'] = '#' . $keyFieldDef->getTitle();
-                                            if (isset($sc['locked'])) {
-                                                $fieldConfig['locked'] = $sc['locked'];
-                                            }
+                                            $fieldConfig = $this->injectCustomLayoutValues($fieldConfig, $sc);
                                             $availableFields[] = $fieldConfig;
                                         }
                                     }
@@ -427,12 +422,7 @@ class DataObjectHelperController extends AdminAbstractController
                             if ($fd !== null) {
                                 $fieldConfig = $this->getFieldGridConfig($fd, $gridType, (string)$sc['position'], true, $keyPrefix, $class, $objectId);
                                 if (!empty($fieldConfig)) {
-                                    if (isset($sc['width'])) {
-                                        $fieldConfig['width'] = $sc['width'];
-                                    }
-                                    if (isset($sc['locked'])) {
-                                        $fieldConfig['locked'] = $sc['locked'];
-                                    }
+                                    $fieldConfig = $this->injectCustomLayoutValues($fieldConfig, $sc);
                                     $availableFields[] = $fieldConfig;
                                 }
                             }
@@ -457,12 +447,7 @@ class DataObjectHelperController extends AdminAbstractController
                                 if (!empty($fd)) {
                                     $fieldConfig = $this->getFieldGridConfig($fd, $gridType, (string)$sc['position'], true, null, $class, $objectId);
                                     if (!empty($fieldConfig)) {
-                                        if (isset($sc['width'])) {
-                                            $fieldConfig['width'] = $sc['width'];
-                                        }
-                                        if (isset($sc['locked'])) {
-                                            $fieldConfig['locked'] = $sc['locked'];
-                                        }
+                                        $fieldConfig = $this->injectCustomLayoutValues($fieldConfig, $sc);
                                         $availableFields[] = $fieldConfig;
                                     }
                                 }
@@ -528,6 +513,26 @@ class DataObjectHelperController extends AdminAbstractController
             'searchFilter' => $gridConfig['searchFilter'] ?? '',
             'filter' => $gridConfig['filter'] ?? [],
         ];
+    }
+
+    private function injectCustomLayoutValues(array $fieldConfig, array $savedColumn): array
+    {
+        $keys = ['width', 'locked'];
+        foreach ($keys as $key){
+            if (isset($savedColumn[$key])) {
+                $fieldConfig[$key] = $savedColumn[$key];
+            }
+        }
+
+        $fieldConfigKeys = ['noteditable'];
+        foreach ($fieldConfigKeys as $fieldConfigKey){
+            if (isset($savedColumn['fieldConfig']['layout'][$fieldConfigKey])) {
+                $setter = 'set' . ucfirst($fieldConfigKey);
+                $fieldConfig['layout']->$setter($savedColumn['fieldConfig']['layout'][$fieldConfigKey]);
+            }
+        }
+
+        return $fieldConfig;
     }
 
     /**

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -518,14 +518,14 @@ class DataObjectHelperController extends AdminAbstractController
     private function injectCustomLayoutValues(array $fieldConfig, array $savedColumn): array
     {
         $keys = ['width', 'locked'];
-        foreach ($keys as $key){
+        foreach ($keys as $key) {
             if (isset($savedColumn[$key])) {
                 $fieldConfig[$key] = $savedColumn[$key];
             }
         }
 
         $fieldConfigKeys = ['noteditable'];
-        foreach ($fieldConfigKeys as $fieldConfigKey){
+        foreach ($fieldConfigKeys as $fieldConfigKey) {
             if (isset($savedColumn['fieldConfig']['layout'][$fieldConfigKey])) {
                 $setter = 'set' . ucfirst($fieldConfigKey);
                 $fieldConfig['layout']->$setter($savedColumn['fieldConfig']['layout'][$fieldConfigKey]);


### PR DESCRIPTION
Resolves https://pimcore.atlassian.net/browse/PEES-376


Steps to reproduce (from @torqdev ):

- Create demo user, giving on the objects, quantity value units, and select options permissions. Under workspaces, the user has all permissions for the /Product Data/Cars folder.
- Create custom layout on Car DataObject. For instance this one is calledLimitedAccessCarLayout. This layout has a small set of fields, including the carClass select field that is marked not editable.
- Assign this custom layout to be the only available layout for the DemoUser created above.
- Open incognito tab, sign in as DemoUser, navigate to the /Product Data/Cars folder in the DataObjects section.
- The default grid should follow the the assigned custom layout fields and specifications. In this case they do, and we receive a warning.
- Create and save an updated grid config, reload the grid, select the updated grid config.
- Fields are now editable