### PR TITLE
Support frame-anchestors property in CSP headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Date/time fields] Date/time fields now support the usage without timezone support.
 - [Icons] Overhauled Icon library and icon dropdown selector in class definition editor.
 - [System Settings] Removed "Default-Language in Admin-Interface" setting.
+- [Security] Add CSP configuration option `frame-ancestors` (default: `self`).
 
 #### v1.4.0
 - [DataObject] Password data type algorithms other than `password_hash` are deprecated since `pimcore/pimcore:^11.2` and will be removed in `pimcore/pimcore:^12`.

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -410,7 +410,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
             try {
                 $this->getDataForObject($object, $objectFromVersion);
-            } catch(\Throwable $e) {
+            } catch (\Throwable $e) {
                 $object = $objectFromDatabase;
                 $this->getDataForObject($object, false);
             }
@@ -1352,7 +1352,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         if ($request->get('data')) {
             try {
                 $this->applyChanges($object, $this->decodeJson($request->get('data')));
-            } catch(\Throwable $e) {
+            } catch (\Throwable $e) {
                 $this->applyChanges($objectFromDatabase, $this->decodeJson($request->get('data')));
             }
         }

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -317,7 +317,7 @@ class DataObjectHelperController extends AdminAbstractController
                 $setAsFavourite = $savedGridConfig->isSetAsFavourite();
                 $saveFilters = $savedGridConfig->isSaveFilters();
 
-                foreach($gridConfig['columns'] as &$column) {
+                foreach ($gridConfig['columns'] as &$column) {
                     if (array_key_exists('isOperator', $column) && $column['isOperator']) {
                         $colAttributes = &$column['fieldConfig']['attributes'];
                         SecurityHelper::convertHtmlSpecialCharsArrayKeys($colAttributes, ['label', 'attribute', 'param1']);
@@ -1184,7 +1184,7 @@ class DataObjectHelperController extends AdminAbstractController
         //prepare fields
         $fieldnames = [];
         $fields = json_decode($allParams['fields'][0], true);
-        foreach($fields as $field) {
+        foreach ($fields as $field) {
             $fieldnames[] = $field['key'];
         }
         $allParams['fields'] = $fieldnames;

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -703,7 +703,7 @@ class ElementController extends AdminAbstractController
                     'requires' => [],  // Initialize 'requires' as an empty array
                 ];
 
-                if(count($elements) > 0) {
+                if (count($elements) > 0) {
                     $result = Model\Element\Service::getFilterRequiresForFrontend($elements);
                     $result['total'] = count($result['requires']);
 
@@ -765,7 +765,7 @@ class ElementController extends AdminAbstractController
                     'requiredBy' => [], // Initialize 'requiredBy' as an empty array
                 ];
 
-                if(count($elements) > 0) {
+                if (count($elements) > 0) {
                     $result = Model\Element\Service::getFilterRequiredByPathForFrontend($elements);
                     $result['total'] = count($result['requiredBy']);
 

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -129,7 +129,7 @@ class MiscController extends AdminAbstractController
     public function scriptProxyAction(Request $request): Response
     {
         $storageFile = $request->get('storageFile');
-        if(!$storageFile) {
+        if (!$storageFile) {
             throw new \InvalidArgumentException('The parameter storageFile is required');
         }
 

--- a/src/Controller/Admin/TranslationController.php
+++ b/src/Controller/Admin/TranslationController.php
@@ -634,10 +634,10 @@ class TranslationController extends AdminAbstractController
             ];
         }
 
-        if(!empty($conditionFilters)) {
+        if (!empty($conditionFilters)) {
             $conditions = [];
             $params = [];
-            foreach($conditionFilters as $conditionFilter) {
+            foreach ($conditionFilters as $conditionFilter) {
                 $conditions[] = $conditionFilter['condition'];
                 $params[$conditionFilter['field']] = $conditionFilter['value'];
             }

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -699,7 +699,7 @@ class GridHelperService
             if (isset($requestParams['filter_by_object_type'])) {
                 if ($requestParams['filter_by_object_type'] === 'only_objects') {
                     $list->setObjectTypes([DataObject::OBJECT_TYPE_OBJECT]);
-                } elseif($requestParams['filter_by_object_type'] === 'only_variant_objects') {
+                } elseif ($requestParams['filter_by_object_type'] === 'only_variant_objects') {
                     $list->setObjectTypes([DataObject::OBJECT_TYPE_VARIANT]);
                 }
             }

--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -29,9 +29,9 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
     use LoggerAwareTrait;
 
     private ?string $nonce = null;
-    
+
     private const SELF = "'self'";
-    
+
     public const DEFAULT_OPT = 'default-src';
 
     public const IMG_OPT = 'img-src';
@@ -80,14 +80,14 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
         $resolver->setDefaults([
             self::DEFAULT_OPT => self::SELF,
             self::IMG_OPT => '* data: blob:',
-            self::MEDIA_OPT => self::SELF . " data:",
+            self::MEDIA_OPT => self::SELF . ' data:',
             self::SCRIPT_OPT => self::SELF . " 'nonce-" . $this->getNonce() . "' 'unsafe-inline' 'unsafe-eval'",
             self::STYLE_OPT => self::SELF . " 'unsafe-inline'",
-            self::FRAME_OPT => self::SELF . " data:",
+            self::FRAME_OPT => self::SELF . ' data:',
             self::FRAME_ANCHESTORS => self::SELF,
-            self::CONNECT_OPT => self::SELF . " blob:",
+            self::CONNECT_OPT => self::SELF . ' blob:',
             self::FONT_OPT => self::SELF,
-            self::WORKER_OPT => self::SELF . " blob:",
+            self::WORKER_OPT => self::SELF . ' blob:',
         ]);
     }
 

--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -29,7 +29,9 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
     use LoggerAwareTrait;
 
     private ?string $nonce = null;
-
+    
+    private const SELF = "'self'";
+    
     public const DEFAULT_OPT = 'default-src';
 
     public const IMG_OPT = 'img-src';
@@ -76,16 +78,16 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            self::DEFAULT_OPT => "'self'",
+            self::DEFAULT_OPT => self::SELF,
             self::IMG_OPT => '* data: blob:',
-            self::MEDIA_OPT => "'self' data:",
-            self::SCRIPT_OPT => "'self' 'nonce-" . $this->getNonce() . "' 'unsafe-inline' 'unsafe-eval'",
-            self::STYLE_OPT => "'self' 'unsafe-inline'",
-            self::FRAME_OPT => "'self' data:",
-            self::FRAME_ANCHESTORS => "'self'",
-            self::CONNECT_OPT => "'self' blob:",
-            self::FONT_OPT => "'self'",
-            self::WORKER_OPT => "'self' blob:",
+            self::MEDIA_OPT => self::SELF . " data:",
+            self::SCRIPT_OPT => self::SELF . " 'nonce-" . $this->getNonce() . "' 'unsafe-inline' 'unsafe-eval'",
+            self::STYLE_OPT => self::SELF . " 'unsafe-inline'",
+            self::FRAME_OPT => self::SELF . " data:",
+            self::FRAME_ANCHESTORS => self::SELF,
+            self::CONNECT_OPT => self::SELF . " blob:",
+            self::FONT_OPT => self::SELF,
+            self::WORKER_OPT => self::SELF . " blob:",
         ]);
     }
 

--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -46,6 +46,8 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
 
     public const FRAME_OPT = 'frame-src';
 
+    public const FRAME_ANCHESTORS = 'frame-ancestors';
+
     public const WORKER_OPT = 'worker-src';
 
     private array $allowedUrls = [
@@ -80,6 +82,7 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
             self::SCRIPT_OPT => "'self' 'nonce-" . $this->getNonce() . "' 'unsafe-inline' 'unsafe-eval'",
             self::STYLE_OPT => "'self' 'unsafe-inline'",
             self::FRAME_OPT => "'self' data:",
+            self::FRAME_ANCHESTORS => "'self'",
             self::CONNECT_OPT => "'self' blob:",
             self::FONT_OPT => "'self'",
             self::WORKER_OPT => "'self' blob:",

--- a/src/Service/PreviewGenerator.php
+++ b/src/Service/PreviewGenerator.php
@@ -115,7 +115,7 @@ class PreviewGenerator implements PreviewGeneratorInterface
             $domains = $site->getDomains();
             array_unshift($domains, $site->getMainDomain());
 
-            if(is_null($preSelectedSite) && in_array(Tool::getHostname(), $domains)) {
+            if (is_null($preSelectedSite) && in_array(Tool::getHostname(), $domains)) {
                 $preSelectedSite = $sitesOptions[$label];
             }
         }

--- a/src/System/AdminConfig.php
+++ b/src/System/AdminConfig.php
@@ -62,7 +62,7 @@ final class AdminConfig
 
         // If the read target is settings-store and no data is found there,
         // load the data from the container config
-        if(!$data && $loadType === $repository::LOCATION_SETTINGS_STORE) {
+        if (!$data && $loadType === $repository::LOCATION_SETTINGS_STORE) {
             $containerConfig = \Pimcore::getContainer()->getParameter('pimcore_admin.config');
             $data[self::BRANDING] = $containerConfig[self::BRANDING];
             $data[self::ASSETS] = $containerConfig[self::ASSETS];


### PR DESCRIPTION
# Pull Request

## Problem
iFrames can load insecure content from untrusted URLs.

## Solution
By adding the frame-anchestor property only trusted URLs can be loaded in iFrames. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors This improves the security and minimizes external impacts.