### PR TITLE
Fix resolve display issue in grid view for filter by link feature

### DIFF
--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -456,7 +456,7 @@ pimcore.element.helpers.gridColumnConfig = {
             title: title,
             items: [formPanel],
             bodyStyle: "background: #fff;",
-            width: 700,
+            width: width: formPanel.items.items[0].width + 25,
             maxHeight: 650
         });
         this.filterByRelationWindow.show();


### PR DESCRIPTION
In the Grid View, the field is sometimes cut off in relation fields in the Filter by link option; this is corrected by this.

![image](https://github.com/user-attachments/assets/9ed96966-1f4e-44e8-a700-bfe7094eca04)
