### PR TITLE
Fix date range fields read only

### DIFF
--- a/public/js/pimcore/object/tags/dateRange.js
+++ b/public/js/pimcore/object/tags/dateRange.js
@@ -82,8 +82,8 @@ pimcore.object.tags.dateRange = Class.create(pimcore.object.tags.abstract, {
 
     getLayoutShow: function () {
         this.component = this.getLayoutEdit();
-        this.component.items[0].setReadOnly(true);
-        this.component.items[2].setReadOnly(true);
+        this.component.items.items[0].setReadOnly(true);
+        this.component.items.items[2].setReadOnly(true);
 
         return this.component;
     },

--- a/public/js/pimcore/object/tags/dateRange.js
+++ b/public/js/pimcore/object/tags/dateRange.js
@@ -82,8 +82,8 @@ pimcore.object.tags.dateRange = Class.create(pimcore.object.tags.abstract, {
 
     getLayoutShow: function () {
         this.component = this.getLayoutEdit();
-        this.component.items[0].setReadonly(true);
-        this.component.items[2].setReadonly(true);
+        this.component.items[0].setReadOnly(true);
+        this.component.items[2].setReadOnly(true);
 
         return this.component;
     },


### PR DESCRIPTION
You could not set DateRange Fields ReadOnly before because an ExtJS error occurred when calling them