### PR TITLE
[Grid] Support sorting by object brick quantity value field

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -566,19 +566,20 @@ class GridHelperService
                     $orderKey = 'concat(' . $orderKey . '__rgb, ' . $orderKey . '__a)';
                     $doNotQuote = true;
                 } elseif (strpos($orderKey, '~') !== false) {
-                    $orderKeyParts = explode('~', $orderKey);
+                    $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
 
-                    if (strpos($orderKey, '?') !== false) {
-                        $brickDescriptor = substr($orderKeyParts[0], 1);
-                        $brickDescriptor = json_decode($brickDescriptor, true);
-                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized')
-                            . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
-                        $doNotQuote = true;
-                    } elseif (count($orderKeyParts) === 2) {
-                        $orderKey = $list->quoteIdentifier($orderKeyParts[0])
-                            . '.' . $list->quoteIdentifier($orderKeyParts[1]);
-                        $doNotQuote = true;
+                    $brickDefinition = Objectbrick\Definition::getByKey($orderKeyParts[0]);
+                    if ($brickDefinition instanceof Objectbrick\Definition) {
+                        $brickFieldDefinition = $brickDefinition->getFieldDefinition($orderKeyParts[1]);
+
+                        if ($brickFieldDefinition instanceof ClassDefinition\Data\QuantityValue) {
+                            $orderKey = 'CONCAT('.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__unit').', '.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__value').')';
+                        } elseif ($brickFieldDefinition instanceof ClassDefinition\Data\RgbaColor) {
+                            $orderKey = 'CONCAT('.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__rgb').', '.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__a').')';
+                        }
                     }
+
+                    $doNotQuote = true;
                 } else {
                     $orderKey = $list->getDao()->getTableName() . '.' . $list->quoteIdentifier($orderKey);
                     $doNotQuote = true;

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -571,10 +571,12 @@ class GridHelperService
                     if (strpos($orderKey, '?') !== false) {
                         $brickDescriptor = substr($orderKeyParts[0], 1);
                         $brickDescriptor = json_decode($brickDescriptor, true);
-                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'].'_localized')
-                            .'.'.$list->quoteIdentifier($brickDescriptor['brickfield']);
+                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'] . '_localized')
+                            . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
+                        $doNotQuote = true;
                     } elseif (count($orderKeyParts) === 2) {
                         $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
+                        $doNotQuote = true;
 
                         $brickDefinition = Objectbrick\Definition::getByKey($orderKeyParts[0]);
                         if ($brickDefinition instanceof Objectbrick\Definition) {
@@ -587,8 +589,6 @@ class GridHelperService
                             }
                         }
                     }
-
-                    $doNotQuote = true;
                 } else {
                     $orderKey = $list->getDao()->getTableName() . '.' . $list->quoteIdentifier($orderKey);
                     $doNotQuote = true;

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -566,16 +566,25 @@ class GridHelperService
                     $orderKey = 'concat(' . $orderKey . '__rgb, ' . $orderKey . '__a)';
                     $doNotQuote = true;
                 } elseif (strpos($orderKey, '~') !== false) {
-                    $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
+                    $orderKeyParts = explode('~', $orderKey);
 
-                    $brickDefinition = Objectbrick\Definition::getByKey($orderKeyParts[0]);
-                    if ($brickDefinition instanceof Objectbrick\Definition) {
-                        $brickFieldDefinition = $brickDefinition->getFieldDefinition($orderKeyParts[1]);
+                    if (strpos($orderKey, '?') !== false) {
+                        $brickDescriptor = substr($orderKeyParts[0], 1);
+                        $brickDescriptor = json_decode($brickDescriptor, true);
+                        $orderKey = $list->quoteIdentifier($brickDescriptor['containerKey'].'_localized')
+                            .'.'.$list->quoteIdentifier($brickDescriptor['brickfield']);
+                    } elseif (count($orderKeyParts) === 2) {
+                        $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
 
-                        if ($brickFieldDefinition instanceof ClassDefinition\Data\QuantityValue) {
-                            $orderKey = 'CONCAT('.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__unit').', '.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__value').')';
-                        } elseif ($brickFieldDefinition instanceof ClassDefinition\Data\RgbaColor) {
-                            $orderKey = 'CONCAT('.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__rgb').', '.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__a').')';
+                        $brickDefinition = Objectbrick\Definition::getByKey($orderKeyParts[0]);
+                        if ($brickDefinition instanceof Objectbrick\Definition) {
+                            $brickFieldDefinition = $brickDefinition->getFieldDefinition($orderKeyParts[1]);
+
+                            if ($brickFieldDefinition instanceof ClassDefinition\Data\QuantityValue) {
+                                $orderKey = 'CONCAT('.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__unit').', '.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__value').')';
+                            } elseif ($brickFieldDefinition instanceof ClassDefinition\Data\RgbaColor) {
+                                $orderKey = 'CONCAT('.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__rgb').', '.$list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1].'__a').')';
+                            }
                         }
                     }
 

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -575,7 +575,8 @@ class GridHelperService
                             . '.' . $list->quoteIdentifier($brickDescriptor['brickfield']);
                         $doNotQuote = true;
                     } elseif (count($orderKeyParts) === 2) {
-                        $orderKey = $list->quoteIdentifier($orderKeyParts[0]).'.'.$list->quoteIdentifier($orderKeyParts[1]);
+                        $orderKey = $list->quoteIdentifier($orderKeyParts[0])
+                            . '.' . $list->quoteIdentifier($orderKeyParts[1]);
                         $doNotQuote = true;
 
                         $brickDefinition = Objectbrick\Definition::getByKey($orderKeyParts[0]);


### PR DESCRIPTION
Steps to reproduce:
1. Create class `Car` with object brick field `attributes`
2. Create object brick `Bodywork`, assign `Car` as allowed class and add quantity value field `cargoCapacity`
3. Go to grid for `Home` (aka `/`), add grid column `Bodywork.cargoCapacity` and sort by `cargoCapacity`

Result:
SQL error 
`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'Bodywork.cargoCapacity' in 'order clause'`

This PR fixes this similar as it is done in https://github.com/pimcore/admin-ui-classic-bundle/blob/d33a87cd8c8cdc5ef203cb83ea49f781a30fb77b/src/Helper/GridHelperService.php#L564-L570 for class fields of type quantity value (and RgbaColor).