### PR TITLE
fix: tooltip error for not editable many to many relation

### DIFF
--- a/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -501,6 +501,8 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             width: this.fieldConfig.width,
             height: this.fieldConfig.height,
             cls: "multihref_field",
+            componentCls: this.getWrapperClassNames(),
+            bodyCssClass: "pimcore_object_tag_multihref",
             autoExpandColumn: 'fullpath',
             border: true,
             style: "margin-bottom: 10px",


### PR DESCRIPTION
Error: application style and tooltip aborted, nor matching element found.
Caused by missing object_field class, which is used by edit.js to find the relevant element to apply the tooltip to.
Fixed by adding class(es) to component in getLayoutShow.