### PR TITLE
Fix: Custom asset metadata of type object cant be set in asset gridview.

### DIFF
--- a/public/js/pimcore/asset/metadata/tags/manyToOneRelation.js
+++ b/public/js/pimcore/asset/metadata/tags/manyToOneRelation.js
@@ -159,6 +159,7 @@ pimcore.asset.metadata.tags.manyToOneRelation = Class.create(pimcore.asset.metad
             if (data.published === false) {
                 this.component.addCls("strikeThrough");
             }
+            this.dataChanged = true;
             this.component.setValue(data.path);
 
             return true;


### PR DESCRIPTION
Custom asset metadata of type object cant be set in asset gridview. State were never set.

Steps to reproduce:

    Creating a custom asset meta data of type object and assign it to an image
    Switch to grid view of the asset directory
    Selecting the created custom metadata of type object for display in the grid
    Click on the field and link a data object
    In the CellEditor click on save
    => The relation is not adopted

The change is not recognized as a change in the manyToOneRelation class because the variable "this.dataChanged" never changes to "true".

Error was introduced by a change from December 4th, 2023 - commit e422dca in js class "pimcore.element.helpers.gridCellEditor" line 123

Found in Pimcore 11.3.2 with admin-ui-classic-bundle version 1.5.4