### PR TITLE
Fix undefined error when copy and paste

### DIFF
--- a/public/js/pimcore/object/classes/data/reverseObjectRelation.js
+++ b/public/js/pimcore/object/classes/data/reverseObjectRelation.js
@@ -235,7 +235,7 @@ pimcore.object.classes.data.reverseObjectRelation = Class.create(pimcore.object.
             }
             Ext.apply(this.datax,
                 {
-                    allowToCreateNewObject: source.data.allowToCreateNewObject,
+                    allowToCreateNewObject: source.datax.allowToCreateNewObject,
                     remoteOwner: source.datax.remoteOwner,
                     width: source.datax.width,
                     height: source.datax.height,


### PR DESCRIPTION
When copying and pasting inside the DataObject editor, it throws an undefined error in the console when a reverse relation exists.