### PR TITLE
Improvement: move annotations to attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "codeception/module-asserts": "^2.0.1",
     "codeception/module-symfony": "^3.1.1",
     "codeception/phpunit-wrapper": "^9",
-    "phpstan/phpstan": "1.10.30",
-    "phpstan/phpstan-symfony": "^1.3.2",
+    "phpstan/phpstan": "^1.12",
+    "phpstan/phpstan-symfony": "^1.4",
     "phpunit/phpunit": "^9.3"
   },
   "autoload": {

--- a/config/pimcore/routing.yaml
+++ b/config/pimcore/routing.yaml
@@ -1,13 +1,13 @@
 _pimcore_admin:
     resource: "../../src/Controller/Admin/"
-    type:     annotation
+    type:     attribute
     prefix:   /admin
     options:
         expose: true
 
 _pimcore_gdpr:
     resource: "../../src/Controller/GDPR/"
-    type:     annotation
+    type:     attribute
     prefix:   /admin/gdpr
     options:
         expose: true

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -58,17 +58,16 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
 
 /**
- * @Route("/asset")
- *
  * @internal
  */
+#[Route(path: '/asset', name: 'pimcore_admin_asset_')]
 class AssetController extends ElementControllerBase implements KernelControllerEventInterface
 {
     use AdminStyleTrait;
@@ -78,25 +77,19 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
     protected Asset\Service $_assetService;
 
-    /**
-     * @Route("/tree-get-root", name="pimcore_admin_asset_treegetroot", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-root', name: 'treegetroot', methods: ['GET'])]
     public function treeGetRootAction(Request $request): JsonResponse
     {
         return parent::treeGetRootAction($request);
     }
 
-    /**
-     * @Route("/delete-info", name="pimcore_admin_asset_deleteinfo", methods={"GET"})
-     */
+    #[Route(path: '/delete-info', name: 'deleteinfo', methods: ['GET'])]
     public function deleteInfoAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         return parent::deleteInfoAction($request, $eventDispatcher);
     }
 
-    /**
-     * @Route("/get-data-by-id", name="pimcore_admin_asset_getdatabyid", methods={"GET"})
-     */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $assetId = $request->query->getInt('id');
@@ -243,9 +236,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         throw $this->createAccessDeniedHttpException();
     }
 
-    /**
-     * @Route("/tree-get-children-by-id", name="pimcore_admin_asset_treegetchildrenbyid", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-children-by-id', name: 'treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -334,9 +325,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/add-asset", name="pimcore_admin_asset_addasset", methods={"POST"})
-     */
+    #[Route(path: '/add-asset', name: 'addasset', methods: ['POST'])]
     public function addAssetAction(Request $request, Config $config): JsonResponse
     {
         try {
@@ -363,9 +352,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/add-asset-compatibility", name="pimcore_admin_asset_addassetcompatibility", methods={"POST"})
-     */
+    #[Route(path: '/add-asset-compatibility', name: 'addassetcompatibility', methods: ['POST'])]
     public function addAssetCompatibilityAction(Request $request, Config $config): JsonResponse
     {
         try {
@@ -391,10 +378,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     }
 
     /**
-     * @Route("/exists", name="pimcore_admin_asset_exists", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/exists', name: 'exists', methods: ['GET'])]
     public function existsAction(Request $request): JsonResponse
     {
         $parentAsset = \Pimcore\Model\Asset::getById((int)$request->get('parentId'));
@@ -564,10 +550,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     }
 
     /**
-     * @Route("/replace-asset", name="pimcore_admin_asset_replaceasset", methods={"POST", "PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/replace-asset', name: 'replaceasset', methods: ['POST', 'PUT'])]
     public function replaceAssetAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -618,9 +603,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/add-folder", name="pimcore_admin_asset_addfolder", methods={"POST"})
-     */
+    #[Route(path: '/add-folder', name: 'addfolder', methods: ['POST'])]
     public function addFolderAction(Request $request): JsonResponse
     {
         $success = false;
@@ -644,9 +627,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $this->adminJson(['success' => $success]);
     }
 
-    /**
-     * @Route("/delete", name="pimcore_admin_asset_delete", methods={"DELETE"})
-     */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
         $type = $request->get('type');
@@ -698,11 +679,11 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     }
 
     /**
-     * @Route("/update", name="pimcore_admin_asset_update", methods={"PUT"})
      *
      * @throws \Exception
      * @throws RuntimeException
      */
+    #[Route(path: '/update', name: 'update', methods: ['PUT'])]
     public function updateAction(Request $request): JsonResponse
     {
         $data = ['success' => false];
@@ -786,10 +767,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     }
 
     /**
-     * @Route("/save", name="pimcore_admin_asset_save", methods={"PUT","POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -887,9 +867,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/publish-version", name="pimcore_admin_asset_publishversion", methods={"POST"})
-     */
+    #[Route(path: '/publish-version', name: 'publishversion', methods: ['POST'])]
     public function publishVersionAction(Request $request): JsonResponse
     {
         $id = (int)$request->get('id');
@@ -917,9 +895,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         throw $this->createAccessDeniedHttpException();
     }
 
-    /**
-     * @Route("/show-version", name="pimcore_admin_asset_showversion", methods={"GET"})
-     */
+    #[Route(path: '/show-version', name: 'showversion', methods: ['GET'])]
     public function showVersionAction(Request $request, Environment $twig): Response
     {
         $id = (int)$request->get('id');
@@ -958,9 +934,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         );
     }
 
-    /**
-     * @Route("/download", name="pimcore_admin_asset_download", methods={"GET"})
-     */
+    #[Route(path: '/download', name: 'download', methods: ['GET'])]
     public function downloadAction(Request $request): StreamedResponse
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -988,9 +962,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         ]);
     }
 
-    /**
-     * @Route("/download-image-thumbnail", name="pimcore_admin_asset_downloadimagethumbnail", methods={"GET"})
-     */
+    #[Route(path: '/download-image-thumbnail', name: 'downloadimagethumbnail', methods: ['GET'])]
     public function downloadImageThumbnailAction(Request $request): BinaryFileResponse
     {
         $image = Asset\Image::getById((int) $request->get('id'));
@@ -1119,9 +1091,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         throw $this->createNotFoundException('Thumbnail not found');
     }
 
-    /**
-     * @Route("/get-asset", name="pimcore_admin_asset_getasset", methods={"GET"})
-     */
+    #[Route(path: '/get-asset', name: 'getasset', methods: ['GET'])]
     public function getAssetAction(Request $request): StreamedResponse
     {
         $image = Asset::getById((int)$request->get('id'));
@@ -1151,9 +1121,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $response;
     }
 
-    /**
-     * @Route("/get-image-thumbnail", name="pimcore_admin_asset_getimagethumbnail", methods={"GET"})
-     */
+    #[Route(path: '/get-image-thumbnail', name: 'getimagethumbnail', methods: ['GET'])]
     public function getImageThumbnailAction(Request $request): BinaryFileResponse|JsonResponse|StreamedResponse
     {
         $fileinfo = $request->get('fileinfo');
@@ -1240,9 +1208,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $response;
     }
 
-    /**
-     * @Route("/get-folder-thumbnail", name="pimcore_admin_asset_getfolderthumbnail", methods={"GET"})
-     */
+    #[Route(path: '/get-folder-thumbnail', name: 'getfolderthumbnail', methods: ['GET'])]
     public function getFolderThumbnailAction(Request $request): StreamedResponse
     {
         $folder = null;
@@ -1274,9 +1240,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         throw $this->createNotFoundException('could not load asset folder');
     }
 
-    /**
-     * @Route("/get-video-thumbnail", name="pimcore_admin_asset_getvideothumbnail", methods={"GET"})
-     */
+    #[Route(path: '/get-video-thumbnail', name: 'getvideothumbnail', methods: ['GET'])]
     public function getVideoThumbnailAction(Request $request): StreamedResponse
     {
         $video = null;
@@ -1349,9 +1313,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $response;
     }
 
-    /**
-     * @Route("/get-document-thumbnail", name="pimcore_admin_asset_getdocumentthumbnail", methods={"GET"})
-     */
+    #[Route(path: '/get-document-thumbnail', name: 'getdocumentthumbnail', methods: ['GET'])]
     public function getDocumentThumbnailAction(Request $request): BinaryFileResponse|StreamedResponse
     {
         $document = Asset\Document::getById((int)$request->get('id'));
@@ -1418,9 +1380,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         $response->headers->set('Pragma', '');
     }
 
-    /**
-     * @Route("/get-preview-document", name="pimcore_admin_asset_getpreviewdocument", methods={"GET"})
-     */
+    #[Route(path: '/get-preview-document', name: 'getpreviewdocument', methods: ['GET'])]
     public function getPreviewDocumentAction(
         Request $request,
         TranslatorInterface $translator
@@ -1505,9 +1465,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $stream;
     }
 
-    /**
-     * @Route("/get-preview-video", name="pimcore_admin_asset_getpreviewvideo", methods={"GET"})
-     */
+    #[Route(path: '/get-preview-video', name: 'getpreviewvideo', methods: ['GET'])]
     public function getPreviewVideoAction(Request $request): Response
     {
         $asset = Asset\Video::getById((int) $request->get('id'));
@@ -1555,9 +1513,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/serve-video-preview", name="pimcore_admin_asset_servevideopreview", methods={"GET"})
-     */
+    #[Route(path: '/serve-video-preview', name: 'servevideopreview', methods: ['GET'])]
     public function serveVideoPreviewAction(Request $request): StreamedResponse
     {
         $asset = Asset\Video::getById((int) $request->get('id'));
@@ -1597,9 +1553,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/image-editor", name="pimcore_admin_asset_imageeditor", methods={"GET"})
-     */
+    #[Route(path: '/image-editor', name: 'imageeditor', methods: ['GET'])]
     public function imageEditorAction(Request $request): Response
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -1614,9 +1568,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         );
     }
 
-    /**
-     * @Route("/image-editor-save", name="pimcore_admin_asset_imageeditorsave", methods={"PUT"})
-     */
+    #[Route(path: '/image-editor-save', name: 'imageeditorsave', methods: ['PUT'])]
     public function imageEditorSaveAction(Request $request): JsonResponse
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -1639,9 +1591,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/get-folder-content-preview", name="pimcore_admin_asset_getfoldercontentpreview", methods={"GET"})
-     */
+    #[Route(path: '/get-folder-content-preview', name: 'getfoldercontentpreview', methods: ['GET'])]
     public function getFolderContentPreviewAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -1731,9 +1681,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $this->adminJson(['assets' => $result['data'], 'success' => $result['success'], 'total' => $result['total']]);
     }
 
-    /**
-     * @Route("/copy-info", name="pimcore_admin_asset_copyinfo", methods={"GET"})
-     */
+    #[Route(path: '/copy-info', name: 'copyinfo', methods: ['GET'])]
     public function copyInfoAction(Request $request): JsonResponse
     {
         $transactionId = time();
@@ -1806,9 +1754,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         ]);
     }
 
-    /**
-     * @Route("/copy", name="pimcore_admin_asset_copy", methods={"POST"})
-     */
+    #[Route(path: '/copy', name: 'copy', methods: ['POST'])]
     public function copyAction(Request $request): JsonResponse
     {
         $success = false;
@@ -1868,9 +1814,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $this->adminJson(['success' => $success]);
     }
 
-    /**
-     * @Route("/download-as-zip-jobs", name="pimcore_admin_asset_downloadaszipjobs", methods={"GET"})
-     */
+    #[Route(path: '/download-as-zip-jobs', name: 'downloadaszipjobs', methods: ['GET'])]
     public function downloadAsZipJobsAction(Request $request): JsonResponse
     {
         $jobId = uniqid();
@@ -1941,9 +1885,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         ]);
     }
 
-    /**
-     * @Route("/download-as-zip-add-files", name="pimcore_admin_asset_downloadaszipaddfiles", methods={"GET"})
-     */
+    #[Route(path: '/download-as-zip-add-files', name: 'downloadaszipaddfiles', methods: ['GET'])]
     public function downloadAsZipAddFilesAction(Request $request): JsonResponse
     {
         $zipFile = PIMCORE_SYSTEM_TEMP_DIRECTORY . '/download-zip-' . $request->get('jobId') . '.zip';
@@ -2025,9 +1967,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     /**
      * Download all assets contained in the folder with parameter id as ZIP file.
      * The suggested filename is either [folder name].zip or assets.zip for the root folder.
-     *
-     * @Route("/download-as-zip", name="pimcore_admin_asset_downloadaszip", methods={"GET"})
      */
+    #[Route(path: '/download-as-zip', name: 'downloadaszip', methods: ['GET'])]
     public function downloadAsZipAction(Request $request): BinaryFileResponse
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -2048,9 +1989,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $response;
     }
 
-    /**
-     * @Route("/import-zip", name="pimcore_admin_asset_importzip", methods={"POST"})
-     */
+    #[Route(path: '/import-zip', name: 'importzip', methods: ['POST'])]
     public function importZipAction(Request $request, TranslatorInterface $translator): Response
     {
         $jobId = uniqid();
@@ -2115,9 +2054,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         }
     }
 
-    /**
-     * @Route("/import-zip-files", name="pimcore_admin_asset_importzipfiles", methods={"POST"})
-     */
+    #[Route(path: '/import-zip-files', name: 'importzipfiles', methods: ['POST'])]
     public function importZipFilesAction(Request $request, Filesystem $filesystem): JsonResponse
     {
         $jobId = $request->get('jobId');
@@ -2193,9 +2130,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         ]);
     }
 
-    /**
-     * @Route("/clear-thumbnail", name="pimcore_admin_asset_clearthumbnail", methods={"POST"})
-     */
+    #[Route(path: '/clear-thumbnail', name: 'clearthumbnail', methods: ['POST'])]
     public function clearThumbnailAction(Request $request): JsonResponse
     {
         $success = false;
@@ -2216,9 +2151,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $this->adminJson(['success' => $success]);
     }
 
-    /**
-     * @Route("/grid-proxy", name="pimcore_admin_asset_gridproxy", methods={"GET", "POST", "PUT"})
-     */
+    #[Route(path: '/grid-proxy', name: 'gridproxy', methods: ['GET', 'POST', 'PUT'])]
     public function gridProxyAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService, CsrfProtectionHandler $csrfProtection): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -2395,9 +2328,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @Route("/get-text", name="pimcore_admin_asset_gettext", methods={"GET"})
-     */
+    #[Route(path: '/get-text', name: 'gettext', methods: ['GET'])]
     public function getTextAction(Request $request): JsonResponse
     {
         $asset = Asset::getById((int) $request->get('id'));

--- a/src/Controller/Admin/Asset/AssetHelperController.php
+++ b/src/Controller/Admin/Asset/AssetHelperController.php
@@ -44,14 +44,13 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @Route("/asset-helper")
- *
  * @internal
  */
+#[Route(path: '/asset-helper', name: 'pimcore_admin_asset_assethelper_')]
 class AssetHelperController extends AdminAbstractController
 {
     public function __construct(
@@ -123,9 +122,7 @@ class AssetHelperController extends AdminAbstractController
         return $configData;
     }
 
-    /**
-     * @Route("/grid-delete-column-config", name="pimcore_admin_asset_assethelper_griddeletecolumnconfig", methods={"DELETE"})
-     */
+    #[Route(path: '/grid-delete-column-config', name: 'griddeletecolumnconfig', methods: ['DELETE'])]
     public function gridDeleteColumnConfigAction(Request $request): JsonResponse
     {
         $gridConfigId = (int) $request->get('gridConfigId');
@@ -146,9 +143,7 @@ class AssetHelperController extends AdminAbstractController
         return $this->adminJson($newGridConfig);
     }
 
-    /**
-     * @Route("/grid-get-column-config", name="pimcore_admin_asset_assethelper_gridgetcolumnconfig", methods={"GET"})
-     */
+    #[Route(path: '/grid-get-column-config', name: 'gridgetcolumnconfig', methods: ['GET'])]
     public function gridGetColumnConfigAction(Request $request): JsonResponse
     {
         $result = $this->doGetGridColumnConfig($request);
@@ -355,9 +350,7 @@ class AssetHelperController extends AdminAbstractController
         return $availableFields;
     }
 
-    /**
-     * @Route("/prepare-helper-column-configs", name="pimcore_admin_asset_assethelper_preparehelpercolumnconfigs", methods={"POST"})
-     */
+    #[Route(path: '/prepare-helper-column-configs', name: 'preparehelpercolumnconfigs', methods: ['POST'])]
     public function prepareHelperColumnConfigs(Request $request): JsonResponse
     {
         $helperColumns = [];
@@ -385,9 +378,7 @@ class AssetHelperController extends AdminAbstractController
         return $this->adminJson(['success' => true, 'columns' => $newData]);
     }
 
-    /**
-     * @Route("/grid-mark-favourite-column-config", name="pimcore_admin_asset_assethelper_gridmarkfavouritecolumnconfig", methods={"POST"})
-     */
+    #[Route(path: '/grid-mark-favourite-column-config', name: 'gridmarkfavouritecolumnconfig', methods: ['POST'])]
     public function gridMarkFavouriteColumnConfigAction(Request $request): JsonResponse
     {
         $classId = $request->get('classId');
@@ -451,9 +442,7 @@ class AssetHelperController extends AdminAbstractController
         return $result;
     }
 
-    /**
-     * @Route("/grid-save-column-config", name="pimcore_admin_asset_assethelper_gridsavecolumnconfig", methods={"POST"})
-     */
+    #[Route(path: '/grid-save-column-config', name: 'gridsavecolumnconfig', methods: ['POST'])]
     public function gridSaveColumnConfigAction(Request $request): JsonResponse
     {
         $asset = Asset::getById((int) $request->get('id'));
@@ -653,9 +642,7 @@ class AssetHelperController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/get-export-jobs", name="pimcore_admin_asset_assethelper_getexportjobs", methods={"POST"})
-     */
+    #[Route(path: '/get-export-jobs', name: 'getexportjobs', methods: ['POST'])]
     public function getExportJobsAction(Request $request, GridHelperService $gridHelperService): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -675,10 +662,9 @@ class AssetHelperController extends AdminAbstractController
     }
 
     /**
-     * @Route("/do-export", name="pimcore_admin_asset_assethelper_doexport", methods={"POST"})
-     *
      * @throws FilesystemException
      */
+    #[Route(path: '/do-export', name: 'doexport', methods: ['POST'])]
     public function doExportAction(Request $request): JsonResponse
     {
         $fileHandle = File::getValidFilename($request->get('fileHandle'));
@@ -824,9 +810,7 @@ class AssetHelperController extends AdminAbstractController
         return $fileHandle . '.csv';
     }
 
-    /**
-     * @Route("/download-csv-file", name="pimcore_admin_asset_assethelper_downloadcsvfile", methods={"GET"})
-     */
+    #[Route(path: '/download-csv-file', name: 'downloadcsvfile', methods: ['GET'])]
     public function downloadCsvFileAction(Request $request): Response
     {
         $storage = Storage::get('temp');
@@ -852,9 +836,7 @@ class AssetHelperController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/download-xlsx-file", name="pimcore_admin_asset_assethelper_downloadxlsxfile", methods={"GET"})
-     */
+    #[Route(path: '/download-xlsx-file', name: 'downloadxlsxfile', methods: ['GET'])]
     public function downloadXlsxFileAction(Request $request, GridHelperService $gridHelperService): BinaryFileResponse
     {
         $storage = Storage::get('temp');
@@ -869,9 +851,7 @@ class AssetHelperController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/get-metadata-for-column-config", name="pimcore_admin_asset_assethelper_getmetadataforcolumnconfig", methods={"GET"})
-     */
+    #[Route(path: '/get-metadata-for-column-config', name: 'getmetadataforcolumnconfig', methods: ['GET'])]
     public function getMetadataForColumnConfigAction(Request $request): JsonResponse
     {
         $result = [];
@@ -924,9 +904,7 @@ class AssetHelperController extends AdminAbstractController
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/get-batch-jobs", name="pimcore_admin_asset_assethelper_getbatchjobs", methods={"POST"})
-     */
+    #[Route(path: '/get-batch-jobs', name: 'getbatchjobs', methods: ['POST'])]
     public function getBatchJobsAction(Request $request, GridHelperService $gridHelperService): JsonResponse
     {
         if ($request->get('language')) {
@@ -941,9 +919,7 @@ class AssetHelperController extends AdminAbstractController
         return $this->adminJson(['success' => true, 'jobs' => $jobs]);
     }
 
-    /**
-     * @Route("/batch", name="pimcore_admin_asset_assethelper_batch", methods={"PUT"})
-     */
+    #[Route(path: '/batch', name: 'batch', methods: ['PUT'])]
     public function batchAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         try {

--- a/src/Controller/Admin/DataObject/ClassController.php
+++ b/src/Controller/Admin/DataObject/ClassController.php
@@ -35,20 +35,17 @@ use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/class", name="pimcore_admin_dataobject_class_")
- *
  * @internal
  */
+#[Route(path: '/class', name: 'pimcore_admin_dataobject_class_')]
 class ClassController extends AdminAbstractController implements KernelControllerEventInterface
 {
-    /**
-     * @Route("/get-document-types", name="getdocumenttypes", methods={"GET"})
-     */
+    #[Route(path: '/get-document-types', name: 'getdocumenttypes', methods: ['GET'])]
     public function getDocumentTypesAction(Request $request): JsonResponse
     {
         $documentTypes = Document::getTypes();
@@ -62,9 +59,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($typeItems);
     }
 
-    /**
-     * @Route("/get-asset-types", name="getassettypes", methods={"GET"})
-     */
+    #[Route(path: '/get-asset-types', name: 'getassettypes', methods: ['GET'])]
     public function getAssetTypesAction(Request $request): JsonResponse
     {
         $assetTypes = Asset::getTypes();
@@ -78,9 +73,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($typeItems);
     }
 
-    /**
-     * @Route("/get-tree", name="gettree", methods={"GET", "POST"})
-     */
+    #[Route(path: '/get-tree', name: 'gettree', methods: ['GET', 'POST'])]
     public function getTreeAction(Request $request): JsonResponse
     {
         try {
@@ -221,9 +214,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($treeNodes);
     }
 
-    /**
-     * @Route("/get", name="get", methods={"GET"})
-     */
+    #[Route(path: '/get', name: 'get', methods: ['GET'])]
     public function getAction(Request $request): JsonResponse
     {
         $class = DataObject\ClassDefinition::getById($request->get('id'));
@@ -238,9 +229,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($class);
     }
 
-    /**
-     * @Route("/get-custom-layout", name="getcustomlayout", methods={"GET"})
-     */
+    #[Route(path: '/get-custom-layout', name: 'getcustomlayout', methods: ['GET'])]
     public function getCustomLayoutAction(Request $request): JsonResponse
     {
         $customLayout = DataObject\ClassDefinition\CustomLayout::getById($request->get('id'));
@@ -276,9 +265,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true, 'data' => $customLayout]);
     }
 
-    /**
-     * @Route("/add", name="add", methods={"POST"})
-     */
+    #[Route(path: '/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request): JsonResponse
     {
         $className = $request->get('className');
@@ -302,9 +289,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true, 'id' => $class->getId()]);
     }
 
-    /**
-     * @Route("/add-custom-layout", name="addcustomlayout", methods={"POST"})
-     */
+    #[Route(path: '/add-custom-layout', name: 'addcustomlayout', methods: ['POST'])]
     public function addCustomLayoutAction(Request $request): JsonResponse
     {
         $layoutId = $request->get('layoutIdentifier');
@@ -335,9 +320,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
                                  'data' => $data, ]);
     }
 
-    /**
-     * @Route("/delete", name="delete", methods={"DELETE"})
-     */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): Response
     {
         $class = DataObject\ClassDefinition::getById($request->get('id'));
@@ -348,9 +331,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return new Response();
     }
 
-    /**
-     * @Route("/delete-custom-layout", name="deletecustomlayout", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-custom-layout', name: 'deletecustomlayout', methods: ['DELETE'])]
     public function deleteCustomLayoutAction(Request $request): JsonResponse
     {
         $customLayouts = new DataObject\ClassDefinition\CustomLayout\Listing();
@@ -368,9 +349,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/save-custom-layout", name="savecustomlayout", methods={"PUT"})
-     */
+    #[Route(path: '/save-custom-layout', name: 'savecustomlayout', methods: ['PUT'])]
     public function saveCustomLayoutAction(Request $request): JsonResponse
     {
         $customLayout = DataObject\ClassDefinition\CustomLayout::getById($request->get('id'));
@@ -410,10 +389,9 @@ class ClassController extends AdminAbstractController implements KernelControlle
     }
 
     /**
-     * @Route("/save", name="save", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
         $class = DataObject\ClassDefinition::getById($request->get('id'));
@@ -501,9 +479,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $name;
     }
 
-    /**
-     * @Route("/import-class", name="importclass", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/import-class', name: 'importclass', methods: ['POST', 'PUT'])]
     public function importClassAction(Request $request): Response
     {
         $class = DataObject\ClassDefinition::getById($request->get('id'));
@@ -524,9 +500,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/import-custom-layout-definition", name="importcustomlayoutdefinition", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/import-custom-layout-definition', name: 'importcustomlayoutdefinition', methods: ['POST', 'PUT'])]
     public function importCustomLayoutDefinitionAction(Request $request): Response
     {
         $success = false;
@@ -576,9 +550,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/get-custom-layout-definitions", name="getcustomlayoutdefinitions", methods={"GET"})
-     */
+    #[Route(path: '/get-custom-layout-definitions', name: 'getcustomlayoutdefinitions', methods: ['GET'])]
     public function getCustomLayoutDefinitionsAction(Request $request): JsonResponse
     {
         $classIds = explode(',', $request->get('classId'));
@@ -600,9 +572,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true, 'data' => $result]);
     }
 
-    /**
-     * @Route("/get-all-layouts", name="getalllayouts", methods={"GET"})
-     */
+    #[Route(path: '/get-all-layouts', name: 'getalllayouts', methods: ['GET'])]
     public function getAllLayoutsAction(Request $request): JsonResponse
     {
         // get all classes
@@ -649,9 +619,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['data' => $resultList]);
     }
 
-    /**
-     * @Route("/export-class", name="exportclass", methods={"GET"})
-     */
+    #[Route(path: '/export-class', name: 'exportclass', methods: ['GET'])]
     public function exportClassAction(Request $request): Response
     {
         $id = $request->get('id');
@@ -673,9 +641,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/export-custom-layout-definition", name="exportcustomlayoutdefinition", methods={"GET"})
-     */
+    #[Route(path: '/export-custom-layout-definition', name: 'exportcustomlayoutdefinition', methods: ['GET'])]
     public function exportCustomLayoutDefinitionAction(Request $request): Response
     {
         $id = $request->get('id');
@@ -700,13 +666,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         throw $this->createNotFoundException($errorMessage);
     }
 
-    /**
-     * FIELDCOLLECTIONS
-     */
-
-    /**
-     * @Route("/fieldcollection-get", name="fieldcollectionget", methods={"GET"})
-     */
+    #[Route(path: '/fieldcollection-get', name: 'fieldcollectionget', methods: ['GET'])]
     public function fieldcollectionGetAction(Request $request): JsonResponse
     {
         $fc = DataObject\Fieldcollection\Definition::getByKey($request->get('id'));
@@ -718,9 +678,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($fc);
     }
 
-    /**
-     * @Route("/fieldcollection-update", name="fieldcollectionupdate", methods={"PUT", "POST"})
-     */
+    #[Route(path: '/fieldcollection-update', name: 'fieldcollectionupdate', methods: ['PUT', 'POST'])]
     public function fieldcollectionUpdateAction(Request $request): JsonResponse
     {
         try {
@@ -771,9 +729,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         }
     }
 
-    /**
-     * @Route("/import-fieldcollection", name="importfieldcollection", methods={"POST"})
-     */
+    #[Route(path: '/import-fieldcollection', name: 'importfieldcollection', methods: ['POST'])]
     public function importFieldcollectionAction(Request $request): Response
     {
         $this->checkPermission('fieldcollections');
@@ -795,9 +751,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/export-fieldcollection", name="exportfieldcollection", methods={"GET"})
-     */
+    #[Route(path: '/export-fieldcollection', name: 'exportfieldcollection', methods: ['GET'])]
     public function exportFieldcollectionAction(Request $request): Response
     {
         $this->checkPermission('fieldcollections');
@@ -819,9 +773,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/fieldcollection-delete", name="fieldcollectiondelete", methods={"DELETE"})
-     */
+    #[Route(path: '/fieldcollection-delete', name: 'fieldcollectiondelete', methods: ['DELETE'])]
     public function fieldcollectionDeleteAction(Request $request): JsonResponse
     {
         $this->checkPermission('fieldcollections');
@@ -832,9 +784,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/fieldcollection-tree", name="fieldcollectiontree", methods={"GET", "POST"})
-     */
+    #[Route(path: '/fieldcollection-tree', name: 'fieldcollectiontree', methods: ['GET', 'POST'])]
     public function fieldcollectionTreeAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $list = new DataObject\Fieldcollection\Definition\Listing();
@@ -934,9 +884,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($definitions);
     }
 
-    /**
-     * @Route("/fieldcollection-list", name="fieldcollectionlist", methods={"GET"})
-     */
+    #[Route(path: '/fieldcollection-list', name: 'fieldcollectionlist', methods: ['GET'])]
     public function fieldcollectionListAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $user = \Pimcore\Tool\Admin::getCurrentUser();
@@ -983,9 +931,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['fieldcollections' => $list]);
     }
 
-    /**
-     * @Route("/get-class-definition-for-column-config", name="getclassdefinitionforcolumnconfig", methods={"GET"})
-     */
+    #[Route(path: '/get-class-definition-for-column-config', name: 'getclassdefinitionforcolumnconfig', methods: ['GET'])]
     public function getClassDefinitionForColumnConfigAction(Request $request): JsonResponse
     {
         $class = DataObject\ClassDefinition::getById($request->get('id'));
@@ -1057,13 +1003,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    /**
-     * OBJECT BRICKS
-     */
-
-    /**
-     * @Route("/objectbrick-get", name="objectbrickget", methods={"GET"})
-     */
+    #[Route(path: '/objectbrick-get', name: 'objectbrickget', methods: ['GET'])]
     public function objectbrickGetAction(Request $request): JsonResponse
     {
         $fc = DataObject\Objectbrick\Definition::getByKey($request->get('id'));
@@ -1075,9 +1015,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($fc);
     }
 
-    /**
-     * @Route("/objectbrick-update", name="objectbrickupdate", methods={"PUT", "POST"})
-     */
+    #[Route(path: '/objectbrick-update', name: 'objectbrickupdate', methods: ['PUT', 'POST'])]
     public function objectbrickUpdateAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         try {
@@ -1137,9 +1075,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         }
     }
 
-    /**
-     * @Route("/import-objectbrick", name="importobjectbrick", methods={"POST"})
-     */
+    #[Route(path: '/import-objectbrick', name: 'importobjectbrick', methods: ['POST'])]
     public function importObjectbrickAction(Request $request): JsonResponse
     {
         $this->checkPermission('objectbricks');
@@ -1160,9 +1096,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/export-objectbrick", name="exportobjectbrick", methods={"GET"})
-     */
+    #[Route(path: '/export-objectbrick', name: 'exportobjectbrick', methods: ['GET'])]
     public function exportObjectbrickAction(Request $request): Response
     {
         $this->checkPermission('objectbricks');
@@ -1184,9 +1118,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/objectbrick-delete", name="objectbrickdelete", methods={"DELETE"})
-     */
+    #[Route(path: '/objectbrick-delete', name: 'objectbrickdelete', methods: ['DELETE'])]
     public function objectbrickDeleteAction(Request $request): JsonResponse
     {
         $this->checkPermission('objectbricks');
@@ -1197,9 +1129,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/objectbrick-tree", name="objectbricktree", methods={"GET", "POST"})
-     */
+    #[Route(path: '/objectbrick-tree', name: 'objectbricktree', methods: ['GET', 'POST'])]
     public function objectbrickTreeAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $list = new DataObject\Objectbrick\Definition\Listing();
@@ -1342,9 +1272,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         }
     }
 
-    /**
-     * @Route("/objectbrick-list", name="objectbricklist", methods={"GET"})
-     */
+    #[Route(path: '/objectbrick-list', name: 'objectbricklist', methods: ['GET'])]
     public function objectbrickListAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $list = new DataObject\Objectbrick\Definition\Listing();
@@ -1404,14 +1332,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['objectbricks' => $list]);
     }
 
-    /**
-     * See http://www.pimcore.org/issues/browse/PIMCORE-2358
-     * Add option to export/import all class definitions/brick definitions etc. at once
-     */
-
-    /**
-     * @Route("/bulk-import", name="bulkimport", methods={"POST"})
-     */
+    #[Route(path: '/bulk-import', name: 'bulkimport', methods: ['POST'])]
     public function bulkImportAction(Request $request): JsonResponse
     {
         $result = [];
@@ -1469,12 +1390,10 @@ class ClassController extends AdminAbstractController implements KernelControlle
      * See http://www.pimcore.org/issues/browse/PIMCORE-2358
      * Add option to export/import all class definitions/brick definitions etc. at once
      */
-
     /**
-     * @Route("/bulk-commit", name="bulkcommit", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/bulk-commit', name: 'bulkcommit', methods: ['POST'])]
     public function bulkCommitAction(Request $request): JsonResponse
     {
         $data = json_decode($request->get('data'), true);
@@ -1572,14 +1491,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * See http://www.pimcore.org/issues/browse/PIMCORE-2358
-     * Add option to export/import all class definitions/brick definitions etc. at once
-     */
-
-    /**
-     * @Route("/bulk-export-prepare", name="bulkexportprepare", methods={"POST"})
-     */
+    #[Route(path: '/bulk-export-prepare', name: 'bulkexportprepare', methods: ['POST'])]
     public function bulkExportPrepareAction(Request $request): Response
     {
         $data = $request->get('data');
@@ -1591,9 +1503,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/bulk-export", name="bulkexport", methods={"GET"})
-     */
+    #[Route(path: '/bulk-export', name: 'bulkexport', methods: ['GET'])]
     public function bulkExportAction(Request $request): JsonResponse
     {
         $result = [];
@@ -1665,9 +1575,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return new JsonResponse(['success' => true, 'data' => $result]);
     }
 
-    /**
-     * @Route("/do-bulk-export", name="dobulkexport", methods={"GET"})
-     */
+    #[Route(path: '/do-bulk-export', name: 'dobulkexport', methods: ['GET'])]
     public function doBulkExportAction(Request $request): Response
     {
         $session = Session::getSessionBag($request->getSession(), 'pimcore_objects');
@@ -1731,9 +1639,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         $this->checkActionPermission($event, 'classes', $unrestrictedActions);
     }
 
-    /**
-     * @Route("/get-fieldcollection-usages", name="getfieldcollectionusages", methods={"GET"})
-     */
+    #[Route(path: '/get-fieldcollection-usages', name: 'getfieldcollectionusages', methods: ['GET'])]
     public function getFieldcollectionUsagesAction(Request $request): Response
     {
         $key = $request->get('key');
@@ -1759,9 +1665,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/get-bricks-usages", name="getbrickusages", methods={"GET"})
-     */
+    #[Route(path: '/get-bricks-usages', name: 'getbrickusages', methods: ['GET'])]
     public function getBrickUsagesAction(Request $request): Response
     {
         $classId = $request->get('classId');
@@ -1804,9 +1708,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($usages);
     }
 
-    /**
-     * @Route("/get-icons", name="geticons", methods={"GET"})
-     */
+    #[Route(path: '/get-icons', name: 'geticons', methods: ['GET'])]
     public function getIconsAction(Request $request, EventDispatcherInterface $eventDispatcher): Response
     {
         $classId = $request->query->get('classId');
@@ -1901,9 +1803,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/suggest-class-identifier", name="suggestclassidentifier")
-     */
+    #[Route(path: '/suggest-class-identifier', name: 'suggestclassidentifier')]
     public function suggestClassIdentifierAction(): Response
     {
         $db = Db::get();
@@ -1919,9 +1819,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/suggest-custom-layout-identifier", name="suggestcustomlayoutidentifier")
-     */
+    #[Route(path: '/suggest-custom-layout-identifier', name: 'suggestcustomlayoutidentifier')]
     public function suggestCustomLayoutIdentifierAction(Request $request): Response
     {
         $classId = $request->get('classId');
@@ -1950,9 +1848,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/text-layout-preview", name="textlayoutpreview")
-     */
+    #[Route(path: '/text-layout-preview', name: 'textlayoutpreview')]
     public function textLayoutPreviewAction(Request $request): Response
     {
         $objPath = $request->get('previewObject', '');
@@ -1995,9 +1891,7 @@ class ClassController extends AdminAbstractController implements KernelControlle
         return $response;
     }
 
-    /**
-     * @Route("/video-supported-types", name="videosupportedTypestypes")
-     */
+    #[Route(path: '/video-supported-types', name: 'videosupportedTypestypes')]
     public function videoAllowedTypesAction(Request $request, TranslatorInterface $translator): Response
     {
         $videoDef = new DataObject\ClassDefinition\Data\Video();

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -30,18 +30,15 @@ use Pimcore\Tool\Admin;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/classificationstore", name="pimcore_admin_dataobject_classificationstore_")
- *
  * @internal
  */
+#[Route(path: '/classificationstore', name: 'pimcore_admin_dataobject_classificationstore_')]
 class ClassificationstoreController extends AdminAbstractController implements KernelControllerEventInterface
 {
-    /**
-     * @Route("/delete-collection", name="deletecollection", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-collection', name: 'deletecollection', methods: ['DELETE'])]
     public function deleteCollectionAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -61,9 +58,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/delete-collection-relation", name="deletecollectionrelation", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-collection-relation', name: 'deletecollectionrelation', methods: ['DELETE'])]
     public function deleteCollectionRelationAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -80,9 +75,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/delete-relation", name="deleterelation", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-relation', name: 'deleterelation', methods: ['DELETE'])]
     public function deleteRelationAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -99,9 +92,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/delete-group", name="deletegroup", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-group', name: 'deletegroup', methods: ['DELETE'])]
     public function deleteGroupAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -115,10 +106,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/create-group", name="creategroup", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/create-group', name: 'creategroup', methods: ['POST'])]
     public function createGroupAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -140,10 +130,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/create-store", name="createstore", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/create-store', name: 'createstore', methods: ['POST'])]
     public function createStoreAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -164,10 +153,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/create-collection", name="createcollection", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/create-collection', name: 'createcollection', methods: ['POST'])]
     public function createCollectionAction(Request $request): JsonResponse
     {
         $this->checkPermission('classificationstore');
@@ -186,9 +174,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => true, 'id' => $config->getName()]);
     }
 
-    /**
-     * @Route("/collections", name="collectionsactionget", methods={"GET"})
-     */
+    #[Route(path: '/collections', name: 'collectionsactionget', methods: ['GET'])]
     public function collectionsActionGet(Request $request): JsonResponse
     {
         $this->checkPermission('objects');
@@ -325,9 +311,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($rootElement);
     }
 
-    /**
-     * @Route("/collections", name="collections", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/collections', name: 'collections', methods: ['POST', 'PUT'])]
     public function collectionsAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -352,9 +336,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @Route("/groups", name="groupsactionget", methods={"GET"})
-     */
+    #[Route(path: '/groups', name: 'groupsactionget', methods: ['GET'])]
     public function groupsActionGet(Request $request): JsonResponse
     {
         $this->checkPermission('objects');
@@ -479,9 +461,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($rootElement);
     }
 
-    /**
-     * @Route("/groups", name="groupsaction", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/groups', name: 'groupsaction', methods: ['POST', 'PUT'])]
     public function groupsAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -506,9 +486,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @Route("/collection-relations", name="collectionrelationsget", methods={"GET"})
-     */
+    #[Route(path: '/collection-relations', name: 'collectionrelationsget', methods: ['GET'])]
     public function collectionRelationsGetAction(Request $request): JsonResponse
     {
         $mapping = ['groupName' => 'name', 'groupDescription' => 'description'];
@@ -603,9 +581,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($rootElement);
     }
 
-    /**
-     * @Route("/collection-relations", name="collectionrelations", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/collection-relations', name: 'collectionrelations', methods: ['POST', 'PUT'])]
     public function collectionRelationsAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -637,9 +613,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @Route("/list-stores", name="liststores", methods={"GET"})
-     */
+    #[Route(path: '/list-stores', name: 'liststores', methods: ['GET'])]
     public function listStoresAction(): JsonResponse
     {
         $storeConfigs = [];
@@ -653,9 +627,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($storeConfigs);
     }
 
-    /**
-     * @Route("/search-relations", name="searchrelations", methods={"GET"})
-     */
+    #[Route(path: '/search-relations', name: 'searchrelations', methods: ['GET'])]
     public function searchRelationsAction(Request $request): JsonResponse
     {
         $db = Db::get();
@@ -772,9 +744,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($rootElement);
     }
 
-    /**
-     * @Route("/relations", name="relationsactionget", methods={"GET"})
-     */
+    #[Route(path: '/relations', name: 'relationsactionget', methods: ['GET'])]
     public function relationsActionGet(Request $request): JsonResponse
     {
         $mapping = ['keyName' => 'name', 'keyDescription' => 'description'];
@@ -894,9 +864,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($rootElement);
     }
 
-    /**
-     * @Route("/relations", name="relations", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/relations', name: 'relations', methods: ['POST', 'PUT'])]
     public function relationsAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -924,10 +892,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/add-collections", name="addcollections", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/add-collections', name: 'addcollections', methods: ['POST'])]
     public function addCollectionsAction(Request $request): JsonResponse
     {
         $this->checkPermission('objects');
@@ -939,7 +906,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
             $db = \Pimcore\Db::get();
             $mappedData = [];
             $groupsData = $db->fetchAllAssociative('select * from classificationstore_groups g, classificationstore_collectionrelations c where colId IN (:ids) and g.id = c.groupId', [
-                'ids' => implode(',', array_filter($ids, 'intval')),
+                'ids' => implode(',', array_filter($ids, fn ($id) => (bool) intval($id))),
             ]);
 
             foreach ($groupsData as $groupData) {
@@ -1033,10 +1000,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/add-groups", name="addgroups", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/add-groups', name: 'addgroups', methods: ['POST'])]
     public function addGroupsAction(Request $request): JsonResponse
     {
         $this->checkPermission('objects');
@@ -1110,10 +1076,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/properties", name="propertiesget", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/properties', name: 'propertiesget', methods: ['GET'])]
     public function propertiesGetAction(Request $request): JsonResponse
     {
         $storeId = (int) $request->get('storeId');
@@ -1257,9 +1222,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($rootElement);
     }
 
-    /**
-     * @Route("/properties", name="properties", methods={"POST", "PUT"})
-     */
+    #[Route(path: '/properties', name: 'properties', methods: ['POST', 'PUT'])]
     public function propertiesAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -1326,9 +1289,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $item;
     }
 
-    /**
-     * @Route("/add-property", name="addproperty", methods={"POST"})
-     */
+    #[Route(path: '/add-property', name: 'addproperty', methods: ['POST'])]
     public function addPropertyAction(Request $request): JsonResponse
     {
         $name = $request->get('name');
@@ -1352,9 +1313,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => true, 'id' => $config->getName()]);
     }
 
-    /**
-     * @Route("/delete-property", name="deleteproperty", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-property', name: 'deleteproperty', methods: ['DELETE'])]
     public function deletePropertyAction(Request $request): JsonResponse
     {
         $id = $request->request->getInt('id');
@@ -1368,10 +1327,9 @@ class ClassificationstoreController extends AdminAbstractController implements K
     }
 
     /**
-     * @Route("/edit-store", name="editstore", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/edit-store', name: 'editstore', methods: ['PUT'])]
     public function editStoreAction(Request $request): JsonResponse
     {
         $id = $request->request->getInt('id');
@@ -1401,9 +1359,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/storetree", name="storetree", methods={"GET"})
-     */
+    #[Route(path: '/storetree', name: 'storetree', methods: ['GET'])]
     public function storetreeAction(Request $request): JsonResponse
     {
         $result = [];
@@ -1431,9 +1387,7 @@ class ClassificationstoreController extends AdminAbstractController implements K
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/get-page", name="getpage", methods={"GET"})
-     */
+    #[Route(path: '/get-page', name: 'getpage', methods: ['GET'])]
     public function getPageAction(Request $request): JsonResponse
     {
         $tableSuffix = $request->get('table');

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -48,16 +48,15 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 use Twig\Extension\CoreExtension;
 
 /**
- * @Route("/object", name="pimcore_admin_dataobject_dataobject_")
- *
  * @internal
  */
+#[Route(path: '/object', name: 'pimcore_admin_dataobject_dataobject_')]
 class DataObjectController extends ElementControllerBase implements KernelControllerEventInterface
 {
     use AdminStyleTrait;
@@ -83,9 +82,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
 
     private array $classFieldDefinitions = [];
 
-    /**
-     * @Route("/tree-get-children-by-id", name="treegetchildrenbyid", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-children-by-id', name: 'treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -240,9 +237,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         return $this->elementService->getElementTreeNodeConfig($element);
     }
 
-    /**
-     * @Route("/get-id-path-paging-info", name="getidpathpaginginfo", methods={"GET"})
-     */
+    #[Route(path: '/get-id-path-paging-info', name: 'getidpathpaginginfo', methods: ['GET'])]
     public function getIdPathPagingInfoAction(Request $request): JsonResponse
     {
         $path = $request->get('path');
@@ -286,10 +281,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/get", name="get", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get', name: 'get', methods: ['GET'])]
     public function getAction(Request $request, EventDispatcherInterface $eventDispatcher, PreviewGeneratorInterface $defaultPreviewGenerator): JsonResponse
     {
         $objectId = $request->query->getInt('id');
@@ -548,10 +542,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/get-select-options", name="getSelectOptions", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-select-options', name: 'getSelectOptions', methods: ['POST'])]
     public function getSelectOptions(Request $request): JsonResponse
     {
         $objectId = $request->request->getInt('objectId');
@@ -749,9 +742,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
     }
 
-    /**
-     * @Route("/get-folder", name="getfolder", methods={"GET"})
-     */
+    #[Route(path: '/get-folder', name: 'getfolder', methods: ['GET'])]
     public function getFolderAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $objectId = (int)$request->get('id');
@@ -837,9 +828,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         return $reduced;
     }
 
-    /**
-     * @Route("/add", name="add", methods={"POST"})
-     */
+    #[Route(path: '/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request, Model\FactoryInterface $modelFactory): JsonResponse
     {
         $message = '';
@@ -907,9 +896,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         return $this->adminJson($return);
     }
 
-    /**
-     * @Route("/add-folder", name="addfolder", methods={"POST"})
-     */
+    #[Route(path: '/add-folder', name: 'addfolder', methods: ['POST'])]
     public function addFolderAction(Request $request): JsonResponse
     {
         $success = false;
@@ -941,10 +928,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/delete", name="delete", methods={"DELETE"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
         $type = $request->get('type');
@@ -988,10 +974,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/change-children-sort-by", name="changechildrensortby", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/change-children-sort-by', name: 'changechildrensortby', methods: ['PUT'])]
     public function changeChildrenSortByAction(Request $request): JsonResponse
     {
         $object = DataObject::getById((int) $request->get('id'));
@@ -1028,10 +1013,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/update", name="update", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/update', name: 'update', methods: ['PUT'])]
     public function updateAction(Request $request): JsonResponse
     {
         $values = $this->decodeJson($request->get('values'));
@@ -1308,10 +1292,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/save", name="save", methods={"POST", "PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
         $objectFromDatabase = DataObject\Concrete::getById((int) $request->get('id'));
@@ -1480,9 +1463,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         return true;
     }
 
-    /**
-     * @Route("/save-folder", name="savefolder", methods={"PUT"})
-     */
+    #[Route(path: '/save-folder', name: 'savefolder', methods: ['PUT'])]
     public function saveFolderAction(Request $request): JsonResponse
     {
         $object = DataObject::getById((int) $request->get('id'));
@@ -1546,9 +1527,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
     }
 
-    /**
-     * @Route("/publish-version", name="publishversion", methods={"POST"})
-     */
+    #[Route(path: '/publish-version', name: 'publishversion', methods: ['POST'])]
     public function publishVersionAction(Request $request): JsonResponse
     {
         $id = (int)$request->get('id');
@@ -1585,10 +1564,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/preview-version", name="previewversion", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/preview-version', name: 'previewversion', methods: ['GET'])]
     public function previewVersionAction(Request $request, Environment $twig): Response
     {
         DataObject::setDoNotRestoreKeyAndPath(true);
@@ -1629,10 +1607,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/diff-versions/from/{from}/to/{to}", name="diffversions", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/diff-versions/from/{from}/to/{to}', name: 'diffversions', methods: ['GET'])]
     public function diffVersionsAction(Request $request, Environment $twig, int $from, int $to): Response
     {
         DataObject::setDoNotRestoreKeyAndPath(true);
@@ -1688,9 +1665,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         throw $this->createAccessDeniedException('Permission denied, version ids [' . $id1 . ', ' . $id2 . ']');
     }
 
-    /**
-     * @Route("/grid-proxy", name="gridproxy", methods={"GET", "POST", "PUT"})
-     */
+    #[Route(path: '/grid-proxy', name: 'gridproxy', methods: ['GET', 'POST', 'PUT'])]
     public function gridProxyAction(
         Request $request,
         EventDispatcherInterface $eventDispatcher,
@@ -1726,9 +1701,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/copy-info", name="copyinfo", methods={"GET"})
-     */
+    #[Route(path: '/copy-info', name: 'copyinfo', methods: ['GET'])]
     public function copyInfoAction(Request $request): JsonResponse
     {
         $transactionId = time();
@@ -1813,10 +1786,9 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     }
 
     /**
-     * @Route("/copy-rewrite-ids", name="copyrewriteids", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/copy-rewrite-ids', name: 'copyrewriteids', methods: ['PUT'])]
     public function copyRewriteIdsAction(Request $request): JsonResponse
     {
         $transactionId = $request->get('transactionId');
@@ -1851,9 +1823,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         ]);
     }
 
-    /**
-     * @Route("/copy", name="copy", methods={"POST"})
-     */
+    #[Route(path: '/copy', name: 'copy', methods: ['POST'])]
     public function copyAction(Request $request): JsonResponse
     {
         $message = '';
@@ -1917,9 +1887,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         }
     }
 
-    /**
-     * @Route("/preview", name="preview", methods={"GET"})
-     */
+    #[Route(path: '/preview', name: 'preview', methods: ['GET'])]
     public function previewAction(Request $request, PreviewGeneratorInterface $defaultPreviewGenerator): RedirectResponse|Response
     {
         $id = $request->query->getInt('id');

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -45,21 +45,18 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @Route("/object-helper", name="pimcore_admin_dataobject_dataobjecthelper_")
- *
  * @internal
  */
+#[Route(path: '/object-helper', name: 'pimcore_admin_dataobject_dataobjecthelper_')]
 class DataObjectHelperController extends AdminAbstractController
 {
     const SYSTEM_COLUMNS = ['id', 'fullpath', 'key', 'published', 'creationDate', 'modificationDate', 'filename', 'classname'];
 
-    /**
-     * @Route("/load-object-data", name="loadobjectdata", methods={"GET"})
-     */
+    #[Route(path: '/load-object-data', name: 'loadobjectdata', methods: ['GET'])]
     public function loadObjectDataAction(Request $request): JsonResponse
     {
         $object = DataObject::getById((int) $request->get('id'));
@@ -138,9 +135,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $configData;
     }
 
-    /**
-     * @Route("/get-export-configs", name="getexportconfigs", methods={"GET"})
-     */
+    #[Route(path: '/get-export-configs', name: 'getexportconfigs', methods: ['GET'])]
     public function getExportConfigsAction(Request $request): JsonResponse
     {
         $classId = $request->get('classId');
@@ -169,9 +164,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $this->adminJson(['success' => true, 'data' => $result]);
     }
 
-    /**
-     * @Route("/grid-delete-column-config", name="griddeletecolumnconfig", methods={"DELETE"})
-     */
+    #[Route(path: '/grid-delete-column-config', name: 'griddeletecolumnconfig', methods: ['DELETE'])]
     public function gridDeleteColumnConfigAction(Request $request, EventDispatcherInterface $eventDispatcher, Config $config): JsonResponse
     {
         $gridConfigId = (int)$request->get('gridConfigId');
@@ -202,9 +195,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $this->adminJson($newGridConfig);
     }
 
-    /**
-     * @Route("/grid-get-column-config", name="gridgetcolumnconfig", methods={"GET"})
-     */
+    #[Route(path: '/grid-get-column-config', name: 'gridgetcolumnconfig', methods: ['GET'])]
     public function gridGetColumnConfigAction(Request $request, EventDispatcherInterface $eventDispatcher, Config $config): JsonResponse
     {
         $result = $this->doGetGridColumnConfig($request, $config);
@@ -689,9 +680,7 @@ class DataObjectHelperController extends AdminAbstractController
         return null;
     }
 
-    /**
-     * @Route("/prepare-helper-column-configs", name="preparehelpercolumnconfigs", methods={"POST"})
-     */
+    #[Route(path: '/prepare-helper-column-configs', name: 'preparehelpercolumnconfigs', methods: ['POST'])]
     public function prepareHelperColumnConfigs(Request $request): JsonResponse
     {
         $helperColumns = [];
@@ -719,9 +708,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $this->adminJson(['success' => true, 'columns' => $newData]);
     }
 
-    /**
-     * @Route("/grid-config-apply-to-all", name="gridconfigapplytoall", methods={"POST"})
-     */
+    #[Route(path: '/grid-config-apply-to-all', name: 'gridconfigapplytoall', methods: ['POST'])]
     public function gridConfigApplyToAllAction(Request $request): JsonResponse
     {
         $objectId = $request->request->getInt('objectId');
@@ -744,9 +731,7 @@ class DataObjectHelperController extends AdminAbstractController
         throw $this->createAccessDeniedHttpException();
     }
 
-    /**
-     * @Route("/grid-mark-favourite-column-config", name="gridmarkfavouritecolumnconfig", methods={"POST"})
-     */
+    #[Route(path: '/grid-mark-favourite-column-config', name: 'gridmarkfavouritecolumnconfig', methods: ['POST'])]
     public function gridMarkFavouriteColumnConfigAction(Request $request): JsonResponse
     {
         $objectId = (int)$request->get('objectId');
@@ -828,9 +813,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $result;
     }
 
-    /**
-     * @Route("/grid-save-column-config", name="gridsavecolumnconfig", methods={"POST"})
-     */
+    #[Route(path: '/grid-save-column-config', name: 'gridsavecolumnconfig', methods: ['POST'])]
     public function gridSaveColumnConfigAction(Request $request): JsonResponse
     {
         $objectId = $request->request->getInt('id');
@@ -1123,13 +1106,7 @@ class DataObjectHelperController extends AdminAbstractController
         }
     }
 
-    /**
-     * IMPORTER
-     */
-
-    /**
-     * @Route("/import-upload", name="importupload", methods={"POST"})
-     */
+    #[Route(path: '/import-upload', name: 'importupload', methods: ['POST'])]
     public function importUploadAction(Request $request, Filesystem $filesystem): JsonResponse
     {
         $data = file_get_contents($_FILES['Filedata']['tmp_name']);
@@ -1173,9 +1150,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $fileHandle . '.csv';
     }
 
-    /**
-     * @Route("/get-export-jobs", name="getexportjobs", methods={"POST"})
-     */
+    #[Route(path: '/get-export-jobs', name: 'getexportjobs', methods: ['POST'])]
     public function getExportJobsAction(Request $request, GridHelperService $gridHelperService, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $requestedLanguage = $this->extractLanguage($request);
@@ -1212,10 +1187,9 @@ class DataObjectHelperController extends AdminAbstractController
     }
 
     /**
-     * @Route("/do-export", name="doexport", methods={"POST"})
-     *
      * @throws \Exception|FilesystemException
      */
+    #[Route(path: '/do-export', name: 'doexport', methods: ['POST'])]
     public function doExportAction(
         Request $request,
         LocaleServiceInterface $localeService,
@@ -1346,9 +1320,7 @@ class DataObjectHelperController extends AdminAbstractController
         return '"' . $value . '"';
     }
 
-    /**
-     * @Route("/download-csv-file", name="downloadcsvfile", methods={"GET"})
-     */
+    #[Route(path: '/download-csv-file', name: 'downloadcsvfile', methods: ['GET'])]
     public function downloadCsvFileAction(Request $request): Response
     {
         $storage = Storage::get('temp');
@@ -1374,9 +1346,7 @@ class DataObjectHelperController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/download-xlsx-file", name="downloadxlsxfile", methods={"GET"})
-     */
+    #[Route(path: '/download-xlsx-file', name: 'downloadxlsxfile', methods: ['GET'])]
     public function downloadXlsxFileAction(Request $request, GridHelperService $gridHelperService): BinaryFileResponse
     {
         $storage = Storage::get('temp');
@@ -1411,9 +1381,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $o;
     }
 
-    /**
-     * @Route("/get-batch-jobs", name="getbatchjobs", methods={"POST"})
-     */
+    #[Route(path: '/get-batch-jobs', name: 'getbatchjobs', methods: ['POST'])]
     public function getBatchJobsAction(Request $request, GridHelperService $gridHelperService): JsonResponse
     {
         if ($request->get('language')) {
@@ -1428,9 +1396,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $this->adminJson(['success' => true, 'jobs' => $jobs]);
     }
 
-    /**
-     * @Route("/batch", name="batch", methods={"PUT"})
-     */
+    #[Route(path: '/batch', name: 'batch', methods: ['PUT'])]
     public function batchAction(Request $request): JsonResponse
     {
         $success = true;
@@ -1637,9 +1603,7 @@ class DataObjectHelperController extends AdminAbstractController
         return $this->adminJson(['success' => $success]);
     }
 
-    /**
-     * @Route("/get-available-visible-vields", name="getavailablevisiblefields", methods={"GET"})
-     */
+    #[Route(path: '/get-available-visible-vields', name: 'getavailablevisiblefields', methods: ['GET'])]
     public function getAvailableVisibleFieldsAction(Request $request): JsonResponse
     {
         $class = null;

--- a/src/Controller/Admin/DataObject/QuantityValueController.php
+++ b/src/Controller/Admin/DataObject/QuantityValueController.php
@@ -25,22 +25,19 @@ use Pimcore\Model\Translation;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/quantity-value", name="pimcore_admin_dataobject_quantityvalue_")
- *
  * @internal
  */
+#[Route(path: '/quantity-value', name: 'pimcore_admin_dataobject_quantityvalue_')]
 class QuantityValueController extends AdminAbstractController
 {
     public function __construct(protected QuantityValueService $service)
     {
     }
 
-    /**
-     * @Route("/unit-import",name="unitimport", methods={"POST","PUT"})
-     */
+    #[Route(path: '/unit-import', name: 'unitimport', methods: ['POST', 'PUT'])]
     public function unitImportAction(Request $request): JsonResponse
     {
         $json = file_get_contents($_FILES['Filedata']['tmp_name']);
@@ -51,9 +48,7 @@ class QuantityValueController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/unit-export", name="unitexport", methods={"GET"})
-     */
+    #[Route(path: '/unit-export', name: 'unitexport', methods: ['GET'])]
     public function unitExportAction(Request $request): Response
     {
         $result = $this->service->generateDefinitionJson();
@@ -65,10 +60,9 @@ class QuantityValueController extends AdminAbstractController
     }
 
     /**
-     * @Route("/unit-proxy", name="unitproxyget", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/unit-proxy', name: 'unitproxyget', methods: ['GET'])]
     public function unitProxyGetAction(Request $request): JsonResponse
     {
         $this->checkPermission('quantityValueUnits');
@@ -120,10 +114,9 @@ class QuantityValueController extends AdminAbstractController
     }
 
     /**
-     * @Route("/unit-proxy", name="unitproxy", methods={"POST", "PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/unit-proxy', name: 'unitproxy', methods: ['POST', 'PUT'])]
     public function unitProxyAction(Request $request): JsonResponse
     {
         $this->checkPermission('quantityValueUnits');
@@ -191,9 +184,7 @@ class QuantityValueController extends AdminAbstractController
         return $mapper[$comparison];
     }
 
-    /**
-     * @Route("/unit-list", name="unitlist", methods={"GET"})
-     */
+    #[Route(path: '/unit-list', name: 'unitlist', methods: ['GET'])]
     public function unitListAction(Request $request): JsonResponse
     {
         $list = new Unit\Listing();
@@ -231,9 +222,7 @@ class QuantityValueController extends AdminAbstractController
         return $this->adminJson(['data' => $result, 'success' => true, 'total' => $list->getTotalCount()]);
     }
 
-    /**
-     * @Route("/convert", name="convert", methods={"GET"})
-     */
+    #[Route(path: '/convert', name: 'convert', methods: ['GET'])]
     public function convertAction(Request $request, UnitConversionService $conversionService): JsonResponse
     {
         $this->checkPermission('objects');
@@ -256,9 +245,7 @@ class QuantityValueController extends AdminAbstractController
         return $this->adminJson(['value' => $convertedValue->getValue(), 'success' => true]);
     }
 
-    /**
-     * @Route("/convert-all", name="convertall", methods={"GET"})
-     */
+    #[Route(path: '/convert-all', name: 'convertall', methods: ['GET'])]
     public function convertAllAction(Request $request, UnitConversionService $conversionService): JsonResponse
     {
         $this->checkPermission('objects');

--- a/src/Controller/Admin/DataObject/VariantsController.php
+++ b/src/Controller/Admin/DataObject/VariantsController.php
@@ -23,21 +23,18 @@ use Pimcore\Localization\LocaleServiceInterface;
 use Pimcore\Model\DataObject;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @Route("/variants", name="pimcore_admin_dataobject_variants_")
- *
  * @internal
  */
+#[Route(path: '/variants', name: 'pimcore_admin_dataobject_variants_')]
 class VariantsController extends AdminAbstractController
 {
     use DataObjectActionsTrait;
 
-    /**
-     * @Route("/update-key", name="updatekey", methods={"PUT"})
-     */
+    #[Route(path: '/update-key', name: 'updatekey', methods: ['PUT'])]
     public function updateKeyAction(Request $request): JsonResponse
     {
         $id = $request->request->getInt('id');
@@ -48,10 +45,9 @@ class VariantsController extends AdminAbstractController
     }
 
     /**
-     * @Route("/get-variants", name="getvariants", methods={"GET", "POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-variants', name: 'getvariants', methods: ['GET', 'POST'])]
     public function getVariantsAction(
         Request $request,
         EventDispatcherInterface $eventDispatcher,

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -56,17 +56,16 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use function uniqid;
 use function unlink;
 
 /**
- * @Route("/document")
- *
  * @internal
  */
+#[Route(path: '/document', name: 'pimcore_admin_document_document_')]
 class DocumentController extends ElementControllerBase implements KernelControllerEventInterface
 {
     use AdminStyleTrait;
@@ -75,25 +74,19 @@ class DocumentController extends ElementControllerBase implements KernelControll
 
     protected Document\Service $_documentService;
 
-    /**
-     * @Route("/tree-get-root", name="pimcore_admin_document_document_treegetroot", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-root', name: 'treegetroot', methods: ['GET'])]
     public function treeGetRootAction(Request $request): JsonResponse
     {
         return parent::treeGetRootAction($request);
     }
 
-    /**
-     * @Route("/delete-info", name="pimcore_admin_document_document_deleteinfo", methods={"GET"})
-     */
+    #[Route(path: '/delete-info', name: 'deleteinfo', methods: ['GET'])]
     public function deleteInfoAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         return parent::deleteInfoAction($request, $eventDispatcher);
     }
 
-    /**
-     * @Route("/get-data-by-id", name="pimcore_admin_document_document_getdatabyid", methods={"GET"})
-     */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $document = Document::getById((int) $request->get('id'));
@@ -134,9 +127,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         throw $this->createAccessDeniedHttpException();
     }
 
-    /**
-     * @Route("/tree-get-children-by-id", name="pimcore_admin_document_document_treegetchildrenbyid", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-children-by-id', name: 'treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -241,9 +232,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
     }
 
-    /**
-     * @Route("/add", name="pimcore_admin_document_document_add", methods={"POST"})
-     */
+    #[Route(path: '/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request): JsonResponse
     {
         $success = false;
@@ -382,9 +371,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    /**
-     * @Route("/delete", name="pimcore_admin_document_document_delete", methods={"DELETE"})
-     */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
         $type = $request->get('type');
@@ -432,11 +419,11 @@ class DocumentController extends ElementControllerBase implements KernelControll
     }
 
     /**
-     * @Route("/update", name="pimcore_admin_document_document_update", methods={"PUT"})
      *
      * @throws Exception
      * @throws RuntimeException
      */
+    #[Route(path: '/update', name: 'update', methods: ['PUT'])]
     public function updateAction(Request $request): JsonResponse
     {
         $data = ['success' => false];
@@ -598,9 +585,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
     }
 
-    /**
-     * @Route("/doc-types", name="pimcore_admin_document_document_doctypesget", methods={"GET"})
-     */
+    #[Route(path: '/doc-types', name: 'doctypesget', methods: ['GET'])]
     public function docTypesGetAction(Request $request): JsonResponse
     {
         // get list of types
@@ -618,9 +603,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson(['data' => $docTypes, 'success' => true, 'total' => count($docTypes)]);
     }
 
-    /**
-     * @Route("/doc-types", name="pimcore_admin_document_document_doctypes", methods={"PUT", "POST", "DELETE"})
-     */
+    #[Route(path: '/doc-types', name: 'doctypes', methods: ['PUT', 'POST', 'DELETE'])]
     public function docTypesAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -675,10 +658,9 @@ class DocumentController extends ElementControllerBase implements KernelControll
     }
 
     /**
-     * @Route("/get-doc-types", name="pimcore_admin_document_document_getdoctypes", methods={"GET"})
-     *
      * @throws BadRequestHttpException If type is invalid
      */
+    #[Route(path: '/get-doc-types', name: 'getdoctypes', methods: ['GET'])]
     public function getDocTypesAction(Request $request): JsonResponse
     {
         $list = new DocType\Listing();
@@ -699,9 +681,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson(['docTypes' => $docTypes]);
     }
 
-    /**
-     * @Route("/version-to-session", name="pimcore_admin_document_document_versiontosession", methods={"POST"})
-     */
+    #[Route(path: '/version-to-session', name: 'versiontosession', methods: ['POST'])]
     public function versionToSessionAction(Request $request): Response
     {
         $id = (int)$request->get('id');
@@ -715,9 +695,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return new Response();
     }
 
-    /**
-     * @Route("/publish-version", name="pimcore_admin_document_document_publishversion", methods={"POST"})
-     */
+    #[Route(path: '/publish-version', name: 'publishversion', methods: ['POST'])]
     public function publishVersionAction(Request $request): JsonResponse
     {
         $this->versionToSessionAction($request);
@@ -750,9 +728,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson(['success' => true, 'treeData' => $treeData]);
     }
 
-    /**
-     * @Route("/update-site", name="pimcore_admin_document_document_updatesite", methods={"PUT"})
-     */
+    #[Route(path: '/update-site', name: 'updatesite', methods: ['PUT'])]
     public function updateSiteAction(Request $request): JsonResponse
     {
         $domains = $request->request->getString('domains');
@@ -789,9 +765,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson($site->getObjectVars());
     }
 
-    /**
-     * @Route("/remove-site", name="pimcore_admin_document_document_removesite", methods={"DELETE"})
-     */
+    #[Route(path: '/remove-site', name: 'removesite', methods: ['DELETE'])]
     public function removeSiteAction(Request $request): JsonResponse
     {
         $site = Site::getByRootId((int)$request->get('id'));
@@ -800,9 +774,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/copy-info", name="pimcore_admin_document_document_copyinfo", methods={"GET"})
-     */
+    #[Route(path: '/copy-info', name: 'copyinfo', methods: ['GET'])]
     public function copyInfoAction(Request $request): JsonResponse
     {
         $transactionId = time();
@@ -895,9 +867,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    /**
-     * @Route("/copy-rewrite-ids", name="pimcore_admin_document_document_copyrewriteids", methods={"PUT"})
-     */
+    #[Route(path: '/copy-rewrite-ids', name: 'copyrewriteids', methods: ['PUT'])]
     public function copyRewriteIdsAction(Request $request): JsonResponse
     {
         $transactionId = $request->get('transactionId');
@@ -936,9 +906,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    /**
-     * @Route("/copy", name="pimcore_admin_document_document_copy", methods={"POST"})
-     */
+    #[Route(path: '/copy', name: 'copy', methods: ['POST'])]
     public function copyAction(Request $request): JsonResponse
     {
         $success = false;
@@ -1011,9 +979,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson(['success' => $success]);
     }
 
-    /**
-     * @Route("/diff-versions/from/{from}/to/{to}", name="pimcore_admin_document_document_diffversions", requirements={"from": "\d+", "to": "\d+"}, methods={"GET"})
-     */
+    #[Route(path: '/diff-versions/from/{from}/to/{to}', name: 'diffversions', requirements: ['from' => '\d+', 'to' => '\d+'], methods: ['GET'])]
     public function diffVersionsAction(Request $request, int $from, int $to, DocumentRenderer $documentRenderer, RouterInterface $router): Response
     {
         // return with error if prerequisites do not match
@@ -1104,9 +1070,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         throw $this->createNotFoundException('Version diff file not found');
     }
 
-    /**
-     * @Route("/get-id-for-path", name="pimcore_admin_document_document_getidforpath", methods={"GET"})
-     */
+    #[Route(path: '/get-id-for-path', name: 'getidforpath', methods: ['GET'])]
     public function getIdForPathAction(Request $request): JsonResponse
     {
         if ($doc = Document::getByPath($request->get('path'))) {
@@ -1119,9 +1083,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         }
     }
 
-    /**
-     * @Route("/language-tree", name="pimcore_admin_document_document_languagetree", methods={"GET"})
-     */
+    #[Route(path: '/language-tree', name: 'languagetree', methods: ['GET'])]
     public function languageTreeAction(Request $request): JsonResponse
     {
         $document = Document::getById((int) $request->query->get('node'));
@@ -1137,10 +1099,9 @@ class DocumentController extends ElementControllerBase implements KernelControll
     }
 
     /**
-     * @Route("/language-tree-root", name="pimcore_admin_document_document_languagetreeroot", methods={"GET"})
-     *
      * @throws Exception
      */
+    #[Route(path: '/language-tree-root', name: 'languagetreeroot', methods: ['GET'])]
     public function languageTreeRootAction(Request $request): JsonResponse
     {
         $document = Document::getById((int) $request->query->get('id'));
@@ -1230,9 +1191,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $config;
     }
 
-    /**
-     * @Route("/convert", name="pimcore_admin_document_document_convert", methods={"PUT"})
-     */
+    #[Route(path: '/convert', name: 'convert', methods: ['PUT'])]
     public function convertAction(Request $request): JsonResponse
     {
         $document = Document::getById((int) $request->get('id'));
@@ -1270,9 +1229,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/translation-determine-parent", name="pimcore_admin_document_document_translationdetermineparent", methods={"GET"})
-     */
+    #[Route(path: '/translation-determine-parent', name: 'translationdetermineparent', methods: ['GET'])]
     public function translationDetermineParentAction(Request $request): JsonResponse
     {
         $success = false;
@@ -1297,9 +1254,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    /**
-     * @Route("/translation-add", name="pimcore_admin_document_document_translationadd", methods={"POST"})
-     */
+    #[Route(path: '/translation-add', name: 'translationadd', methods: ['POST'])]
     public function translationAddAction(Request $request): JsonResponse
     {
         $sourceDocument = Document::getById((int) $request->get('sourceId'));
@@ -1326,9 +1281,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    /**
-     * @Route("/translation-remove", name="pimcore_admin_document_document_translationremove", methods={"DELETE"})
-     */
+    #[Route(path: '/translation-remove', name: 'translationremove', methods: ['DELETE'])]
     public function translationRemoveAction(Request $request): JsonResponse
     {
         $sourceDocument = Document::getById((int) $request->get('sourceId'));
@@ -1343,9 +1296,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         ]);
     }
 
-    /**
-     * @Route("/translation-check-language", name="pimcore_admin_document_document_translationchecklanguage", methods={"GET"})
-     */
+    #[Route(path: '/translation-check-language', name: 'translationchecklanguage', methods: ['GET'])]
     public function translationCheckLanguageAction(Request $request): JsonResponse
     {
         $success = false;

--- a/src/Controller/Admin/Document/DocumentControllerBase.php
+++ b/src/Controller/Admin/Document/DocumentControllerBase.php
@@ -37,7 +37,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @internal
@@ -205,9 +205,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
         $data['unlinkTranslations'] = $unlinkTranslations;
     }
 
-    /**
-     * @Route("/save-to-session", name="savetosession", methods={"POST"})
-     */
+    #[Route(path: '/save-to-session', name: 'savetosession', methods: ['POST'])]
     public function saveToSessionAction(Request $request): JsonResponse
     {
         if ($documentId = (int) $request->get('id')) {
@@ -258,9 +256,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
         return $sessionDocument;
     }
 
-    /**
-     * @Route("/remove-from-session", name="removefromsession", methods={"DELETE"})
-     */
+    #[Route(path: '/remove-from-session', name: 'removefromsession', methods: ['DELETE'])]
     public function removeFromSessionAction(Request $request): JsonResponse
     {
         Model\Document\Service::removeElementFromSession('document', $request->get('id'), $request->getSession()->getId());
@@ -307,10 +303,10 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
     /**
      * This is used for pages and snippets to change the main document (which is not saved with the normal save button)
      *
-     * @Route("/change-main-document", name="changemaindocument", methods={"PUT"})
      *
      * @throws \Exception
      */
+    #[Route(path: '/change-main-document', name: 'changemaindocument', methods: ['PUT'])]
     public function changeMainDocumentAction(Request $request): JsonResponse
     {
         $doc = Model\Document\PageSnippet::getById((int) $request->get('id'));

--- a/src/Controller/Admin/Document/EmailController.php
+++ b/src/Controller/Admin/Document/EmailController.php
@@ -20,20 +20,18 @@ use Pimcore\Model\Document;
 use Pimcore\Model\Element;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/email", name="pimcore_admin_document_email_")
- *
  * @internal
  */
+#[Route(path: '/email', name: 'pimcore_admin_document_email_')]
 class EmailController extends DocumentControllerBase
 {
     /**
-     * @Route("/get-data-by-id", name="getdatabyid", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
         $email = Document\Email::getById((int)$request->get('id'));
@@ -71,10 +69,9 @@ class EmailController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/save", name="save", methods={"PUT", "POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request): JsonResponse
     {
         $page = Document\Email::getById((int) $request->get('id'));

--- a/src/Controller/Admin/Document/FolderController.php
+++ b/src/Controller/Admin/Document/FolderController.php
@@ -19,20 +19,18 @@ namespace Pimcore\Bundle\AdminBundle\Controller\Admin\Document;
 use Pimcore\Model\Document;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/folder", name="pimcore_admin_document_folder_")
- *
  * @internal
  */
+#[Route(path: '/folder', name: 'pimcore_admin_document_folder_')]
 class FolderController extends DocumentControllerBase
 {
     /**
-     * @Route("/get-data-by-id", name="getdatabyid", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
         $folder = Document\Folder::getById((int)$request->get('id'));
@@ -54,10 +52,9 @@ class FolderController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/save", name="save", methods={"PUT", "POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request): JsonResponse
     {
         $folder = Document\Folder::getById((int) $request->get('id'));

--- a/src/Controller/Admin/Document/HardlinkController.php
+++ b/src/Controller/Admin/Document/HardlinkController.php
@@ -20,20 +20,18 @@ use Pimcore\Model\Document;
 use Pimcore\Model\Schedule\Task;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/hardlink", name="pimcore_admin_document_hardlink_")
- *
  * @internal
  */
+#[Route(path: '/hardlink', name: 'pimcore_admin_document_hardlink_')]
 class HardlinkController extends DocumentControllerBase
 {
     /**
-     * @Route("/get-data-by-id", name="getdatabyid", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
         $link = Document\Hardlink::getById((int)$request->get('id'));
@@ -70,10 +68,9 @@ class HardlinkController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/save", name="save", methods={"POST", "PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
         $link = Document\Hardlink::getById((int) $request->get('id'));

--- a/src/Controller/Admin/Document/LinkController.php
+++ b/src/Controller/Admin/Document/LinkController.php
@@ -23,21 +23,19 @@ use Pimcore\Model\Element;
 use Pimcore\Model\Schedule\Task;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
- * @Route("/link", name="pimcore_admin_document_link_")
- *
  * @internal
  */
+#[Route(path: '/link', name: 'pimcore_admin_document_link_')]
 class LinkController extends DocumentControllerBase
 {
     /**
-     * @Route("/get-data-by-id", name="getdatabyid", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, SerializerInterface $serializer): JsonResponse
     {
         $link = Document\Link::getById((int)$request->get('id'));
@@ -74,10 +72,9 @@ class LinkController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/save", name="save", methods={"POST", "PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
         $link = Document\Link::getById((int) $request->get('id'));

--- a/src/Controller/Admin/Document/PageController.php
+++ b/src/Controller/Admin/Document/PageController.php
@@ -38,23 +38,21 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Twig\Environment;
 
 /**
- * @Route("/page", name="pimcore_admin_document_page_")
- *
  * @internal
  */
+#[Route(path: '/page', name: 'pimcore_admin_document_page_')]
 class PageController extends DocumentControllerBase
 {
     use RecursionBlockingEventDispatchHelperTrait;
 
     /**
-     * @Route("/get-data-by-id", name="getdatabyid", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request, StaticPageGenerator $staticPageGenerator): JsonResponse
     {
         $page = Document\Page::getById((int)$request->get('id'));
@@ -106,10 +104,9 @@ class PageController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/save", name="save", methods={"PUT", "POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['PUT', 'POST'])]
     public function saveAction(Request $request, StaticPageGenerator $staticPageGenerator): JsonResponse
     {
         $oldPage = Document\Page::getById((int) $request->get('id'));
@@ -181,9 +178,7 @@ class PageController extends DocumentControllerBase
         }
     }
 
-    /**
-     * @Route("/generate-previews", name="generatepreviews", methods={"GET"})
-     */
+    #[Route(path: '/generate-previews', name: 'generatepreviews', methods: ['GET'])]
     public function generatePreviewsAction(Request $request, MessageBusInterface $messengerBusPimcoreCore): JsonResponse
     {
         $list = new Document\Listing();
@@ -200,9 +195,7 @@ class PageController extends DocumentControllerBase
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/display-preview-image", name="display_preview_image", methods={"GET"})
-     */
+    #[Route(path: '/display-preview-image', name: 'display_preview_image', methods: ['GET'])]
     public function displayPreviewImageAction(Request $request): BinaryFileResponse
     {
         $document = Document\Page::getById((int) $request->get('id'));
@@ -215,9 +208,7 @@ class PageController extends DocumentControllerBase
         throw $this->createNotFoundException('Page not found');
     }
 
-    /**
-     * @Route("/check-pretty-url", name="checkprettyurl", methods={"POST"})
-     */
+    #[Route(path: '/check-pretty-url', name: 'checkprettyurl', methods: ['POST'])]
     public function checkPrettyUrlAction(Request $request): JsonResponse
     {
         $docId = $request->request->getInt('id');
@@ -284,9 +275,7 @@ class PageController extends DocumentControllerBase
         ]);
     }
 
-    /**
-     * @Route("/clear-editable-data", name="cleareditabledata", methods={"PUT"})
-     */
+    #[Route(path: '/clear-editable-data', name: 'cleareditabledata', methods: ['PUT'])]
     public function clearEditableDataAction(Request $request): JsonResponse
     {
         $docId = $request->request->getInt('id');
@@ -312,10 +301,9 @@ class PageController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/qr-code", name="qrcode", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/qr-code', name: 'qrcode', methods: ['GET'])]
     public function qrCodeAction(Request $request): BinaryFileResponse
     {
         $page = Document\Page::getById((int) $request->query->get('id'));
@@ -348,10 +336,9 @@ class PageController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/areabrick-render-index-editmode", name="areabrick-render-index-editmode", methods={"POST"})
-     *
      * @throws NotFoundHttpException|\Exception
      */
+    #[Route(path: '/areabrick-render-index-editmode', name: 'areabrick-render-index-editmode', methods: ['POST'])]
     public function areabrickRenderIndexEditmode(
         Request $request,
         BlockStateStack $blockStateStack,

--- a/src/Controller/Admin/Document/RenderletController.php
+++ b/src/Controller/Admin/Document/RenderletController.php
@@ -29,19 +29,19 @@ use Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
  */
+#[Route(path: '/document_tag', name: 'pimcore_admin_document_')]
 class RenderletController extends AdminAbstractController
 {
     /**
      * Handles editmode preview for renderlets
-     *
-     * @Route("/document_tag/renderlet", name="pimcore_admin_document_renderlet_renderlet")
      */
+    #[Route(path: '/renderlet', name: 'renderlet_renderlet')]
     public function renderletAction(
         Request $request,
         ActionRenderer $actionRenderer,

--- a/src/Controller/Admin/Document/SnippetController.php
+++ b/src/Controller/Admin/Document/SnippetController.php
@@ -21,20 +21,18 @@ use Pimcore\Model\Element;
 use Pimcore\Model\Schedule\Task;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/snippet", name="pimcore_admin_document_snippet_")
- *
  * @internal
  */
+#[Route(path: '/snippet', name: 'pimcore_admin_document_snippet_')]
 class SnippetController extends DocumentControllerBase
 {
     /**
-     * @Route("/get-data-by-id", name="getdatabyid", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-data-by-id', name: 'getdatabyid', methods: ['GET'])]
     public function getDataByIdAction(Request $request): JsonResponse
     {
         $snippet = Document\Snippet::getById((int)$request->get('id'));
@@ -81,10 +79,9 @@ class SnippetController extends DocumentControllerBase
     }
 
     /**
-     * @Route("/save", name="save", methods={"POST","PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/save', name: 'save', methods: ['POST', 'PUT'])]
     public function saveAction(Request $request): JsonResponse
     {
         $snippet = Document\Snippet::getById((int) $request->get('id'));

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -31,18 +31,17 @@ use Pimcore\Model\Version;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  *
  * @internal
  */
+#[Route(path: '/element', name: 'pimcore_admin_element_')]
 class ElementController extends AdminAbstractController
 {
-    /**
-     * @Route("/element/lock-element", name="pimcore_admin_element_lockelement", methods={"PUT"})
-     */
+    #[Route(path: '/lock-element', name: 'lockelement', methods: ['PUT'])]
     public function lockElementAction(Request $request): Response
     {
         Element\Editlock::lock($request->request->getInt('id'), $request->request->get('type'), $request->getSession()->getId());
@@ -50,9 +49,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/element/unlock-element", name="pimcore_admin_element_unlockelement", methods={"PUT"})
-     */
+    #[Route(path: '/unlock-element', name: 'unlockelement', methods: ['PUT'])]
     public function unlockElementAction(Request $request): Response
     {
         Element\Editlock::unlock((int)$request->get('id'), $request->get('type'));
@@ -60,9 +57,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/element/unlock-elements", name="pimcore_admin_element_unlockelements", methods={"POST"})
-     */
+    #[Route(path: '/unlock-elements', name: 'unlockelements', methods: ['POST'])]
     public function unlockElementsAction(Request $request): Response
     {
         $request = json_decode($request->getContent(), true) ?? [];
@@ -75,9 +70,8 @@ class ElementController extends AdminAbstractController
 
     /**
      * Returns the element data denoted by the given type and ID or path.
-     *
-     * @Route("/element/get-subtype", name="pimcore_admin_element_getsubtype", methods={"GET"})
      */
+    #[Route(path: '/get-subtype', name: 'getsubtype', methods: ['GET'])]
     public function getSubtypeAction(Request $request): JsonResponse
     {
         $idOrPath = trim($request->query->get('id', ''));
@@ -134,9 +128,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['noteTypes' => $result]);
     }
 
-    /**
-     * @Route("/element/note-types", name="pimcore_admin_element_notetypes", methods={"GET"})
-     */
+    #[Route(path: '/note-types', name: 'notetypes', methods: ['GET'])]
     public function noteTypes(Request $request): JsonResponse
     {
         switch ($request->get('ctype')) {
@@ -151,9 +143,7 @@ class ElementController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/element/note-list", name="pimcore_admin_element_notelist", methods={"POST"})
-     */
+    #[Route(path: '/note-list', name: 'notelist', methods: ['POST'])]
     public function noteListAction(Request $request): JsonResponse
     {
         $this->checkPermission('notes_events');
@@ -280,9 +270,7 @@ class ElementController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/element/note-add", name="pimcore_admin_element_noteadd", methods={"POST"})
-     */
+    #[Route(path: '/note-add', name: 'noteadd', methods: ['POST'])]
     public function noteAddAction(Request $request): JsonResponse
     {
         $this->checkPermission('notes_events');
@@ -302,9 +290,7 @@ class ElementController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/element/find-usages", name="pimcore_admin_element_findusages", methods={"GET"})
-     */
+    #[Route(path: '/find-usages', name: 'findusages', methods: ['GET'])]
     public function findUsagesAction(Request $request): JsonResponse
     {
         $element = null;
@@ -367,9 +353,7 @@ class ElementController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/element/get-replace-assignments-batch-jobs", name="pimcore_admin_element_getreplaceassignmentsbatchjobs", methods={"GET"})
-     */
+    #[Route(path: '/get-replace-assignments-batch-jobs', name: 'getreplaceassignmentsbatchjobs', methods: ['GET'])]
     public function getReplaceAssignmentsBatchJobsAction(Request $request): JsonResponse
     {
         $element = null;
@@ -390,9 +374,7 @@ class ElementController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/element/replace-assignments", name="pimcore_admin_element_replaceassignments", methods={"POST"})
-     */
+    #[Route(path: '/replace-assignments', name: 'replaceassignments', methods: ['POST'])]
     public function replaceAssignmentsAction(Request $request): JsonResponse
     {
         $success = false;
@@ -434,9 +416,7 @@ class ElementController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/element/unlock-propagate", name="pimcore_admin_element_unlockpropagate", methods={"PUT"})
-     */
+    #[Route(path: '/unlock-propagate', name: 'unlockpropagate', methods: ['PUT'])]
     public function unlockPropagateAction(Request $request): JsonResponse
     {
         $success = false;
@@ -452,9 +432,7 @@ class ElementController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/element/type-path", name="pimcore_admin_element_typepath", methods={"GET"})
-     */
+    #[Route(path: '/type-path', name: 'typepath', methods: ['GET'])]
     public function typePathAction(Request $request): JsonResponse
     {
         $id = $request->query->getInt('id');
@@ -491,9 +469,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson($data);
     }
 
-    /**
-     * @Route("/element/version-update", name="pimcore_admin_element_versionupdate", methods={"PUT"})
-     */
+    #[Route(path: '/version-update', name: 'versionupdate', methods: ['PUT'])]
     public function versionUpdateAction(Request $request): JsonResponse
     {
         $data = $this->decodeJson($request->get('data'));
@@ -510,10 +486,9 @@ class ElementController extends AdminAbstractController
     }
 
     /**
-     * @Route("/element/get-nice-path", name="pimcore_admin_element_getnicepath", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-nice-path', name: 'getnicepath', methods: ['POST'])]
     public function getNicePathAction(Request $request): JsonResponse
     {
         $source = $this->decodeJson($request->get('source'));
@@ -565,10 +540,9 @@ class ElementController extends AdminAbstractController
     }
 
     /**
-     * @Route("/element/get-versions", name="pimcore_admin_element_getversions", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-versions', name: 'getversions', methods: ['GET'])]
     public function getVersionsAction(Request $request): JsonResponse
     {
         $id = (int)$request->get('id');
@@ -621,9 +595,7 @@ class ElementController extends AdminAbstractController
         throw $this->createNotFoundException('Element type not found');
     }
 
-    /**
-     * @Route("/element/delete-draft", name="pimcore_admin_element_deletedraft", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-draft', name: 'deletedraft', methods: ['DELETE'])]
     public function deleteDraftAction(Request $request): JsonResponse
     {
         $version = Version::getById((int) $request->get('id'));
@@ -634,9 +606,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/element/delete-version", name="pimcore_admin_element_deleteversion", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-version', name: 'deleteversion', methods: ['DELETE'])]
     public function deleteVersionAction(Request $request): JsonResponse
     {
         $version = Model\Version::getById((int) $request->get('id'));
@@ -645,9 +615,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/element/delete-all-versions", name="pimcore_admin_element_deleteallversion", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-all-versions', name: 'deleteallversion', methods: ['DELETE'])]
     public function deleteAllVersionAction(Request $request): JsonResponse
     {
         $elementId = $request->request->getInt('id');
@@ -666,9 +634,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/element/get-requires-dependencies", name="pimcore_admin_element_getrequiresdependencies", methods={"GET"})
-     */
+    #[Route(path: '/get-requires-dependencies', name: 'getrequiresdependencies', methods: ['GET'])]
     public function getRequiresDependenciesAction(Request $request): JsonResponse
     {
         $id = $request->query->getInt('id');
@@ -728,9 +694,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(false);
     }
 
-    /**
-     * @Route("/element/get-required-by-dependencies", name="pimcore_admin_element_getrequiredbydependencies", methods={"GET"})
-     */
+    #[Route(path: '/get-required-by-dependencies', name: 'getrequiredbydependencies', methods: ['GET'])]
     public function getRequiredByDependenciesAction(Request $request): JsonResponse
     {
         $id = $request->query->getInt('id');
@@ -790,9 +754,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(false);
     }
 
-    /**
-     * @Route("/element/get-predefined-properties", name="pimcore_admin_element_getpredefinedproperties", methods={"GET"})
-     */
+    #[Route(path: '/get-predefined-properties', name: 'getpredefinedproperties', methods: ['GET'])]
     public function getPredefinedPropertiesAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
         $properties = [];
@@ -821,9 +783,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['properties' => $properties]);
     }
 
-    /**
-     * @Route("/element/analyze-permissions", name="pimcore_admin_element_analyzepermissions", methods={"POST"})
-     */
+    #[Route(path: '/analyze-permissions', name: 'analyzepermissions', methods: ['POST'])]
     public function analyzePermissionsAction(Request $request): Response
     {
         $userId = $request->request->getInt('userId');

--- a/src/Controller/Admin/ElementControllerBase.php
+++ b/src/Controller/Admin/ElementControllerBase.php
@@ -33,7 +33,7 @@ use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Element\Service;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -54,9 +54,7 @@ abstract class ElementControllerBase extends AdminAbstractController
         return [];
     }
 
-    /**
-     * @Route("/tree-get-root", name="treegetroot", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-root', name: 'treegetroot', methods: ['GET'])]
     public function treeGetRootAction(Request $request): JsonResponse
     {
         $type = $request->get('elementType');
@@ -80,10 +78,9 @@ abstract class ElementControllerBase extends AdminAbstractController
     }
 
     /**
-     * @Route("/delete-info", name="deleteinfo", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/delete-info', name: 'deleteinfo', methods: ['GET'])]
     public function deleteInfoAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $hasDependency = false;

--- a/src/Controller/Admin/EmailController.php
+++ b/src/Controller/Admin/EmailController.php
@@ -27,20 +27,18 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Mime\Address;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/email")
- *
  * @internal
  */
+#[Route(path: '/email', name: 'pimcore_admin_email_')]
 class EmailController extends AdminAbstractController
 {
     /**
-     * @Route("/email-logs", name="pimcore_admin_email_emaillogs", methods={"GET", "POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/email-logs', name: 'emaillogs', methods: ['GET', 'POST'])]
     public function emailLogsAction(Request $request): JsonResponse
     {
         if (!$this->getAdminUser()->isAllowed('emails') && !$this->getAdminUser()->isAllowed('gdpr_data_extractor')) {
@@ -111,10 +109,9 @@ class EmailController extends AdminAbstractController
     }
 
     /**
-     * @Route("/show-email-log", name="pimcore_admin_email_showemaillog", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/show-email-log', name: 'showemaillog', methods: ['GET'])]
     public function showEmailLogAction(Request $request, ?Profiler $profiler): JsonResponse|Response
     {
         if ($profiler) {
@@ -240,10 +237,9 @@ class EmailController extends AdminAbstractController
     }
 
     /**
-     * @Route("/delete-email-log", name="pimcore_admin_email_deleteemaillog", methods={"DELETE"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/delete-email-log', name: 'deleteemaillog', methods: ['DELETE'])]
     public function deleteEmailLogAction(Request $request): JsonResponse
     {
         if (!$this->getAdminUser()->isAllowed('emails')) {
@@ -263,10 +259,9 @@ class EmailController extends AdminAbstractController
     }
 
     /**
-     * @Route("/resend-email", name="pimcore_admin_email_resendemail", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/resend-email', name: 'resendemail', methods: ['POST'])]
     public function resendEmailAction(Request $request): JsonResponse
     {
         if (!$this->getAdminUser()->isAllowed('emails')) {
@@ -354,10 +349,9 @@ class EmailController extends AdminAbstractController
     }
 
     /**
-     * @Route("/send-test-email", name="pimcore_admin_email_sendtestemail", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/send-test-email', name: 'sendtestemail', methods: ['POST'])]
     public function sendTestEmailAction(Request $request): JsonResponse
     {
         if (!$this->getAdminUser()->isAllowed('emails')) {
@@ -418,10 +412,9 @@ class EmailController extends AdminAbstractController
     }
 
     /**
-     * @Route("/blocklist", name="pimcore_admin_email_blocklist", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/blocklist', name: 'blocklist', methods: ['POST'])]
     public function blocklistAction(Request $request): JsonResponse
     {
         if (!$this->getAdminUser()->isAllowed('emails')) {

--- a/src/Controller/Admin/IndexController.php
+++ b/src/Controller/Admin/IndexController.php
@@ -49,7 +49,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
@@ -68,10 +68,9 @@ class IndexController extends AdminAbstractController implements KernelResponseE
     }
 
     /**
-     * @Route("/", name="pimcore_admin_index", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/', name: 'pimcore_admin_index', methods: ['GET'])]
     public function indexAction(
         Request $request,
         KernelInterface $kernel,
@@ -118,10 +117,9 @@ class IndexController extends AdminAbstractController implements KernelResponseE
     }
 
     /**
-     * @Route("/index/statistics", name="pimcore_admin_index_statistics", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/index/statistics', name: 'pimcore_admin_index_statistics', methods: ['GET'])]
     public function statisticsAction(Request $request, Connection $db, KernelInterface $kernel): JsonResponse
     {
         if (!$request->isXmlHttpRequest()) {

--- a/src/Controller/Admin/InstallController.php
+++ b/src/Controller/Admin/InstallController.php
@@ -22,18 +22,15 @@ use Pimcore\Tool\Requirements;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/install")
- *
  * @internal
  */
+#[Route(path: '/install', name: 'pimcore_admin_install_')]
 class InstallController extends AdminAbstractController
 {
-    /**
-     * @Route("/check", name="pimcore_admin_install_check", methods={"GET", "POST"})
-     */
+    #[Route(path: '/check', name: 'check', methods: ['GET', 'POST'])]
     public function checkAction(Request $request, Connection $db, ?Profiler $profiler): Response
     {
         if ($profiler) {

--- a/src/Controller/Admin/LoginController.php
+++ b/src/Controller/Admin/LoginController.php
@@ -44,7 +44,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -94,10 +94,8 @@ class LoginController extends AdminAbstractController implements KernelControlle
         $this->responseHelper->disableCache($response, true);
     }
 
-    /**
-     * @Route("/login", name="pimcore_admin_login")
-     * @Route("/login/", name="pimcore_admin_login_fallback")
-     */
+    #[Route(path: '/login', name: 'pimcore_admin_login')]
+    #[Route(path: '/login/', name: 'pimcore_admin_login_fallback')]
     public function loginAction(
         Request $request,
         AuthenticationUtils $authenticationUtils,
@@ -164,9 +162,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         return $this->render('@PimcoreAdmin/admin/login/login.html.twig', $params);
     }
 
-    /**
-     * @Route("/login/csrf-token", name="pimcore_admin_login_csrf_token")
-     */
+    #[Route(path: '/login/csrf-token', name: 'pimcore_admin_login_csrf_token')]
     public function csrfTokenAction(Request $request, CsrfProtectionHandler $csrfProtection): \Symfony\Component\HttpFoundation\JsonResponse
     {
         if (!$this->getAdminUser()) {
@@ -178,9 +174,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         ]);
     }
 
-    /**
-     * @Route("/logout", name="pimcore_admin_logout" , methods={"POST"})
-     */
+    #[Route(path: '/logout', name: 'pimcore_admin_logout', methods: ['POST'])]
     public function logoutAction(): void
     {
         // this route will never be matched, but will be handled by the logout handler
@@ -188,18 +182,15 @@ class LoginController extends AdminAbstractController implements KernelControlle
 
     /**
      * Dummy route used to check authentication
-     *
-     * @Route("/login/login", name="pimcore_admin_login_check")
      */
+    #[Route(path: '/login/login', name: 'pimcore_admin_login_check')]
     public function loginCheckAction(Request $request): RedirectResponse
     {
         // just in case the authenticator didn't redirect
         return new RedirectResponse($this->generateUrl('pimcore_admin_login', ['perspective' => strip_tags($request->get('perspective', ''))]));
     }
 
-    /**
-     * @Route("/login/lostpassword", name="pimcore_admin_login_lostpassword")
-     */
+    #[Route(path: '/login/lostpassword', name: 'pimcore_admin_login_lostpassword')]
     public function lostpasswordAction(
         Request $request,
         CsrfProtectionHandler $csrfProtection,
@@ -289,9 +280,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         return $this->render('@PimcoreAdmin/admin/login/lost_password.html.twig', $params);
     }
 
-    /**
-     * @Route("/login/deeplink", name="pimcore_admin_login_deeplink")
-     */
+    #[Route(path: '/login/deeplink', name: 'pimcore_admin_login_deeplink')]
     public function deeplinkAction(Request $request): Response
     {
         // check for deeplink
@@ -337,9 +326,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         ];
     }
 
-    /**
-     * @Route("/login/2fa", name="pimcore_admin_2fa")
-     */
+    #[Route(path: '/login/2fa', name: 'pimcore_admin_2fa')]
     public function twoFactorAuthenticationAction(Request $request, Config $config): Response
     {
         $params = $this->buildLoginPageViewParams($config);
@@ -359,9 +346,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         return $this->render('@PimcoreAdmin/admin/login/two_factor_authentication.html.twig', $params);
     }
 
-    /**
-     * @Route("/login/2fa-setup", name="pimcore_admin_2fa_setup")
-     */
+    #[Route(path: '/login/2fa-setup', name: 'pimcore_admin_2fa_setup')]
     public function twoFactorSetupAuthenticationAction(
         Request $request,
         Config $config,
@@ -418,9 +403,7 @@ class LoginController extends AdminAbstractController implements KernelControlle
         return $this->render('@PimcoreAdmin/admin/login/two_factor_setup.html.twig', $params);
     }
 
-    /**
-     * @Route("/login/2fa-verify", name="pimcore_admin_2fa-verify")
-     */
+    #[Route(path: '/login/2fa-verify', name: 'pimcore_admin_2fa-verify')]
     public function twoFactorAuthenticationVerifyAction(Request $request): void
     {
     }

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -30,19 +30,16 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/misc")
- *
  * @internal
  */
+#[Route(path: '/misc', name: 'pimcore_admin_misc_')]
 class MiscController extends AdminAbstractController
 {
-    /**
-     * @Route("/get-available-controller-references", name="pimcore_admin_misc_getavailablecontroller_references", methods={"GET"})
-     */
+    #[Route(path: '/get-available-controller-references', name: 'getavailablecontroller_references', methods: ['GET'])]
     public function getAvailableControllerReferencesAction(Request $request, ControllerDataProvider $provider): JsonResponse
     {
         $controllerReferences = $provider->getControllerReferences();
@@ -60,9 +57,7 @@ class MiscController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/get-available-templates", name="pimcore_admin_misc_getavailabletemplates", methods={"GET"})
-     */
+    #[Route(path: '/get-available-templates', name: 'getavailabletemplates', methods: ['GET'])]
     public function getAvailableTemplatesAction(ControllerDataProvider $provider): JsonResponse
     {
         $templates = $provider->getTemplates();
@@ -80,9 +75,7 @@ class MiscController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/json-translations-system", name="pimcore_admin_misc_jsontranslationssystem", methods={"GET"})
-     */
+    #[Route(path: '/json-translations-system', name: 'jsontranslationssystem', methods: ['GET'])]
     public function jsonTranslationsSystemAction(Request $request, TranslatorInterface $translator): Response
     {
         $language = $request->get('language');
@@ -122,10 +115,9 @@ class MiscController extends AdminAbstractController
     }
 
     /**
-     * @Route("/script-proxy", name="pimcore_admin_misc_scriptproxy", methods={"GET"})
-     *
      * @internal
      */
+    #[Route(path: '/script-proxy', name: 'scriptproxy', methods: ['GET'])]
     public function scriptProxyAction(Request $request): Response
     {
         $storageFile = $request->get('storageFile');
@@ -157,9 +149,7 @@ class MiscController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/admin-css", name="pimcore_admin_misc_admincss", methods={"GET"})
-     */
+    #[Route(path: '/admin-css', name: 'admincss', methods: ['GET'])]
     public function adminCssAction(Request $request, Config $config): Response
     {
         // customviews config
@@ -180,9 +170,7 @@ class MiscController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/ping", name="pimcore_admin_misc_ping", methods={"GET"})
-     */
+    #[Route(path: '/ping', name: 'ping', methods: ['GET'])]
     public function pingAction(Request $request): JsonResponse
     {
         $response = [
@@ -192,9 +180,7 @@ class MiscController extends AdminAbstractController
         return $this->adminJson($response);
     }
 
-    /**
-     * @Route("/available-languages", name="pimcore_admin_misc_availablelanguages", methods={"GET"})
-     */
+    #[Route(path: '/available-languages', name: 'availablelanguages', methods: ['GET'])]
     public function availableLanguagesAction(Request $request): Response
     {
         $locales = Tool::getSupportedLocales();
@@ -204,9 +190,7 @@ class MiscController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/get-valid-filename", name="pimcore_admin_misc_getvalidfilename", methods={"GET"})
-     */
+    #[Route(path: '/get-valid-filename', name: 'getvalidfilename', methods: ['GET'])]
     public function getValidFilenameAction(Request $request): JsonResponse
     {
         return $this->adminJson([
@@ -214,9 +198,7 @@ class MiscController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/maintenance", name="pimcore_admin_misc_maintenance", methods={"POST"})
-     */
+    #[Route(path: '/maintenance', name: 'maintenance', methods: ['POST'])]
     public function maintenanceAction(Request $request, Tool\MaintenanceModeHelperInterface $maintenanceModeHelper): JsonResponse
     {
         $this->checkPermission('maintenance_mode');
@@ -237,9 +219,7 @@ class MiscController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/country-list", name="pimcore_admin_misc_countrylist", methods={"GET"})
-     */
+    #[Route(path: '/country-list', name: 'countrylist', methods: ['GET'])]
     public function countryListAction(LocaleServiceInterface $localeService): JsonResponse
     {
         $countries = $localeService->getDisplayRegions();
@@ -258,9 +238,7 @@ class MiscController extends AdminAbstractController
         return $this->adminJson(['data' => $options]);
     }
 
-    /**
-     * @Route("/language-list", name="pimcore_admin_misc_languagelist", methods={"GET"})
-     */
+    #[Route(path: '/language-list', name: 'languagelist', methods: ['GET'])]
     public function languageListAction(Request $request): JsonResponse
     {
         $locales = Tool::getSupportedLocales();
@@ -276,9 +254,7 @@ class MiscController extends AdminAbstractController
         return $this->adminJson(['data' => $options]);
     }
 
-    /**
-     * @Route("/get-language-flag", name="pimcore_admin_misc_getlanguageflag", methods={"GET"})
-     */
+    #[Route(path: '/get-language-flag', name: 'getlanguageflag', methods: ['GET'])]
     public function getLanguageFlagAction(Request $request): BinaryFileResponse
     {
         $iconPath = AdminTool::getLanguageFlagFile($request->get('language'));
@@ -288,9 +264,7 @@ class MiscController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/icon-list", name="pimcore_admin_misc_iconlist", methods={"GET"})
-     */
+    #[Route(path: '/icon-list', name: 'iconlist', methods: ['GET'])]
     public function iconListAction(Request $request, ?Profiler $profiler): Response
     {
         if ($profiler) {
@@ -358,9 +332,7 @@ class MiscController extends AdminAbstractController
         return $languageOptions;
     }
 
-    /**
-     * @Route("/test", name="pimcore_admin_misc_test")
-     */
+    #[Route(path: '/test', name: 'test')]
     public function testAction(Request $request): Response
     {
         return new Response('done');

--- a/src/Controller/Admin/NotificationController.php
+++ b/src/Controller/Admin/NotificationController.php
@@ -25,19 +25,16 @@ use Pimcore\Model\Notification\Service\UserService;
 use Pimcore\Model\User;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/notification")
- *
  * @internal
  */
+#[Route(path: '/notification', name: 'pimcore_admin_notification_')]
 class NotificationController extends AdminAbstractController
 {
-    /**
-     * @Route("/recipients", name="pimcore_admin_notification_recipients", methods={"GET"})
-     */
+    #[Route(path: '/recipients', name: 'recipients', methods: ['GET'])]
     public function recipientsAction(UserService $service, TranslatorInterface $translator): JsonResponse
     {
         $this->checkPermission('notifications_send');
@@ -57,9 +54,7 @@ class NotificationController extends AdminAbstractController
         return $this->adminJson($data);
     }
 
-    /**
-     * @Route("/send", name="pimcore_admin_notification_send", methods={"POST"})
-     */
+    #[Route(path: '/send', name: 'send', methods: ['POST'])]
     public function sendAction(Request $request, NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications_send');
@@ -85,9 +80,7 @@ class NotificationController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/find", name="pimcore_admin_notification_find", methods={"GET"})
-     */
+    #[Route(path: '/find', name: 'find', methods: ['GET'])]
     public function findAction(Request $request, NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications');
@@ -112,9 +105,7 @@ class NotificationController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/find-all", name="pimcore_admin_notification_findall", methods={"POST"})
-     */
+    #[Route(path: '/find-all', name: 'findall', methods: ['POST'])]
     public function findAllAction(Request $request, NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications');
@@ -146,9 +137,7 @@ class NotificationController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/find-last-unread", name="pimcore_admin_notification_findlastunread", methods={"GET"})
-     */
+    #[Route(path: '/find-last-unread', name: 'findlastunread', methods: ['GET'])]
     public function findLastUnreadAction(Request $request, NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications');
@@ -172,9 +161,7 @@ class NotificationController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/mark-as-read", name="pimcore_admin_notification_markasread", methods={"PUT"})
-     */
+    #[Route(path: '/mark-as-read', name: 'markasread', methods: ['PUT'])]
     public function markAsReadAction(Request $request, NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications');
@@ -185,9 +172,7 @@ class NotificationController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/delete", name="pimcore_admin_notification_delete", methods={"DELETE"})
-     */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request, NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications');
@@ -198,9 +183,7 @@ class NotificationController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/delete-all", name="pimcore_admin_notification_deleteall", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-all', name: 'deleteall', methods: ['DELETE'])]
     public function deleteAllAction(NotificationService $service): JsonResponse
     {
         $this->checkPermission('notifications');

--- a/src/Controller/Admin/PortalController.php
+++ b/src/Controller/Admin/PortalController.php
@@ -25,13 +25,12 @@ use Pimcore\Model\Document;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @Route("/portal")
- *
  * @internal
  */
+#[Route(path: '/portal', name: 'pimcore_admin_portal_')]
 class PortalController extends AdminAbstractController implements KernelControllerEventInterface
 {
     protected ?Dashboard $dashboardHelper = null;
@@ -46,9 +45,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         $this->dashboardHelper->saveDashboard($request->get('key'), $config);
     }
 
-    /**
-     * @Route("/dashboard-list", name="pimcore_admin_portal_dashboardlist", methods={"GET"})
-     */
+    #[Route(path: '/dashboard-list', name: 'dashboardlist', methods: ['GET'])]
     public function dashboardListAction(Request $request): JsonResponse
     {
         $dashboards = $this->dashboardHelper->getAllDashboards();
@@ -63,9 +60,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson($data);
     }
 
-    /**
-     * @Route("/create-dashboard", name="pimcore_admin_portal_createdashboard", methods={"POST"})
-     */
+    #[Route(path: '/create-dashboard', name: 'createdashboard', methods: ['POST'])]
     public function createDashboardAction(Request $request): JsonResponse
     {
         $dashboards = $this->dashboardHelper->getAllDashboards();
@@ -82,9 +77,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         }
     }
 
-    /**
-     * @Route("/delete-dashboard", name="pimcore_admin_portal_deletedashboard", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-dashboard', name: 'deletedashboard', methods: ['DELETE'])]
     public function deleteDashboardAction(Request $request): JsonResponse
     {
         $key = $request->get('key');
@@ -93,17 +86,13 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/get-configuration", name="pimcore_admin_portal_getconfiguration", methods={"GET"})
-     */
+    #[Route(path: '/get-configuration', name: 'getconfiguration', methods: ['GET'])]
     public function getConfigurationAction(Request $request): JsonResponse
     {
         return $this->adminJson($this->getCurrentConfiguration($request));
     }
 
-    /**
-     * @Route("/remove-widget", name="pimcore_admin_portal_removewidget", methods={"DELETE"})
-     */
+    #[Route(path: '/remove-widget', name: 'removewidget', methods: ['DELETE'])]
     public function removeWidgetAction(Request $request): JsonResponse
     {
         $config = $this->getCurrentConfiguration($request);
@@ -125,9 +114,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/add-widget", name="pimcore_admin_portal_addwidget", methods={"POST"})
-     */
+    #[Route(path: '/add-widget', name: 'addwidget', methods: ['POST'])]
     public function addWidgetAction(Request $request): JsonResponse
     {
         $config = $this->getCurrentConfiguration($request);
@@ -147,9 +134,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson(['success' => true, 'id' => $nextId]);
     }
 
-    /**
-     * @Route("/reorder-widget", name="pimcore_admin_portal_reorderwidget", methods={"PUT"})
-     */
+    #[Route(path: '/reorder-widget', name: 'reorderwidget', methods: ['PUT'])]
     public function reorderWidgetAction(Request $request): JsonResponse
     {
         $config = $this->getCurrentConfiguration($request);
@@ -176,9 +161,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/update-portlet-config", name="pimcore_admin_portal_updateportletconfig", methods={"PUT"})
-     */
+    #[Route(path: '/update-portlet-config', name: 'updateportletconfig', methods: ['PUT'])]
     public function updatePortletConfigAction(Request $request): JsonResponse
     {
         $key = $request->get('key');
@@ -200,9 +183,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/portlet-modified-documents", name="pimcore_admin_portal_portletmodifieddocuments", methods={"GET"})
-     */
+    #[Route(path: '/portlet-modified-documents', name: 'portletmodifieddocuments', methods: ['GET'])]
     public function portletModifiedDocumentsAction(Request $request): JsonResponse
     {
         $list = Document::getList([
@@ -229,9 +210,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson($response);
     }
 
-    /**
-     * @Route("/portlet-modified-assets", name="pimcore_admin_portal_portletmodifiedassets", methods={"GET"})
-     */
+    #[Route(path: '/portlet-modified-assets', name: 'portletmodifiedassets', methods: ['GET'])]
     public function portletModifiedAssetsAction(Request $request): JsonResponse
     {
         $list = Asset::getList([
@@ -261,9 +240,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson($response);
     }
 
-    /**
-     * @Route("/portlet-modified-objects", name="pimcore_admin_portal_portletmodifiedobjects", methods={"GET"})
-     */
+    #[Route(path: '/portlet-modified-objects', name: 'portletmodifiedobjects', methods: ['GET'])]
     public function portletModifiedObjectsAction(Request $request): JsonResponse
     {
         $list = DataObject::getList([
@@ -290,9 +267,7 @@ class PortalController extends AdminAbstractController implements KernelControll
         return $this->adminJson($response);
     }
 
-    /**
-     * @Route("/portlet-modification-statistics", name="pimcore_admin_portal_portletmodificationstatistics", methods={"GET"})
-     */
+    #[Route(path: '/portlet-modification-statistics', name: 'portletmodificationstatistics', methods: ['GET'])]
     public function portletModificationStatisticsAction(Request $request): JsonResponse
     {
         $db = \Pimcore\Db::get();

--- a/src/Controller/Admin/RecyclebinController.php
+++ b/src/Controller/Admin/RecyclebinController.php
@@ -23,16 +23,15 @@ use Pimcore\Model\Element\Recyclebin;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @internal
  */
+#[Route(path: '/recyclebin', name: 'pimcore_admin_recyclebin_')]
 class RecyclebinController extends AdminAbstractController implements KernelControllerEventInterface
 {
-    /**
-     * @Route("/recyclebin/list", name="pimcore_admin_recyclebin_list", methods={"POST"})
-     */
+    #[Route(path: '/list', name: 'list', methods: ['POST'])]
     public function listAction(Request $request): JsonResponse
     {
         if ($request->get('xaction') == 'destroy') {
@@ -138,9 +137,7 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
         }
     }
 
-    /**
-     * @Route("/recyclebin/restore", name="pimcore_admin_recyclebin_restore", methods={"POST"})
-     */
+    #[Route(path: '/restore', name: 'restore', methods: ['POST'])]
     public function restoreAction(Request $request): JsonResponse
     {
         $item = Recyclebin\Item::getById((int) $request->get('id'));
@@ -152,9 +149,7 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/recyclebin/flush", name="pimcore_admin_recyclebin_flush", methods={"DELETE"})
-     */
+    #[Route(path: '/flush', name: 'flush', methods: ['DELETE'])]
     public function flushAction(): JsonResponse
     {
         $bin = new Element\Recyclebin();
@@ -163,9 +158,7 @@ class RecyclebinController extends AdminAbstractController implements KernelCont
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/recyclebin/add", name="pimcore_admin_recyclebin_add", methods={"POST"})
-     */
+    #[Route(path: '/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request): JsonResponse
     {
         try {

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -47,14 +47,13 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/settings")
- *
  * @internal
  */
+#[Route(path: '/settings', name: 'pimcore_admin_settings_')]
 class SettingsController extends AdminAbstractController
 {
     use StopMessengerWorkersTrait;
@@ -65,9 +64,7 @@ class SettingsController extends AdminAbstractController
     {
     }
 
-    /**
-     * @Route("/display-custom-logo", name="pimcore_settings_display_custom_logo", methods={"GET"})
-     */
+    #[Route(path: '/display-custom-logo', name: 'display_custom_logo', methods: ['GET'])]
     public function displayCustomLogoAction(Request $request): StreamedResponse
     {
         $mime = 'image/svg+xml';
@@ -98,10 +95,9 @@ class SettingsController extends AdminAbstractController
     }
 
     /**
-     * @Route("/upload-custom-logo", name="pimcore_admin_settings_uploadcustomlogo", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/upload-custom-logo', name: 'uploadcustomlogo', methods: ['POST'])]
     public function uploadCustomLogoAction(Request $request): JsonResponse
     {
         $logoFile = $request->files->get('Filedata');
@@ -124,9 +120,7 @@ class SettingsController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/delete-custom-logo", name="pimcore_admin_settings_deletecustomlogo", methods={"DELETE"})
-     */
+    #[Route(path: '/delete-custom-logo', name: 'deletecustomlogo', methods: ['DELETE'])]
     public function deleteCustomLogoAction(Request $request): JsonResponse
     {
         if (Tool\Storage::get('admin')->fileExists(self::CUSTOM_LOGO_PATH)) {
@@ -138,9 +132,8 @@ class SettingsController extends AdminAbstractController
 
     /**
      * Used by the predefined metadata grid
-     *
-     * @Route("/predefined-metadata", name="pimcore_admin_settings_metadata", methods={"POST"})
      */
+    #[Route(path: '/predefined-metadata', name: 'metadata', methods: ['POST'])]
     public function metadataAction(Request $request): JsonResponse
     {
         $this->checkPermission('asset_metadata');
@@ -233,9 +226,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @Route("/get-predefined-metadata", name="pimcore_admin_settings_getpredefinedmetadata", methods={"GET"})
-     */
+    #[Route(path: '/get-predefined-metadata', name: 'getpredefinedmetadata', methods: ['GET'])]
     public function getPredefinedMetadataAction(Request $request): JsonResponse
     {
         $type = $request->get('type');
@@ -256,9 +247,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['data' => $result, 'success' => true]);
     }
 
-    /**
-     * @Route("/properties", name="pimcore_admin_settings_properties", methods={"POST"})
-     */
+    #[Route(path: '/properties', name: 'properties', methods: ['POST'])]
     public function propertiesAction(Request $request): JsonResponse
     {
         if ($request->get('data')) {
@@ -346,9 +335,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => false]);
     }
 
-    /**
-     * @Route("/get-admin-system", name="pimcore_appearance_admin_settings_get", methods={"GET"})
-     */
+    #[Route(path: '/get-admin-system', name: 'pimcore_appearance_admin_settings_get', methods: ['GET'])]
     public function getAppearanceSystemAction(AdminConfig $config): JsonResponse
     {
         $this->checkPermission('system_appearance_settings');
@@ -361,9 +348,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($response);
     }
 
-    /**
-     * @Route("/get-system", name="pimcore_admin_settings_getsystem", methods={"GET"})
-     */
+    #[Route(path: '/get-system', name: 'getsystem', methods: ['GET'])]
     public function getSystemAction(Request $request, SystemSettingsConfig $config): JsonResponse
     {
         $this->checkPermission('system_settings');
@@ -417,9 +402,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($response);
     }
 
-    /**
-     * @Route("/set-appearance", name="pimcore_admin_settings_appearance_set", methods={"PUT"})
-     */
+    #[Route(path: '/set-appearance', name: 'appearance_set', methods: ['PUT'])]
     public function setAppearanceSystemAction(
         Request $request,
         KernelInterface $kernel,
@@ -451,9 +434,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/set-system", name="pimcore_admin_settings_setsystem", methods={"PUT"})
-     */
+    #[Route(path: '/set-system', name: 'setsystem', methods: ['PUT'])]
     public function setSystemAction(
         Request $request,
         KernelInterface $kernel,
@@ -485,9 +466,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/clear-cache", name="pimcore_admin_settings_clearcache", methods={"DELETE"})
-     */
+    #[Route(path: '/clear-cache', name: 'clearcache', methods: ['DELETE'])]
     public function clearCacheAction(
         Request $request,
         KernelInterface $kernel,
@@ -597,9 +576,7 @@ class SettingsController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/clear-output-cache", name="pimcore_admin_settings_clearoutputcache", methods={"DELETE"})
-     */
+    #[Route(path: '/clear-output-cache', name: 'clearoutputcache', methods: ['DELETE'])]
     public function clearOutputCacheAction(EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $this->checkPermission('clear_fullpage_cache');
@@ -615,9 +592,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/clear-temporary-files", name="pimcore_admin_settings_cleartemporaryfiles", methods={"DELETE"})
-     */
+    #[Route(path: '/clear-temporary-files', name: 'cleartemporaryfiles', methods: ['DELETE'])]
     public function clearTemporaryFilesAction(EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $this->checkPermission('clear_temp_files');
@@ -636,9 +611,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/get-available-admin-languages", name="pimcore_admin_settings_getavailableadminlanguages", methods={"GET"})
-     */
+    #[Route(path: '/get-available-admin-languages', name: 'getavailableadminlanguages', methods: ['GET'])]
     public function getAvailableAdminLanguagesAction(Request $request): JsonResponse
     {
         $langs = [];
@@ -661,9 +634,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($langs);
     }
 
-    /**
-     * @Route("/get-available-sites", name="pimcore_admin_settings_getavailablesites", methods={"GET"})
-     */
+    #[Route(path: '/get-available-sites', name: 'getavailablesites', methods: ['GET'])]
     public function getAvailableSitesAction(Request $request): JsonResponse
     {
         try {
@@ -711,9 +682,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($sites);
     }
 
-    /**
-     * @Route("/get-available-countries", name="pimcore_admin_settings_getavailablecountries", methods={"GET"})
-     */
+    #[Route(path: '/get-available-countries', name: 'getavailablecountries', methods: ['GET'])]
     public function getAvailableCountriesAction(LocaleServiceInterface $localeService): JsonResponse
     {
         $countries = $localeService->getDisplayRegions();
@@ -735,9 +704,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/thumbnail-adapter-check", name="pimcore_admin_settings_thumbnailadaptercheck", methods={"GET"})
-     */
+    #[Route(path: '/thumbnail-adapter-check', name: 'thumbnailadaptercheck', methods: ['GET'])]
     public function thumbnailAdapterCheckAction(Request $request, TranslatorInterface $translator): Response
     {
         $content = '';
@@ -752,9 +719,7 @@ class SettingsController extends AdminAbstractController
         return new Response($content);
     }
 
-    /**
-     * @Route("/thumbnail-tree", name="pimcore_admin_settings_thumbnailtree", methods={"GET", "POST"})
-     */
+    #[Route(path: '/thumbnail-tree', name: 'thumbnailtree', methods: ['GET', 'POST'])]
     public function thumbnailTreeAction(): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -806,9 +771,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($thumbnails);
     }
 
-    /**
-     * @Route("/thumbnail-downloadable", name="pimcore_admin_settings_thumbnaildownloadable", methods={"GET"})
-     */
+    #[Route(path: '/thumbnail-downloadable', name: 'thumbnaildownloadable', methods: ['GET'])]
     public function thumbnailDownloadableAction(): JsonResponse
     {
         $thumbnails = [];
@@ -828,9 +791,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($thumbnails);
     }
 
-    /**
-     * @Route("/thumbnail-add", name="pimcore_admin_settings_thumbnailadd", methods={"POST"})
-     */
+    #[Route(path: '/thumbnail-add', name: 'thumbnailadd', methods: ['POST'])]
     public function thumbnailAddAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -858,9 +819,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => $success, 'id' => $pipe->getName()]);
     }
 
-    /**
-     * @Route("/thumbnail-delete", name="pimcore_admin_settings_thumbnaildelete", methods={"DELETE"})
-     */
+    #[Route(path: '/thumbnail-delete', name: 'thumbnaildelete', methods: ['DELETE'])]
     public function thumbnailDeleteAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -876,9 +835,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/thumbnail-get", name="pimcore_admin_settings_thumbnailget", methods={"GET"})
-     */
+    #[Route(path: '/thumbnail-get', name: 'thumbnailget', methods: ['GET'])]
     public function thumbnailGetAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -890,9 +847,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($data);
     }
 
-    /**
-     * @Route("/thumbnail-update", name="pimcore_admin_settings_thumbnailupdate", methods={"PUT"})
-     */
+    #[Route(path: '/thumbnail-update', name: 'thumbnailupdate', methods: ['PUT'])]
     public function thumbnailUpdateAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -942,9 +897,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/video-thumbnail-adapter-check", name="pimcore_admin_settings_videothumbnailadaptercheck", methods={"GET"})
-     */
+    #[Route(path: '/video-thumbnail-adapter-check', name: 'videothumbnailadaptercheck', methods: ['GET'])]
     public function videoThumbnailAdapterCheckAction(Request $request, TranslatorInterface $translator): Response
     {
         $content = '';
@@ -958,9 +911,7 @@ class SettingsController extends AdminAbstractController
         return new Response($content);
     }
 
-    /**
-     * @Route("/video-thumbnail-tree", name="pimcore_admin_settings_videothumbnailtree", methods={"GET", "POST"})
-     */
+    #[Route(path: '/video-thumbnail-tree', name: 'videothumbnailtree', methods: ['GET', 'POST'])]
     public function videoThumbnailTreeAction(): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -1012,9 +963,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($thumbnails);
     }
 
-    /**
-     * @Route("/video-thumbnail-list", name="pimcore_admin_settings_videothumbnail_list", methods={"GET"})
-     */
+    #[Route(path: '/video-thumbnail-list', name: 'videothumbnail_list', methods: ['GET'])]
     public function videoThumbnailListAction(): JsonResponse
     {
         $thumbnails = [
@@ -1032,9 +981,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($thumbnails);
     }
 
-    /**
-     * @Route("/video-thumbnail-add", name="pimcore_admin_settings_videothumbnailadd", methods={"POST"})
-     */
+    #[Route(path: '/video-thumbnail-add', name: 'videothumbnailadd', methods: ['POST'])]
     public function videoThumbnailAddAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -1062,9 +1009,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => $success, 'id' => $pipe->getName()]);
     }
 
-    /**
-     * @Route("/video-thumbnail-delete", name="pimcore_admin_settings_videothumbnaildelete", methods={"DELETE"})
-     */
+    #[Route(path: '/video-thumbnail-delete', name: 'videothumbnaildelete', methods: ['DELETE'])]
     public function videoThumbnailDeleteAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -1080,9 +1025,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/video-thumbnail-get", name="pimcore_admin_settings_videothumbnailget", methods={"GET"})
-     */
+    #[Route(path: '/video-thumbnail-get', name: 'videothumbnailget', methods: ['GET'])]
     public function videoThumbnailGetAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -1095,9 +1038,7 @@ class SettingsController extends AdminAbstractController
         return $this->adminJson($data);
     }
 
-    /**
-     * @Route("/video-thumbnail-update", name="pimcore_admin_settings_videothumbnailupdate", methods={"PUT"})
-     */
+    #[Route(path: '/video-thumbnail-update', name: 'videothumbnailupdate', methods: ['PUT'])]
     public function videoThumbnailUpdateAction(Request $request): JsonResponse
     {
         $this->checkPermission('thumbnails');
@@ -1144,10 +1085,9 @@ class SettingsController extends AdminAbstractController
     }
 
     /**
-     * @Route("/website-settings", name="pimcore_admin_settings_websitesettings", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/website-settings', name: 'websitesettings', methods: ['POST'])]
     public function websiteSettingsAction(Request $request): JsonResponse
     {
         $this->checkPermission('website_settings');
@@ -1274,9 +1214,7 @@ class SettingsController extends AdminAbstractController
         return $resultItem;
     }
 
-    /**
-     * @Route("/get-available-algorithms", name="pimcore_admin_settings_getavailablealgorithms", methods={"GET"})
-     */
+    #[Route(path: '/get-available-algorithms', name: 'getavailablealgorithms', methods: ['GET'])]
     public function getAvailableAlgorithmsAction(Request $request): JsonResponse
     {
         $options = [

--- a/src/Controller/Admin/TagsController.php
+++ b/src/Controller/Admin/TagsController.php
@@ -22,19 +22,16 @@ use Pimcore\Model\Element\Tag;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
- * @Route("/tags")
- *
  * @internal
  */
+#[Route(path: '/tags', name: 'pimcore_admin_tags_')]
 class TagsController extends AdminAbstractController
 {
-    /**
-     * @Route("/add", name="pimcore_admin_tags_add", methods={"POST"})
-     */
+    #[Route(path: '/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request): JsonResponse
     {
         $this->checkPermission('tags_configuration');
@@ -52,10 +49,9 @@ class TagsController extends AdminAbstractController
     }
 
     /**
-     * @Route("/delete", name="pimcore_admin_tags_delete", methods={"DELETE"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
         $this->checkPermission('tags_configuration');
@@ -71,10 +67,9 @@ class TagsController extends AdminAbstractController
     }
 
     /**
-     * @Route("/update", name="pimcore_admin_tags_update", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/update', name: 'update', methods: ['PUT'])]
     public function updateAction(Request $request): JsonResponse
     {
         $this->checkPermission('tags_configuration');
@@ -97,9 +92,7 @@ class TagsController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/tree-get-children-by-id", name="pimcore_admin_tags_treegetchildrenbyid", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-children-by-id', name: 'treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request): JsonResponse
     {
         $showSelection = $request->get('showSelection') == 'true';
@@ -183,9 +176,7 @@ class TagsController extends AdminAbstractController
         return $tagArray;
     }
 
-    /**
-     * @Route("/load-tags-for-element", name="pimcore_admin_tags_loadtagsforelement", methods={"GET"})
-     */
+    #[Route(path: '/load-tags-for-element', name: 'loadtagsforelement', methods: ['GET'])]
     public function loadTagsForElementAction(Request $request): JsonResponse
     {
         $assginmentCId = (int)$request->get('assignmentCId');
@@ -203,9 +194,7 @@ class TagsController extends AdminAbstractController
         return $this->adminJson($assignedTagArray);
     }
 
-    /**
-     * @Route("/add-tag-to-element", name="pimcore_admin_tags_addtagtoelement", methods={"PUT"})
-     */
+    #[Route(path: '/add-tag-to-element', name: 'addtagtoelement', methods: ['PUT'])]
     public function addTagToElementAction(Request $request): JsonResponse
     {
         $assginmentCId = (int)$request->get('assignmentElementId');
@@ -222,9 +211,7 @@ class TagsController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/remove-tag-from-element", name="pimcore_admin_tags_removetagfromelement", methods={"DELETE"})
-     */
+    #[Route(path: '/remove-tag-from-element', name: 'removetagfromelement', methods: ['DELETE'])]
     public function removeTagFromElementAction(Request $request): JsonResponse
     {
         $assginmentCId = (int)$request->get('assignmentElementId');
@@ -241,9 +228,7 @@ class TagsController extends AdminAbstractController
         }
     }
 
-    /**
-     * @Route("/get-batch-assignment-jobs", name="pimcore_admin_tags_getbatchassignmentjobs", methods={"GET"})
-     */
+    #[Route(path: '/get-batch-assignment-jobs', name: 'getbatchassignmentjobs', methods: ['GET'])]
     public function getBatchAssignmentJobsAction(Request $request, EventDispatcherInterface $eventDispatcher): JsonResponse
     {
         $elementId = (int)$request->get('elementId');
@@ -375,9 +360,7 @@ class TagsController extends AdminAbstractController
         return $childrenList->loadIdList();
     }
 
-    /**
-     * @Route("/do-batch-assignment", name="pimcore_admin_tags_dobatchassignment", methods={"PUT"})
-     */
+    #[Route(path: '/do-batch-assignment', name: 'dobatchassignment', methods: ['PUT'])]
     public function doBatchAssignmentAction(Request $request): JsonResponse
     {
         $cType = strip_tags($request->get('elementType', ''));

--- a/src/Controller/Admin/TranslationController.php
+++ b/src/Controller/Admin/TranslationController.php
@@ -32,21 +32,18 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/translation")
- *
  * @internal
  */
+#[Route(path: '/translation', name: 'pimcore_admin_translation_')]
 class TranslationController extends AdminAbstractController
 {
     protected const PLACEHOLDER_NAME = 'placeHolder';
 
-    /**
-     * @Route("/import", name="pimcore_admin_translation_import", methods={"POST"})
-     */
+    #[Route(path: '/import', name: 'import', methods: ['POST'])]
     public function importAction(Request $request, LocaleServiceInterface $localeService): JsonResponse
     {
         $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
@@ -108,9 +105,7 @@ class TranslationController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/upload-import", name="pimcore_admin_translation_uploadimportfile", methods={"POST"})
-     */
+    #[Route(path: '/upload-import', name: 'uploadimportfile', methods: ['POST'])]
     public function uploadImportFileAction(Request $request, Filesystem $filesystem): JsonResponse
     {
         $tmpData = file_get_contents($_FILES['Filedata']['tmp_name']);
@@ -140,9 +135,7 @@ class TranslationController extends AdminAbstractController
         ]);
     }
 
-    /**
-     * @Route("/export", name="pimcore_admin_translation_export", methods={"GET"})
-     */
+    #[Route(path: '/export', name: 'export', methods: ['GET'])]
     public function exportAction(Request $request): Response
     {
         $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
@@ -273,9 +266,7 @@ class TranslationController extends AdminAbstractController
         return $response;
     }
 
-    /**
-     * @Route("/add-admin-translation-keys", name="pimcore_admin_translation_addadmintranslationkeys", methods={"POST"})
-     */
+    #[Route(path: '/add-admin-translation-keys', name: 'addadmintranslationkeys', methods: ['POST'])]
     public function addAdminTranslationKeysAction(Request $request): JsonResponse
     {
         $keys = $request->get('keys');
@@ -314,10 +305,9 @@ class TranslationController extends AdminAbstractController
     }
 
     /**
-     * @Route("/translations", name="pimcore_admin_translation_translations", methods={"POST"})
-     *
      * @param Translator $translator
      */
+    #[Route(path: '/translations', name: 'translations', methods: ['POST'])]
     public function translationsAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
         $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
@@ -651,9 +641,7 @@ class TranslationController extends AdminAbstractController
         return $conditionFilters;
     }
 
-    /**
-     * @Route("/cleanup", name="pimcore_admin_translation_cleanup", methods={"DELETE"})
-     */
+    #[Route(path: '/cleanup', name: 'cleanup', methods: ['DELETE'])]
     public function cleanupAction(Request $request): JsonResponse
     {
         $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
@@ -666,16 +654,7 @@ class TranslationController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * -----------------------------------------------------------------------------------
-     * THE FOLLOWING ISN'T RELATED TO THE SHARED TRANSLATIONS OR ADMIN-TRANSLATIONS
-     * XLIFF CONTENT-EXPORT & MS WORD CONTENT-EXPORT
-     * -----------------------------------------------------------------------------------
-     */
-
-    /**
-     * @Route("/content-export-jobs", name="pimcore_admin_translation_contentexportjobs", methods={"POST"})
-     */
+    #[Route(path: '/content-export-jobs', name: 'contentexportjobs', methods: ['POST'])]
     public function contentExportJobsAction(Request $request): JsonResponse
     {
         $data = $this->decodeJson($request->get('data'));
@@ -785,9 +764,7 @@ class TranslationController extends AdminAbstractController
         );
     }
 
-    /**
-     * @Route("/merge-item", name="pimcore_admin_translation_mergeitem", methods={"PUT"})
-     */
+    #[Route(path: '/merge-item', name: 'mergeitem', methods: ['PUT'])]
     public function mergeItemAction(Request $request): JsonResponse
     {
         $domain = $request->get('domain', Translation::DOMAIN_DEFAULT);
@@ -809,9 +786,7 @@ class TranslationController extends AdminAbstractController
         );
     }
 
-    /**
-     * @Route("/get-website-translation-languages", name="pimcore_admin_translation_getwebsitetranslationlanguages", methods={"GET"})
-     */
+    #[Route(path: '/get-website-translation-languages', name: 'getwebsitetranslationlanguages', methods: ['GET'])]
     public function getWebsiteTranslationLanguagesAction(Request $request): JsonResponse
     {
         return $this->adminJson(
@@ -825,9 +800,7 @@ class TranslationController extends AdminAbstractController
         );
     }
 
-    /**
-     * @Route("/get-translation-domains", name="pimcore_admin_translation_gettranslationdomains", methods={"GET"})
-     */
+    #[Route(path: '/get-translation-domains', name: 'gettranslationdomains', methods: ['GET'])]
     public function getTranslationDomainsAction(Request $request): JsonResponse
     {
         $translation = new Translation();

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -34,7 +34,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
@@ -44,11 +44,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
+#[Route(path: '/user', name: 'pimcore_admin_user_')]
 class UserController extends AdminAbstractController implements KernelControllerEventInterface
 {
-    /**
-     * @Route("/user/tree-get-children-by-id", name="pimcore_admin_user_treegetchildrenbyid", methods={"GET"})
-     */
+    #[Route(path: '/tree-get-children-by-id', name: 'treegetchildrenbyid', methods: ['GET'])]
     public function treeGetChildrenByIdAction(Request $request): JsonResponse
     {
         $list = new User\Listing();
@@ -106,9 +105,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $tmpUser;
     }
 
-    /**
-     * @Route("/user/add", name="pimcore_admin_user_add", methods={"POST"})
-     */
+    #[Route(path: '/add', name: 'add', methods: ['POST'])]
     public function addAction(Request $request): JsonResponse
     {
         try {
@@ -224,10 +221,9 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     /**
-     * @Route("/user/delete", name="pimcore_admin_user_delete", methods={"DELETE"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/delete', name: 'delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
         $user = User\AbstractUser::getById((int)$request->get('id'));
@@ -257,10 +253,9 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     /**
-     * @Route("/user/update", name="pimcore_admin_user_update", methods={"PUT"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/update', name: 'update', methods: ['PUT'])]
     public function updateAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
         /** @var User|User\Role|null $user */
@@ -366,10 +361,9 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     /**
-     * @Route("/user/get", name="pimcore_admin_user_get", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get', name: 'get', methods: ['GET'])]
     public function getAction(Request $request): JsonResponse
     {
         $userId = (int)$request->get('id');
@@ -472,9 +466,7 @@ class UserController extends AdminAbstractController implements KernelController
         ]);
     }
 
-    /**
-     * @Route("/user/get-minimal", name="pimcore_admin_user_getminimal", methods={"GET"})
-     */
+    #[Route(path: '/get-minimal', name: 'getminimal', methods: ['GET'])]
     public function getMinimalAction(Request $request): JsonResponse
     {
         $user = User::getById((int)$request->get('id'));
@@ -493,9 +485,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $this->adminJson($minimalUserData);
     }
 
-    /**
-     * @Route("/user/upload-current-user-image", name="pimcore_admin_user_uploadcurrentuserimage", methods={"POST"})
-     */
+    #[Route(path: '/upload-current-user-image', name: 'uploadcurrentuserimage', methods: ['POST'])]
     public function uploadCurrentUserImageAction(Request $request): JsonResponse
     {
         $user = $this->getAdminUser();
@@ -512,9 +502,7 @@ class UserController extends AdminAbstractController implements KernelController
         }
     }
 
-    /**
-     * @Route("/user/update-current-user", name="pimcore_admin_user_updatecurrentuser", methods={"PUT"})
-     */
+    #[Route(path: '/update-current-user', name: 'updatecurrentuser', methods: ['PUT'])]
     public function updateCurrentUserAction(Request $request, ValidatorInterface $validator): JsonResponse
     {
         //TODO Can be completely validated with Symfony Validator
@@ -600,9 +588,7 @@ class UserController extends AdminAbstractController implements KernelController
         }
     }
 
-    /**
-     * @Route("/user/get-current-user", name="pimcore_admin_user_getcurrentuser", methods={"GET"})
-     */
+    #[Route(path: '/get-current-user', name: 'getcurrentuser', methods: ['GET'])]
     public function getCurrentUserAction(Request $request): Response
     {
         $user = $this->getAdminUser();
@@ -639,10 +625,7 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     // ROLES
-
-    /**
-     * @Route("/user/role-tree-get-children-by-id", name="pimcore_admin_user_roletreegetchildrenbyid", methods={"GET"})
-     */
+    #[Route(path: '/role-tree-get-children-by-id', name: 'roletreegetchildrenbyid', methods: ['GET'])]
     public function roleTreeGetChildrenByIdAction(Request $request): JsonResponse
     {
         $list = new User\Role\Listing();
@@ -691,9 +674,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $tmpUser;
     }
 
-    /**
-     * @Route("/user/role-get", name="pimcore_admin_user_roleget", methods={"GET"})
-     */
+    #[Route(path: '/role-get', name: 'roleget', methods: ['GET'])]
     public function roleGetAction(Request $request): JsonResponse
     {
         $role = User\Role::getById((int)$request->get('id'));
@@ -742,10 +723,9 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     /**
-     * @Route("/user/upload-image", name="pimcore_admin_user_uploadimage", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/upload-image', name: 'uploadimage', methods: ['POST'])]
     public function uploadImageAction(Request $request): JsonResponse
     {
         $userObj = User::getById($this->getUserId($request));
@@ -779,10 +759,9 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     /**
-     * @Route("/user/delete-image", name="pimcore_admin_user_deleteimage", methods={"DELETE"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/delete-image', name: 'deleteimage', methods: ['DELETE'])]
     public function deleteImageAction(Request $request): JsonResponse
     {
         $userObj = User::getById($this->getUserId($request));
@@ -808,9 +787,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $this->adminJson(['success' => true]);
     }
 
-    /**
-     * @Route("/user/disable-2fa", name="pimcore_admin_user_disable2fasecret", methods={"DELETE"})
-     */
+    #[Route(path: '/disable-2fa', name: 'disable2fasecret', methods: ['DELETE'])]
     public function disable2FaSecretAction(Request $request): JsonResponse
     {
         $user = $this->getAdminUser();
@@ -828,9 +805,7 @@ class UserController extends AdminAbstractController implements KernelController
         ]);
     }
 
-    /**
-     * @Route("/user/reset-2fa-secret", name="pimcore_admin_user_reset2fasecret", methods={"PUT"})
-     */
+    #[Route(path: '/reset-2fa-secret', name: 'reset2fasecret', methods: ['PUT'])]
     public function reset2FaSecretAction(Request $request): JsonResponse
     {
         $user = User::getById((int)$request->get('id'));
@@ -846,9 +821,7 @@ class UserController extends AdminAbstractController implements KernelController
         ]);
     }
 
-    /**
-     * @Route("/user/reset-my-2fa-secret", name="pimcore_admin_user_reset_my_2fa_secret", methods={"PUT"})
-     */
+    #[Route(path: '/reset-my-2fa-secret', name: 'reset_my_2fa_secret', methods: ['PUT'])]
     public function resetMy2FaSecretAction(Request $request): JsonResponse
     {
         $user = $this->getAdminUser();
@@ -862,9 +835,7 @@ class UserController extends AdminAbstractController implements KernelController
         ]);
     }
 
-    /**
-     * @Route("/user/get-image", name="pimcore_admin_user_getimage", methods={"GET"})
-     */
+    #[Route(path: '/get-image', name: 'getimage', methods: ['GET'])]
     public function getImageAction(Request $request): StreamedResponse
     {
         $userObj = User::getById($this->getUserId($request));
@@ -881,10 +852,9 @@ class UserController extends AdminAbstractController implements KernelController
     }
 
     /**
-     * @Route("/user/get-token-login-link", name="pimcore_admin_user_gettokenloginlink", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/get-token-login-link', name: 'gettokenloginlink', methods: ['GET'])]
     public function getTokenLoginLinkAction(Request $request, TranslatorInterface $translator): JsonResponse
     {
         $user = User::getById((int) $request->get('id'));
@@ -921,9 +891,7 @@ class UserController extends AdminAbstractController implements KernelController
         ]);
     }
 
-    /**
-     * @Route("/user/search", name="pimcore_admin_user_search", methods={"GET"})
-     */
+    #[Route(path: '/search', name: 'search', methods: ['GET'])]
     public function searchAction(Request $request): JsonResponse
     {
         $q = '%' . $request->get('query') . '%';
@@ -971,9 +939,7 @@ class UserController extends AdminAbstractController implements KernelController
         $this->checkActionPermission($event, 'users', $unrestrictedActions);
     }
 
-    /**
-     * @Route("/user/get-users-for-sharing", name="pimcore_admin_user_getusersforsharing", methods={"GET"})
-     */
+    #[Route(path: '/get-users-for-sharing', name: 'getusersforsharing', methods: ['GET'])]
     public function getUsersForSharingAction(Request $request): JsonResponse
     {
         $this->checkPermission('share_configurations');
@@ -981,9 +947,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $this->getUsersAction($request);
     }
 
-    /**
-     * @Route("/user/get-roles-for-sharing", name="pimcore_admin_user_getrolesforsharing", methods={"GET"}))
-     */
+    #[Route(path: '/get-roles-for-sharing', name: 'getrolesforsharing', methods: ['GET'])]
     public function getRolesForSharingAction(Request $request): JsonResponse
     {
         $this->checkPermission('share_configurations');
@@ -991,9 +955,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $this->getRolesAction($request);
     }
 
-    /**
-     * @Route("/user/get-users", name="pimcore_admin_user_getusers", methods={"GET"})
-     */
+    #[Route(path: '/get-users', name: 'getusers', methods: ['GET'])]
     public function getUsersAction(Request $request): JsonResponse
     {
         $users = [];
@@ -1024,9 +986,7 @@ class UserController extends AdminAbstractController implements KernelController
         return $this->adminJson(['success' => true, 'total' => count($users), 'data' => $users]);
     }
 
-    /**
-     * @Route("/user/get-roles", name="pimcore_admin_user_getroles", methods={"GET"})
-     */
+    #[Route(path: '/get-roles', name: 'getroles', methods: ['GET'])]
     public function getRolesAction(Request $request): JsonResponse
     {
         $roles = [];
@@ -1048,19 +1008,16 @@ class UserController extends AdminAbstractController implements KernelController
         return $this->adminJson(['success' => true, 'total' => count($roles), 'data' => $roles]);
     }
 
-    /**
-     * @Route("/user/get-default-key-bindings", name="pimcore_admin_user_getdefaultkeybindings", methods={"GET"})
-     */
+    #[Route(path: '/get-default-key-bindings', name: 'getdefaultkeybindings', methods: ['GET'])]
     public function getDefaultKeyBindingsAction(Request $request): JsonResponse
     {
         return $this->adminJson(['success' => true, 'data' => UserHelper::getDefaultKeyBindings()]);
     }
 
     /**
-     * @Route("/user/invitationlink", name="pimcore_admin_user_invitationlink", methods={"POST"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/invitationlink', name: 'invitationlink', methods: ['POST'])]
     public function invitationLinkAction(Request $request, TranslatorInterface $translator, RouterInterface $router): JsonResponse
     {
         $success = false;

--- a/src/Controller/Admin/WorkflowController.php
+++ b/src/Controller/Admin/WorkflowController.php
@@ -34,17 +34,16 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Workflow\Registry;
 use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @Route("/workflow")
- *
  * @internal
  */
+#[Route(path: '/workflow', name: 'pimcore_admin_workflow')]
 class WorkflowController extends AdminAbstractController implements KernelControllerEventInterface
 {
     private ConcreteObject|Document|Asset|null $element;
@@ -55,9 +54,8 @@ class WorkflowController extends AdminAbstractController implements KernelContro
 
     /**
      * Returns a JSON of the available workflow actions to the admin panel
-     *
-     * @Route("/get-workflow-form", name="pimcore_admin_workflow_getworkflowform")
      */
+    #[Route(path: '/get-workflow-form', name: '_getworkflowform')]
     public function getWorkflowFormAction(Request $request, Manager $workflowManager): JsonResponse
     {
         try {
@@ -98,9 +96,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
         return $this->adminJson($wfConfig);
     }
 
-    /**
-     * @Route("/submit-workflow-transition", name="pimcore_admin_workflow_submitworkflowtransition", methods={"POST"})
-     */
+    #[Route(path: '/submit-workflow-transition', name: '_submitworkflowtransition', methods: ['POST'])]
     public function submitWorkflowTransitionAction(Request $request, Registry $workflowRegistry, Manager $workflowManager): JsonResponse
     {
         $workflowOptions = $request->get('workflow', []);
@@ -152,9 +148,7 @@ class WorkflowController extends AdminAbstractController implements KernelContro
         return $this->adminJson($data);
     }
 
-    /**
-     * @Route("/submit-global-action", name="pimcore_admin_workflow_submitglobal", methods={"POST"})
-     */
+    #[Route(path: '/submit-global-action', name: '_submitglobal', methods: ['POST'])]
     public function submitGlobalAction(
         Request $request,
         Registry $workflowRegistry,
@@ -208,10 +202,10 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     /**
      * Returns the JSON needed by the workflow elements detail tab store
      *
-     * @Route("/get-workflow-details", name="pimcore_admin_workflow_getworkflowdetailsstore")
      *
      * @throws \Exception
      */
+    #[Route(path: '/get-workflow-details', name: '_getworkflowdetailsstore')]
     public function getWorkflowDetailsStore(Request $request, Manager $workflowManager, StatusInfo $placeStatusInfo, RouterInterface $router, ActionsButtonService $actionsButtonService): JsonResponse
     {
         $data = [];
@@ -259,10 +253,10 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     /**
      * Returns the JSON needed by the workflow elements detail tab store
      *
-     * @Route("/show-graph", name="pimcore_admin_workflow_show_graph")
      *
      * @throws \Exception
      */
+    #[Route(path: '/show-graph', name: '_show_graph')]
     public function showGraph(Request $request, Manager $workflowManager): Response
     {
         $workflow = $workflowManager->getWorkflowByName($request->get('workflow'));
@@ -276,10 +270,10 @@ class WorkflowController extends AdminAbstractController implements KernelContro
     /**
      * Get custom HTML for the workflow transition submit modal, depending whether it is configured or not.
      *
-     * @Route("/modal-custom-html", name="pimcore_admin_workflow_modal_custom_html", methods={"POST"})
      *
      * @throws \Exception
      */
+    #[Route(path: '/modal-custom-html', name: '_modal_custom_html', methods: ['POST'])]
     public function getModalCustomHtml(Request $request, Registry $workflowRegistry, Manager $manager): JsonResponse
     {
         $workflow = $workflowRegistry->get($this->element, $request->get('workflowName'));

--- a/src/Controller/GDPR/AdminController.php
+++ b/src/Controller/GDPR/AdminController.php
@@ -22,17 +22,16 @@ use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\Manager;
 use Pimcore\Controller\KernelControllerEventInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  *
  * @internal
  */
+#[Route(name: 'pimcore_admin_gdpr_admin_')]
 class AdminController extends AdminAbstractController implements KernelControllerEventInterface
 {
-    /**
-     * @Route("/get-data-providers", name="pimcore_admin_gdpr_admin_getdataproviders", methods={"GET"})
-     */
+    #[Route(path: '/get-data-providers', name: 'getdataproviders', methods: ['GET'])]
     public function getDataProvidersAction(Manager $manager): JsonResponse
     {
         $response = [];

--- a/src/Controller/GDPR/AssetController.php
+++ b/src/Controller/GDPR/AssetController.php
@@ -24,17 +24,16 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class AssetController
  *
- * @Route("/asset")
  *
  * @package GDPRDataExtractorBundle\Controller
- *
  * @internal
  */
+#[Route(path: '/asset', name: 'pimcore_admin_gdpr_asset_')]
 class AssetController extends AdminAbstractController implements KernelControllerEventInterface
 {
     public function onKernelControllerEvent(ControllerEvent $event): void
@@ -46,9 +45,7 @@ class AssetController extends AdminAbstractController implements KernelControlle
         $this->checkActionPermission($event, 'gdpr_data_extractor');
     }
 
-    /**
-     * @Route("/search-assets", name="pimcore_admin_gdpr_asset_searchasset", methods={"GET"})
-     */
+    #[Route(path: '/search-assets', name: 'searchasset', methods: ['GET'])]
     public function searchAssetAction(Request $request, Assets $service): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -67,10 +64,9 @@ class AssetController extends AdminAbstractController implements KernelControlle
     }
 
     /**
-     * @Route("/export", name="pimcore_admin_gdpr_asset_exportassets", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/export', name: 'exportassets', methods: ['GET'])]
     public function exportAssetsAction(Request $request, Assets $service): Response
     {
         $asset = Asset::getById((int) $request->get('id'));

--- a/src/Controller/GDPR/DataObjectController.php
+++ b/src/Controller/GDPR/DataObjectController.php
@@ -23,15 +23,15 @@ use Pimcore\Model\DataObject;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class DataObjectController
  *
- * @Route("/data-object")
  *
  * @internal
  */
+#[Route(path: '/data-object', name: 'pimcore_admin_gdpr_dataobject_')]
 class DataObjectController extends AdminAbstractController implements KernelControllerEventInterface
 {
     public function onKernelControllerEvent(ControllerEvent $event): void
@@ -43,9 +43,7 @@ class DataObjectController extends AdminAbstractController implements KernelCont
         $this->checkActionPermission($event, 'gdpr_data_extractor');
     }
 
-    /**
-     * @Route("/search-data-objects", name="pimcore_admin_gdpr_dataobject_searchdataobjects", methods={"GET"})
-     */
+    #[Route(path: '/search-data-objects', name: 'searchdataobjects', methods: ['GET'])]
     public function searchDataObjectsAction(Request $request, DataObjects $service): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -64,10 +62,9 @@ class DataObjectController extends AdminAbstractController implements KernelCont
     }
 
     /**
-     * @Route("/export", name="pimcore_admin_gdpr_dataobject_exportdataobject", methods={"GET"})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/export', name: 'exportdataobject', methods: ['GET'])]
     public function exportDataObjectAction(Request $request, DataObjects $service): JsonResponse
     {
         $object = DataObject::getById((int) $request->get('id'));

--- a/src/Controller/GDPR/PimcoreUsersController.php
+++ b/src/Controller/GDPR/PimcoreUsersController.php
@@ -22,15 +22,15 @@ use Pimcore\Controller\KernelControllerEventInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class PimcoreUsersController
  *
- * @Route("/pimcore-users")
  *
  * @internal
  */
+#[Route(path: '/pimcore-users', name: 'pimcore_admin_gdpr_pimcoreusers_')]
 class PimcoreUsersController extends AdminAbstractController implements KernelControllerEventInterface
 {
     public function onKernelControllerEvent(ControllerEvent $event): void
@@ -42,9 +42,7 @@ class PimcoreUsersController extends AdminAbstractController implements KernelCo
         $this->checkActionPermission($event, 'gdpr_data_extractor');
     }
 
-    /**
-     * @Route("/search-users", name="pimcore_admin_gdpr_pimcoreusers_searchusers", methods={"GET"})
-     */
+    #[Route(path: '/search-users', name: 'searchusers', methods: ['GET'])]
     public function searchUsersAction(Request $request, PimcoreUsers $pimcoreUsers): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
@@ -62,9 +60,7 @@ class PimcoreUsersController extends AdminAbstractController implements KernelCo
         return $this->adminJson($result);
     }
 
-    /**
-     * @Route("/export-user-data", name="pimcore_admin_gdpr_pimcoreusers_exportuserdata", methods={"GET"})
-     */
+    #[Route(path: '/export-user-data', name: 'exportuserdata', methods: ['GET'])]
     public function exportUserDataAction(Request $request, PimcoreUsers $pimcoreUsers): JsonResponse
     {
         $this->checkPermission('users');

--- a/src/Controller/GDPR/SentMailController.php
+++ b/src/Controller/GDPR/SentMailController.php
@@ -22,15 +22,15 @@ use Pimcore\Model\Tool\Email\Log;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * Class SentMailController
  *
- * @Route("/sent-mail")
  *
  * @internal
  */
+#[Route(path: '/sent-mail', name: 'pimcore_admin_gdpr_sentmail_')]
 class SentMailController extends AdminAbstractController implements KernelControllerEventInterface
 {
     public function onKernelControllerEvent(ControllerEvent $event): void
@@ -42,9 +42,7 @@ class SentMailController extends AdminAbstractController implements KernelContro
         $this->checkActionPermission($event, 'gdpr_data_extractor');
     }
 
-    /**
-     * @Route("/export", name="pimcore_admin_gdpr_sentmail_exportdataobject", methods={"GET"})
-     */
+    #[Route(path: '/export', name: 'exportdataobject', methods: ['GET'])]
     public function exportDataObjectAction(Request $request): JsonResponse
     {
         $this->checkPermission('emails');


### PR DESCRIPTION
Migrating annotations from Symfony\Component\Routing\Annotation\Route to attributes has several advantages, which can make project cleaner, more modern, and maintainable. Migrating to attributes is needed to move to newer versions of Symfony in the future.