### PR TITLE
Fix Asset exists check for files within folders when drag and dropping.

### DIFF
--- a/public/js/pimcore/asset/tree.js
+++ b/public/js/pimcore/asset/tree.js
@@ -278,7 +278,8 @@
                  url: Routing.generate('pimcore_admin_asset_exists'),
                  params: {
                      parentId: parentNode.id,
-                     filename: file.name
+                     filename: file.name,
+                     dir: path
                  },
                  async: false,
                  success: function (response) {

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -400,15 +400,16 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function existsAction(Request $request): JsonResponse
     {
         $parentAsset = \Pimcore\Model\Asset::getById((int)$request->get('parentId'));
-        if ($dir = $request->get('dir')){
+
+        $dir = '';
+        if ($request->get('dir')){
+            $dir = $request->get('dir');
             // this is for uploading folders with Drag&Drop
             // param "dir" contains the relative path of the file
             if (strpos($dir, '..') !== false) {
                 throw new \Exception('not allowed');
             }
             $dir =  '/' . trim($dir, '/ ');
-        } else {
-            $dir = '';
         }
 
         $assetPath = $parentAsset->getRealFullPath() . $dir . '/' . $request->get('filename');

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -400,9 +400,21 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     public function existsAction(Request $request): JsonResponse
     {
         $parentAsset = \Pimcore\Model\Asset::getById((int)$request->get('parentId'));
+        if ($dir = $request->get('dir')){
+            // this is for uploading folders with Drag&Drop
+            // param "dir" contains the relative path of the file
+            if (strpos($dir, '..') !== false) {
+                throw new \Exception('not allowed');
+            }
+            $dir = trim($dir, '/ ');
+        } else {
+            $dir = '';
+        }
+
+        $assetPath = $parentAsset->getRealFullPath() . $dir . '/' . $request->get('filename');
 
         return new JsonResponse([
-            'exists' => Asset\Service::pathExists($parentAsset->getRealFullPath().'/'.$request->get('filename')),
+            'exists' => Asset\Service::pathExists($assetPath),
         ]);
     }
 

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -406,7 +406,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             if (strpos($dir, '..') !== false) {
                 throw new \Exception('not allowed');
             }
-            $dir = trim($dir, '/ ');
+            $dir =  '/' . trim($dir, '/ ');
         } else {
             $dir = '';
         }

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -401,9 +401,8 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     {
         $parentAsset = \Pimcore\Model\Asset::getById((int)$request->get('parentId'));
 
-        $dir = '';
-        if ($request->get('dir')){
-            $dir = $request->get('dir');
+        $dir = $request->get('dir', '');
+        if ($dir){
             // this is for uploading folders with Drag&Drop
             // param "dir" contains the relative path of the file
             if (strpos($dir, '..') !== false) {


### PR DESCRIPTION
Closes #626

The asset is not correctly resolved in the exists check if it is in a folder. 

Currently, the `add-asset` endpoint is passed the directory path but the `exists` endpoint is not.