### PR TITLE
BUG: display the nice path if field type combo is not editable

### DIFF
--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -671,8 +671,9 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
         if (!this.object) {
             return;
         }
+
         let targets, responseHandler;
-        if (pimcore.helpers.hasSearchImplementation() && this.fieldConfig.displayMode === 'combo') {
+        if (pimcore.helpers.hasSearchImplementation() && this.fieldConfig.displayMode === 'combo' && !this.fieldConfig.noteditable) {
             targets = this.store.data;
             responseHandler = function (responseData) {
                 this.component.removeCls('grid_nicepath_requested');


### PR DESCRIPTION
I had the phenomenon that when I had set a OneToManyRelation field with the Inline Search type, the PathFormatter was not applied there. The problem occurres only when the user is in not editable mode.

![image](https://github.com/user-attachments/assets/13437cc7-076c-450a-8e58-d8810c10c03f)


I have made an adjustment that fixes the problem.

![image-20241022-123834](https://github.com/user-attachments/assets/cc2421e9-cdb4-4ddb-8c84-4fad6a58983c)
