### PR TITLE
Fix background for external transparent image

### DIFF
--- a/public/js/pimcore/object/tags/externalImage.js
+++ b/public/js/pimcore/object/tags/externalImage.js
@@ -163,6 +163,7 @@ pimcore.object.tags.externalImage = Class.create(pimcore.object.tags.abstract, {
             backgroundSize: "contain",
             backgroundImage: "url(" + path + ")",
             backgroundPosition: "center center",
+            backgroundColor: "white",
             backgroundRepeat: "no-repeat"
         });
         body.repaint();


### PR DESCRIPTION
For external image:
<img width="515" alt="Screenshot 2024-10-28 at 12 06 26" src="https://github.com/user-attachments/assets/c49f187d-84e0-40f8-a717-073382c6a249">

when uploading a transparent image, it looks like:
<img width="515" alt="Screenshot 2024-10-28 at 12 06 00" src="https://github.com/user-attachments/assets/b36b0f5d-df9c-4913-8e56-2e6e4a5c9902">
