### PR TITLE
[Bug]: Fix deletion of context.objectId

### DIFF
--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -208,7 +208,7 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
     },
 
     getColumnWidthLocalStorageKey: function (column) {
-        let context = this.context;
+        let context = { ...this.context };
         delete context.objectId;
         context.column = column;
 


### PR DESCRIPTION
This code change fixes the mistaken deletion of "objectId" from "this.context".

Without this, the following example is broken:
https://pimcore.com/docs/platform/Pimcore/Extending_Pimcore/Event_API_and_Event_Manager/#asset-upload-path