### PR TITLE
[2FA] Set default issuer to "Pimcore" instead of "Pimcore 2 Factor Authentication"

### DIFF
--- a/config/pimcore/two_factor_authentication.yaml
+++ b/config/pimcore/two_factor_authentication.yaml
@@ -3,7 +3,7 @@ scheb_two_factor:
     google:
         enabled: true                                       # If Google Authenticator should be enabled, default false
         server_name: Pimcore                                # Server name used in QR code
-        issuer: Pimcore 2 Factor Authentication             # Issuer name used in QR code
+        issuer: Pimcore                                     # Issuer name used in QR code
 
     security_tokens:
         - Pimcore\Bundle\AdminBundle\Security\Authentication\Token\TwoFactorRequiredToken


### PR DESCRIPTION
Currently the QR code for 2FA is set to "Pimcore 2 Factor Authentication" by default. This is not optimal because:
1. All applications in Google Authenticator app are 2 factor authentications, so it does not make sense to write this information
2. The string "Pimcore 2 Factor Authentication" is so long that the actual project name is not visible on most mobile phones (in portrait mode) - even if you rename the application in Google Authenticator, the issuer name is kept. Thus if you have multiple Pimcore systems in Authenticator app, you always have to use landscape mode to see which Pimcore app to use

With this PR, the issuer name gets changed to "Pimcore". So by default the app in Google Authenticator would get named

> Pimcore: username@Pimcore

If you change the app name in Authenticator, you will still have

> Pimcore: App name