### PR TITLE
[Bugfix] Pass allowedTypes correctly on video editable

### DIFF
--- a/public/js/pimcore/document/editables/video.js
+++ b/public/js/pimcore/document/editables/video.js
@@ -20,6 +20,7 @@ pimcore.document.editables.video = Class.create(pimcore.document.editable, {
     initialize: function($super, id, name, config, data, inherited) {
         $super(id, name, config, data, inherited);
 
+        data.allowedTypes = config.allowedTypes;
         this.data = data;
     },
 


### PR DESCRIPTION
fix passing the correct allowedTypes from config to data (which is then passed to the helper to build the popup dialog)