### PR TITLE
[Bug]: Fix Icon library Jquery CSP problem

### DIFF
--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -59,7 +59,7 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
         ],
         self::SCRIPT_OPT => [
             'https://buttons.github.io/buttons.js', // GitHub star button on login page
-            'https://code.jquery.com/jquery-3.7.1.min.js', // jQuery for the icon library
+            'https://code.jquery.com/', // jQuery for the icon library
         ],
         self::FRAME_OPT => [
             'https://www.youtube-nocookie.com/', // Video preview thumbnail for YouTube

--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -59,6 +59,7 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
         ],
         self::SCRIPT_OPT => [
             'https://buttons.github.io/buttons.js', // GitHub star button on login page
+            'https://code.jquery.com/jquery-3.7.1.min.js', // jQuery for the icon library
         ],
         self::FRAME_OPT => [
             'https://www.youtube-nocookie.com/', // Video preview thumbnail for YouTube


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/17395

Based on the suggestion on https://github.com/pimcore/pimcore/issues/17395#issuecomment-2252104553

It indeed broke in the skeleton and not the demo, because in the demo we have it introduced by https://github.com/pimcore/openid-connect/blob/0dc81fea71aa75173050131fba301f14fa335bac/src/DependencyInjection/Compiler/ContentSecurityPolicyUrlsPass.php#L31