### PR TITLE
[Relational fields] Sort options for column filters alphabetically

### DIFF
--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -222,5 +222,30 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
             return width;
         }
         return null;
+    },
+
+    getSortedStore: function (store, sortField) {
+        return Ext.create('Ext.data.ChainedStore', {
+            source: store, sorters: [
+                {
+                    sorterFn: function (record1, record2) {
+                        let value1, value2;
+                        try {
+                            value1 = (record1.get(sortField)+'').toLowerCase();
+                        } catch (e) {
+                            value1 = '';
+                        }
+
+                        try {
+                            value2 = (record2.get(sortField)+'').toLowerCase();
+                        } catch (e) {
+                            value2 = '';
+                        }
+
+                        return value1 > value2 ? 1 : (value1 === value2) ? 0 : -1;
+                    }
+                }
+            ]
+        });
     }
 });

--- a/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -163,13 +163,16 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                     });
                 }
 
-                let filterType = 'list';
+                fc.filter = {
+                    type: 'list'
+                };
 
                 if (fc.layout.layout.fieldtype === 'checkbox' || fc.layout.key === 'published') {
-                    filterType = 'boolean';
-                }
-                fc.filter = {
-                    type: filterType
+                    fc.filter.type = 'boolean';
+                } else {
+                    fc.filter.labelField = visibleFields[i];
+                    fc.filter.idField = visibleFields[i];
+                    fc.filter.store = this.getSortedStore(this.store, visibleFields[i]);
                 }
 
                 columns.push(fc);
@@ -303,6 +306,12 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                     type: filterType
                 }
             };
+
+            if (filterType === 'list') {
+                columnConfig.filter.labelField = this.fieldConfig.columns[i].key;
+                columnConfig.filter.idField = this.fieldConfig.columns[i].key;
+                columnConfig.filter.store = this.getSortedStore(this.store, this.fieldConfig.columns[i].key);
+            }
 
             if (cellEditor) {
                 columnConfig.getEditor = cellEditor;

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -240,6 +240,12 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 }
             };
 
+            if(filterType === 'list') {
+                columnConfig.filter.labelField = this.fieldConfig.columns[i].key;
+                columnConfig.filter.idField = this.fieldConfig.columns[i].key;
+                columnConfig.filter.store = this.getSortedStore(this.store, this.fieldConfig.columns[i].key);
+            }
+
             if (cellEditor) {
                 columnConfig.getEditor = cellEditor;
             }

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -388,14 +388,16 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                     });
                 }
 
-                let filterType = 'list';
+                fc.filter = {
+                    type: 'list'
+                };
 
                 if (fc.layout.layout.fieldtype === 'checkbox' || fc.layout.key === 'published') {
-                    filterType = 'boolean';
-                }
-
-                fc.filter = {
-                    type: filterType
+                    fc.filter.type = 'boolean';
+                } else {
+                    fc.filter.labelField = field.key;
+                    fc.filter.idField = field.key;
+                    fc.filter.store = this.getSortedStore(this.store, field.key);
                 }
 
                 columns.push(fc);

--- a/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -448,8 +448,11 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
 
         columns = Ext.Array.map(columns, function(column) {
             column.filter = {
-                type: 'list'
-            }
+                type: 'list',
+                labelField: column.dataIndex,
+                idField: column.dataIndex,
+                store: this.getSortedStore(this.store, column.dataIndex)
+            };
 
             let columnWidth = this.getColumnWidth(column.dataIndex);
             if (columnWidth > 0) {


### PR DESCRIPTION
Follow-up of #659

Currently the order of column filter options for (advanced) many-to-many (object) relation fields depends on the order of assigned elements in the relation. This makes it hard to find a certain filter value. This PR sorts the filter values alphabetically.

Before:
<img width="1058" alt="Bildschirmfoto 2024-11-21 um 19 05 03" src="https://github.com/user-attachments/assets/65d35c84-e575-4c46-a4e9-7951b4afbab8">
(Imagine a relation with 100 items, then finding the desired value will take some time)

After:
<img width="1065" alt="Bildschirmfoto 2024-11-21 um 19 04 16" src="https://github.com/user-attachments/assets/b15de856-fb83-4ce3-a6d5-094e55e4cde4">
