### PR TITLE
Revert "Fix formatting for alias on relations (#745)"

### DIFF
--- a/src/DataObject/GridColumnConfig/Value/DefaultValue.php
+++ b/src/DataObject/GridColumnConfig/Value/DefaultValue.php
@@ -75,10 +75,6 @@ final class DefaultValue extends AbstractValue
             }
         }
 
-        if ($value instanceof ElementInterface) {
-            $value = $value->getFullPath();
-        }
-
         if (!$fieldDefinition instanceof Data) {
             return $this->getDefaultValue($value);
         }


### PR DESCRIPTION
This reverts commit 91d1903a946931d9899b4c81fccfd96061fdd46f.

Closes #780

The original fix was at the wrong location in the evaluation tree. Whatever is calling Alias handles result from alias differently from result from DefaultValue. I need to track that down.

Basically without alias, `getFullPath` (or similar) gets called and with alias it does not. Not sure why.

@fashxp 
@solverat
@la-lisa