### PR TITLE
Allow calling shadowed method when using addMethods.

### DIFF
--- a/public/js/lib/class.js
+++ b/public/js/lib/class.js
@@ -64,9 +64,9 @@ var Class = (function() {
 
         for ( var i = 0, length = properties.length; i < length; i++) {
             var property = properties[i], value = source[property];
+            const method = value;
             if (ancestor && isFunction(value)
                     && argumentNames(value)[0] == "$super") {
-                var method = value;
 
                 value = wrap.bind((function(m) {
                     const method = ancestor[m];
@@ -78,10 +78,8 @@ var Class = (function() {
                 value.valueOf = method.valueOf.bind(method);
                 value.toString = method.toString.bind(method);
             } else if (self && isFunction(value)
-                // TODO: reduce copy and patin here
                 && argumentNames(value)[0] == "$this") {
-                var method = value;
-
+                // TODO: reduce copy and pasting here
                 value = wrap.bind((function(m) {
                     const method = self[m];
                     return function() {

--- a/public/js/lib/class.js
+++ b/public/js/lib/class.js
@@ -59,6 +59,7 @@ var Class = (function() {
 
     function addMethods(source) {
         var ancestor = this.superclass && this.superclass.prototype;
+        const self = this.prototype;
         var properties = Object.keys(source);
 
         for ( var i = 0, length = properties.length; i < length; i++) {
@@ -68,8 +69,23 @@ var Class = (function() {
                 var method = value;
 
                 value = wrap.bind((function(m) {
+                    const method = ancestor[m];
                     return function() {
-                        return ancestor[m].apply(this, arguments);
+                        return method.apply(this, arguments);
+                    };
+                })(property))(method);
+
+                value.valueOf = method.valueOf.bind(method);
+                value.toString = method.toString.bind(method);
+            } else if (self && isFunction(value)
+                // TODO: reduce copy and patin here
+                && argumentNames(value)[0] == "$this") {
+                var method = value;
+
+                value = wrap.bind((function(m) {
+                    const method = self[m];
+                    return function() {
+                        return method.apply(this, arguments);
                     };
                 })(property))(method);
 

--- a/public/js/lib/class.js
+++ b/public/js/lib/class.js
@@ -69,9 +69,9 @@ var Class = (function() {
                     && argumentNames(value)[0] == "$super") {
 
                 value = wrap.bind((function(m) {
-                    const method = ancestor[m];
+                    const shadowMethod = ancestor[m];
                     return function() {
-                        return method.apply(this, arguments);
+                        return shadowMethod.apply(this, arguments);
                     };
                 })(property))(method);
 
@@ -81,9 +81,9 @@ var Class = (function() {
                 && argumentNames(value)[0] == "$this") {
                 // TODO: reduce copy and pasting here
                 value = wrap.bind((function(m) {
-                    const method = self[m];
+                    const shadowMethod = self[m];
                     return function() {
-                        return method.apply(this, arguments);
+                        return shadowMethod.apply(this, arguments);
                     };
                 })(property))(method);
 


### PR DESCRIPTION
Currently this does not work:
```js
pimcore.object.search.addMethods({
    onRowContextmenu: function ($super, grid, record, tr, rowIndex, e, eOpts) {
        if (pimcore.currentuser.admin === true) {
            $super(grid, record, tr, rowIndex, e, eOpts);
            return;
        }
        ///
     }
});
```
Since `$super` looks for a method on the _superclass_ of `pimcore.object.search` and `onRowContextmenu` is defined on the class itself. With this PR, I can now do:
```js
pimcore.object.search.addMethods({
    onRowContextmenu: function ($this, grid, record, tr, rowIndex, e, eOpts) {
        if (pimcore.currentuser.admin === true) {
            $this(grid, record, tr, rowIndex, e, eOpts);
            return;
        }
        ///
     }
});
```