### PR TITLE
Field Type Table: Support drag & drop to change order of rows

### DIFF
--- a/public/js/pimcore/object/tags/table.js
+++ b/public/js/pimcore/object/tags/table.js
@@ -230,6 +230,9 @@ pimcore.object.tags.table = Class.create(pimcore.object.tags.abstract, {
             viewConfig: {
                 markDirty: false,
                 forceFit: true,
+                plugins: {
+                    ptype: 'gridviewdragdrop'
+                },
                 listeners: {
                     refresh: function (dataview) {
                         Ext.suspendLayouts();


### PR DESCRIPTION
This PR adds drag & drop support to change order of rows for field type `Table`.