### PR TITLE
[Many-to-many Relations] Add "Clear filters" button

### DIFF
--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -26,7 +26,18 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
                 text: t("clear_filters"),
                 handler: function (button) {
                     this.component.filters.clearFilters();
-                    this.component.getStore().clearFilter();
+
+                    let columns = this.component.getColumns();
+                    for (let i = 0; i < columns.length; i++) {
+                        if(columns[i].filter.menu) {
+                            columns[i].filter.menu.items.each(function (filterOption) {
+                                if (filterOption.setChecked) {
+                                    filterOption.setChecked(false);
+                                }
+                            });
+                        }
+                    }
+
                     const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
                     if (filterInput) {
                         filterInput.setValue('');

--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -20,6 +20,23 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
     getFilterEditToolbarItems: function () {
         return [
             {
+                iconCls: "pimcore_icon_clear_filters",
+                itemId: "clearFilters",
+                hidden: true,
+                text: t("clear_filters"),
+                tooltip: t("clear_filters"),
+                handler: function (button) {
+                    this.component.filters.clearFilters();
+                    this.component.getStore().clearFilter();
+                    const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+                    if (filterInput) {
+                        filterInput.setValue('');
+                        this.hideFilterInput(filterInput);
+                    }
+                    button.hide();
+                }.bind(this)
+            },
+            {
                 xtype: 'textfield',
                 hidden: true,
                 cls: 'relations_grid_filter_input',
@@ -46,6 +63,25 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
                 handler: this.showFilterInput.bind(this)
             }
         ];
+    },
+
+    addFilterChangeListener: function() {
+        this.component.on("filterchange", function () {
+            const filterData = this.component.getStore().getFilters().items;
+
+            const hasStoreFilters = filterData.some(function (filter) {
+                return filter.getValue() !== null && filter.getValue() !== '';
+            });
+
+            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+            const hasTextFilter = filterInput && filterInput.getValue() !== '';
+
+            if (hasStoreFilters || hasTextFilter) {
+                this.component.queryById('clearFilters').show();
+            } else {
+                this.component.queryById('clearFilters').hide();
+            }
+        }.bind(this));
     },
 
     showFilterInput: function (filterBtn) {

--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -26,6 +26,7 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
                 text: t("clear_filters"),
                 handler: function (button) {
                     this.component.filters.clearFilters();
+                    this.component.getStore().clearFilter();
 
                     let columns = this.component.getColumns();
                     for (let i = 0; i < columns.length; i++) {

--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -30,7 +30,7 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
 
                     let columns = this.component.getColumns();
                     for (let i = 0; i < columns.length; i++) {
-                        if(columns[i].filter.menu) {
+                        if(columns[i].filter?.menu?.items) {
                             columns[i].filter.menu.items.each(function (filterOption) {
                                 if (filterOption.setChecked) {
                                     filterOption.setChecked(false);
@@ -85,12 +85,16 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
             });
 
             const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-            const hasTextFilter = filterInput && filterInput.getValue() !== '';
+            const hasTextFilter = filterInput?.getValue() !== '';
 
-            if (hasStoreFilters || hasTextFilter) {
-                this.component.queryById('clearFilters').show();
-            } else {
-                this.component.queryById('clearFilters').hide();
+            const clearFilters = this.component.queryById('clearFilters');
+            
+            if (clearFilters){
+                  if (hasStoreFilters || hasTextFilter) {
+                      clearFilters.show();
+                  } else {
+                      clearFilters.hide();
+                  }
             }
         }.bind(this));
     },

--- a/public/js/pimcore/object/tags/abstractRelations.js
+++ b/public/js/pimcore/object/tags/abstractRelations.js
@@ -24,7 +24,6 @@ pimcore.object.tags.abstractRelations = Class.create(pimcore.object.tags.abstrac
                 itemId: "clearFilters",
                 hidden: true,
                 text: t("clear_filters"),
-                tooltip: t("clear_filters"),
                 handler: function (button) {
                     this.component.filters.clearFilters();
                     this.component.getStore().clearFilter();

--- a/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -401,6 +401,23 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             });
         }
 
+        this.clearFilterButtonRelation = new Ext.Button({
+            iconCls: "pimcore_icon_clear_filters",
+            hidden: true,
+            text: t("clear_filters"),
+            tooltip: t("clear_filters"),
+            handler: function () {
+                this.component.filters.clearFilters();
+                this.component.getStore().clearFilter();
+                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+                if (filterInput) {
+                    filterInput.setValue('');
+                    this.hideFilterInput(filterInput);
+                }
+                this.clearFilterButtonRelation.hide();
+            }.bind(this)
+        });
+
         let toolbarItems = this.getEditToolbarItems(readOnly);
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
@@ -497,6 +514,23 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         }
 
         this.component.reference = this;
+
+        this.component.on("filterchange", function () {
+            const filterData = this.component.getStore().getFilters().items;
+
+            const hasStoreFilters = filterData.some(function (filter) {
+                return filter.getValue() !== null && filter.getValue() !== '';
+            });
+
+            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+            const hasTextFilter = filterInput && filterInput.getValue() !== '';
+
+            if (hasStoreFilters || hasTextFilter) {
+                this.clearFilterButtonRelation.show();
+            } else {
+                this.clearFilterButtonRelation.hide();
+            }
+        }.bind(this));
 
         if (!readOnly) {
             this.component.on("afterrender", function () {

--- a/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -401,23 +401,6 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             });
         }
 
-        this.clearFilterButtonRelation = new Ext.Button({
-            iconCls: "pimcore_icon_clear_filters",
-            hidden: true,
-            text: t("clear_filters"),
-            tooltip: t("clear_filters"),
-            handler: function () {
-                this.component.filters.clearFilters();
-                this.component.getStore().clearFilter();
-                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-                if (filterInput) {
-                    filterInput.setValue('');
-                    this.hideFilterInput(filterInput);
-                }
-                this.clearFilterButtonRelation.hide();
-            }.bind(this)
-        });
-
         let toolbarItems = this.getEditToolbarItems(readOnly);
 
         this.cellEditing = Ext.create('Ext.grid.plugin.CellEditing', {
@@ -514,23 +497,6 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
         }
 
         this.component.reference = this;
-
-        this.component.on("filterchange", function () {
-            const filterData = this.component.getStore().getFilters().items;
-
-            const hasStoreFilters = filterData.some(function (filter) {
-                return filter.getValue() !== null && filter.getValue() !== '';
-            });
-
-            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-            const hasTextFilter = filterInput && filterInput.getValue() !== '';
-
-            if (hasStoreFilters || hasTextFilter) {
-                this.clearFilterButtonRelation.show();
-            } else {
-                this.clearFilterButtonRelation.hide();
-            }
-        }.bind(this));
 
         if (!readOnly) {
             this.component.on("afterrender", function () {
@@ -639,6 +605,8 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
                 }
             }.bind(this));
         }
+
+        this.addFilterChangeListener();
 
         return this.component;
     },

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -376,6 +376,23 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             });
         }
 
+        this.clearFilterButtonRelation = new Ext.Button({
+            iconCls: "pimcore_icon_clear_filters",
+            hidden: true,
+            text: t("clear_filters"),
+            tooltip: t("clear_filters"),
+            handler: function () {
+                this.component.filters.clearFilters();
+                this.component.getStore().clearFilter();
+                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+                if (filterInput) {
+                    filterInput.setValue('');
+                    this.hideFilterInput(filterInput);
+                }
+                this.clearFilterButtonRelation.hide();
+            }.bind(this)
+        });
+
         var toolbarItems = this.getEditToolbarItems(readOnly);
 
 
@@ -469,6 +486,23 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
         this.component.on("rowcontextmenu", this.onRowContextmenu.bind(this));
         this.component.reference = this;
+
+        this.component.on("filterchange", function () {
+            const filterData = this.component.getStore().getFilters().items;
+
+            const hasStoreFilters = filterData.some(function (filter) {
+                return filter.getValue() !== null && filter.getValue() !== '';
+            });
+
+            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+            const hasTextFilter = filterInput && filterInput.getValue() !== '';
+
+            if (hasStoreFilters || hasTextFilter) {
+                this.clearFilterButtonRelation.show();
+            } else {
+                this.clearFilterButtonRelation.hide();
+            }
+        }.bind(this));
 
         if (!readOnly) {
             this.component.on("afterrender", function () {

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -376,23 +376,6 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             });
         }
 
-        this.clearFilterButtonRelation = new Ext.Button({
-            iconCls: "pimcore_icon_clear_filters",
-            hidden: true,
-            text: t("clear_filters"),
-            tooltip: t("clear_filters"),
-            handler: function () {
-                this.component.filters.clearFilters();
-                this.component.getStore().clearFilter();
-                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-                if (filterInput) {
-                    filterInput.setValue('');
-                    this.hideFilterInput(filterInput);
-                }
-                this.clearFilterButtonRelation.hide();
-            }.bind(this)
-        });
-
         var toolbarItems = this.getEditToolbarItems(readOnly);
 
 
@@ -486,23 +469,6 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
         this.component.on("rowcontextmenu", this.onRowContextmenu.bind(this));
         this.component.reference = this;
-
-        this.component.on("filterchange", function () {
-            const filterData = this.component.getStore().getFilters().items;
-
-            const hasStoreFilters = filterData.some(function (filter) {
-                return filter.getValue() !== null && filter.getValue() !== '';
-            });
-
-            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-            const hasTextFilter = filterInput && filterInput.getValue() !== '';
-
-            if (hasStoreFilters || hasTextFilter) {
-                this.clearFilterButtonRelation.show();
-            } else {
-                this.clearFilterButtonRelation.hide();
-            }
-        }.bind(this));
 
         if (!readOnly) {
             this.component.on("afterrender", function () {
@@ -631,6 +597,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             }.bind(this));
         }
 
+        this.addFilterChangeListener();
 
         return this.component;
     },

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -540,6 +540,22 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 }
             ]
         });
+            this.clearFilterButtonRelation = new Ext.Button({
+                iconCls: "pimcore_icon_clear_filters",
+                hidden: true,
+                text: t("clear_filters"),
+                tooltip: t("clear_filters"),
+                handler: function () {
+                    this.component.filters.clearFilters();
+                    this.component.getStore().clearFilter();
+                    const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+                    if (filterInput) {
+                        filterInput.setValue('');
+                        this.hideFilterInput(filterInput);
+                    }
+                    this.clearFilterButtonRelation.hide();
+                }.bind(this)
+            });
 
             this.component = Ext.create('Ext.grid.Panel', {
                 store: this.store,
@@ -594,6 +610,23 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
 
             this.component.on("rowcontextmenu", this.onRowContextmenu);
             this.component.reference = this;
+
+            this.component.on("filterchange", function () {
+                const filterData = this.component.getStore().getFilters().items;
+
+                const hasStoreFilters = filterData.some(function (filter) {
+                    return filter.getValue() !== null && filter.getValue() !== '';
+                });
+
+                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+                const hasTextFilter = filterInput && filterInput.getValue() !== '';
+
+                if (hasStoreFilters || hasTextFilter) {
+                    this.clearFilterButtonRelation.show();
+                } else {
+                    this.clearFilterButtonRelation.hide();
+                }
+            }.bind(this));
 
             this.component.on("afterrender", function () {
                 let dropTargetEl = this.component.getEl();
@@ -680,6 +713,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 xtype: "tbtext",
                 text: "<b>" + this.fieldConfig.title + "</b>"
             },
+            this.clearFilterButtonRelation,
             "->"
         ];
 

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -540,7 +540,7 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 }
             ]
         });
-            this.clearFilterButtonRelation = new Ext.Button({
+            this.clearFilterButtonRelation = Ext.create('Ext.Button', {
                 iconCls: "pimcore_icon_clear_filters",
                 hidden: true,
                 text: t("clear_filters"),

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -540,22 +540,6 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 }
             ]
         });
-            this.clearFilterButtonRelation = Ext.create('Ext.Button', {
-                iconCls: "pimcore_icon_clear_filters",
-                hidden: true,
-                text: t("clear_filters"),
-                tooltip: t("clear_filters"),
-                handler: function () {
-                    this.component.filters.clearFilters();
-                    this.component.getStore().clearFilter();
-                    const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-                    if (filterInput) {
-                        filterInput.setValue('');
-                        this.hideFilterInput(filterInput);
-                    }
-                    this.clearFilterButtonRelation.hide();
-                }.bind(this)
-            });
 
             this.component = Ext.create('Ext.grid.Panel', {
                 store: this.store,
@@ -610,23 +594,6 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
 
             this.component.on("rowcontextmenu", this.onRowContextmenu);
             this.component.reference = this;
-
-            this.component.on("filterchange", function () {
-                const filterData = this.component.getStore().getFilters().items;
-
-                const hasStoreFilters = filterData.some(function (filter) {
-                    return filter.getValue() !== null && filter.getValue() !== '';
-                });
-
-                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-                const hasTextFilter = filterInput && filterInput.getValue() !== '';
-
-                if (hasStoreFilters || hasTextFilter) {
-                    this.clearFilterButtonRelation.show();
-                } else {
-                    this.clearFilterButtonRelation.hide();
-                }
-            }.bind(this));
 
             this.component.on("afterrender", function () {
                 let dropTargetEl = this.component.getEl();
@@ -696,6 +663,8 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                     }.bind(this)
                 });
             }.bind(this));
+
+            this.addFilterChangeListener();
         }
 
         return this.component;
@@ -713,7 +682,6 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                 xtype: "tbtext",
                 text: "<b>" + this.fieldConfig.title + "</b>"
             },
-            this.clearFilterButtonRelation,
             "->"
         ];
 

--- a/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -235,6 +235,23 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             }]
         });
 
+        this.clearFilterButtonRelation = new Ext.Button({
+            iconCls: "pimcore_icon_clear_filters",
+            hidden: true,
+            text: t("clear_filters"),
+            tooltip: t("clear_filters"),
+            handler: function () {
+                this.component.filters.clearFilters();
+                this.component.getStore().clearFilter();
+                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+                if (filterInput) {
+                    filterInput.setValue('');
+                    this.hideFilterInput(filterInput);
+                }
+                this.clearFilterButtonRelation.hide();
+            }.bind(this)
+        });
+
         this.component = new Ext.grid.GridPanel({
             store: this.store,
             border: true,
@@ -285,6 +302,23 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
 
         this.component.on("rowcontextmenu", this.onRowContextmenu);
         this.component.reference = this;
+
+        this.component.on("filterchange", function () {
+            const filterData = this.component.getStore().getFilters().items;
+
+            const hasStoreFilters = filterData.some(function (filter) {
+                return filter.getValue() !== null && filter.getValue() !== '';
+            });
+
+            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
+            const hasTextFilter = filterInput && filterInput.getValue() !== '';
+
+            if (hasStoreFilters || hasTextFilter) {
+                this.clearFilterButtonRelation.show();
+            } else {
+                this.clearFilterButtonRelation.hide();
+            }
+        }.bind(this));
 
         this.component.on("afterrender", function () {
 
@@ -389,6 +423,7 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
                 xtype: "tbtext",
                 text: "<b>" + this.fieldConfig.title + "</b>"
             },
+            this.clearFilterButtonRelation,
             "->"
         ];
         toolbarItems = toolbarItems.concat(this.getFilterEditToolbarItems());

--- a/public/js/pimcore/object/tags/manyToManyRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyRelation.js
@@ -235,23 +235,6 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             }]
         });
 
-        this.clearFilterButtonRelation = new Ext.Button({
-            iconCls: "pimcore_icon_clear_filters",
-            hidden: true,
-            text: t("clear_filters"),
-            tooltip: t("clear_filters"),
-            handler: function () {
-                this.component.filters.clearFilters();
-                this.component.getStore().clearFilter();
-                const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-                if (filterInput) {
-                    filterInput.setValue('');
-                    this.hideFilterInput(filterInput);
-                }
-                this.clearFilterButtonRelation.hide();
-            }.bind(this)
-        });
-
         this.component = new Ext.grid.GridPanel({
             store: this.store,
             border: true,
@@ -302,23 +285,6 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
 
         this.component.on("rowcontextmenu", this.onRowContextmenu);
         this.component.reference = this;
-
-        this.component.on("filterchange", function () {
-            const filterData = this.component.getStore().getFilters().items;
-
-            const hasStoreFilters = filterData.some(function (filter) {
-                return filter.getValue() !== null && filter.getValue() !== '';
-            });
-
-            const filterInput = this.component.down('textfield[cls~=relations_grid_filter_input]');
-            const hasTextFilter = filterInput && filterInput.getValue() !== '';
-
-            if (hasStoreFilters || hasTextFilter) {
-                this.clearFilterButtonRelation.show();
-            } else {
-                this.clearFilterButtonRelation.hide();
-            }
-        }.bind(this));
 
         this.component.on("afterrender", function () {
 
@@ -407,6 +373,8 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
             });
         }.bind(this));
 
+        this.addFilterChangeListener();
+
         return this.component;
     },
 
@@ -423,7 +391,6 @@ pimcore.object.tags.manyToManyRelation = Class.create(pimcore.object.tags.abstra
                 xtype: "tbtext",
                 text: "<b>" + this.fieldConfig.title + "</b>"
             },
-            this.clearFilterButtonRelation,
             "->"
         ];
         toolbarItems = toolbarItems.concat(this.getFilterEditToolbarItems());


### PR DESCRIPTION
(Advanced) Many-to-many (object) relations can be filtered with a text search and after #659 also with column filters. 
This PR adds a "Clear filters" button to reset those filters:
<img width="873" alt="Bildschirmfoto 2024-12-13 um 07 55 03" src="https://github.com/user-attachments/assets/cc88d761-8479-4391-8fda-c10b3c006a1b" />

