### PR TITLE
[BUG] fix permission check in GridHelperService for wrong query column if type is asset

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -962,7 +962,7 @@ class GridHelperService
         return '(
             (`path` != "' . $path . '/" AND ' . $queryColumn .  ' != "' . $leaf . '")
             AND
-            `path` NOT LIKE "' . $fullpath . '%"
+            `path` NOT LIKE "' . $fullpath . '/%"
         )';
 
     }

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -936,7 +936,7 @@ class GridHelperService
         return '(
             (`path` = "' . $path . '/" AND ' . $queryColumn .  ' = "' . $leaf . '")
             OR
-            `path` LIKE "' . $fullpath . '/%"
+            `path` LIKE "' . $fullpath . '%"
         )';
     }
 
@@ -962,7 +962,7 @@ class GridHelperService
         return '(
             (`path` != "' . $path . '/" AND ' . $queryColumn .  ' != "' . $leaf . '")
             AND
-            `path` NOT LIKE "' . $fullpath . '/%"
+            `path` NOT LIKE "' . $fullpath . '%"
         )';
 
     }
@@ -1005,11 +1005,11 @@ class GridHelperService
             // the result would be like `(((path1 OR path2) AND (not_path3 AND not_path4)))`
             $forbiddenAndAllowedSql = '(';
 
-            if ($allowedPathSql || $forbiddenPathSql) {
+            if (!empty($allowedPathSql) || !empty($forbiddenPathSql)) {
                 $forbiddenAndAllowedSql .= '(';
                 $forbiddenAndAllowedSql .= $allowedPathSql ? '( ' . implode(' OR ', $allowedPathSql) . ' )' : '';
 
-                if ($forbiddenPathSql) {
+                if (!empty($forbiddenPathSql)) {
                     //if $allowedPathSql "implosion" is present, we need `AND` in between
                     $forbiddenAndAllowedSql .= $allowedPathSql ? ' AND ' : '';
                     $forbiddenAndAllowedSql .= implode(' AND ', $forbiddenPathSql);

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -315,8 +315,8 @@ class GridHelperService
                             $fieldConditions = [];
                             foreach ($filter['value'] as $filterValue) {
                                 $brickCondition = '(' . $brickField->getFilterCondition($filterValue, $operator,
-                                    ['brickPrefix' => $brickPrefix]
-                                ) . ' AND ' . $brickType . '.fieldname = ' . $db->quote($brickFilterField) . ')';
+                                        ['brickPrefix' => $brickPrefix]
+                                    ) . ' AND ' . $brickType . '.fieldname = ' . $db->quote($brickFilterField) . ')';
                                 $fieldConditions[] = $brickCondition;
                             }
 
@@ -325,7 +325,7 @@ class GridHelperService
                             }
                         } else {
                             $brickCondition = '(' . $brickField->getFilterCondition($filter['value'], $operator,
-                                ['brickPrefix' => $brickPrefix]) . ' AND ' . $brickType . '.fieldname = ' . $db->quote($brickFilterField) . ')';
+                                    ['brickPrefix' => $brickPrefix]) . ' AND ' . $brickType . '.fieldname = ' . $db->quote($brickFilterField) . ')';
                             $conditionPartsFilters[] = $brickCondition;
                         }
                     } elseif ($field instanceof ClassDefinition\Data\UrlSlug) {
@@ -926,16 +926,17 @@ class GridHelperService
     /**
      * A more performant alternative to "CONCAT(`path`,`key`) LIKE $fullpath"
      */
-    private function optimizedConcatLike(string $fullpath): string
+    private function optimizedConcatLike(string $fullpath, string $type = 'object'): string
     {
         $pathParts = explode('/', $fullpath);
         $leaf = array_pop($pathParts);
         $path = implode('/', $pathParts);
+        $queryColumn = $type === 'asset' ? '`filename`' : '`key`';
 
         return '(
-            (`path` = "' . $path . '/" AND `key` = "' . $leaf . '")
+            (`path` = "' . $path . '/" AND ' . $queryColumn .  ' = "' . $leaf . '")
             OR
-            `path` LIKE "' . $fullpath . '%"
+            `path` LIKE "' . $fullpath . '/%"
         )';
     }
 
@@ -943,18 +944,23 @@ class GridHelperService
      * A more performant alternative to "CONCAT(`path`,`key`) NOT LIKE $fullpath"
      * Set $onlyChildren to true when you want to exclude the folder/element itself
      */
-    private function optimizedConcatNotLike(string $fullpath, bool $onlyChildren = false): string
+    private function optimizedConcatNotLike(
+        string $fullpath,
+        bool $onlyChildren = false,
+        string $type = 'object'
+    ): string
     {
         $pathParts = explode('/', $fullpath);
         $leaf = array_pop($pathParts);
         $path = implode('/', $pathParts);
+        $queryColumn = $type === 'asset' ? '`filename`' : '`key`';
 
         if ($onlyChildren) {
             return '`path` NOT LIKE "' . $fullpath . '/%"';
         }
 
         return '(
-            (`path` != "' . $path . '/" AND `key` != "' . $leaf . '")
+            (`path` != "' . $path . '/" AND ' . $queryColumn .  ' != "' . $leaf . '")
             AND
             `path` NOT LIKE "' . $fullpath . '/%"
         )';
@@ -983,27 +989,27 @@ class GridHelperService
                         if ($exceptionsConcat !== '') {
                             $exceptionsConcat.= ' OR ';
                         }
-                        $exceptionsConcat.= $this->optimizedConcatLike($path);
+                        $exceptionsConcat.= $this->optimizedConcatLike($path, $type);
                     }
                     $exceptions = ' OR (' . $exceptionsConcat . ')';
                     //if any allowed child is found, the current folder can be listed but its content is still blocked
                     $onlyChildren = true;
                 }
-                $forbiddenPathSql[] = $this->optimizedConcatNotLike($forbiddenPath, $onlyChildren) . $exceptions;
+                $forbiddenPathSql[] = $this->optimizedConcatNotLike($forbiddenPath, $onlyChildren, $type) . $exceptions;
             }
             foreach ($elementPaths['allowed'] as $allowedPaths) {
-                $allowedPathSql[] = $this->optimizedConcatLike($allowedPaths);
+                $allowedPathSql[] = $this->optimizedConcatLike($allowedPaths, $type);
             }
 
             // this is to avoid query error when implode is empty.
             // the result would be like `(((path1 OR path2) AND (not_path3 AND not_path4)))`
             $forbiddenAndAllowedSql = '(';
 
-            if (!empty($allowedPathSql) || !empty($forbiddenPathSql)) {
+            if ($allowedPathSql || $forbiddenPathSql) {
                 $forbiddenAndAllowedSql .= '(';
                 $forbiddenAndAllowedSql .= $allowedPathSql ? '( ' . implode(' OR ', $allowedPathSql) . ' )' : '';
 
-                if (!empty($forbiddenPathSql)) {
+                if ($forbiddenPathSql) {
                     //if $allowedPathSql "implosion" is present, we need `AND` in between
                     $forbiddenAndAllowedSql .= $allowedPathSql ? ' AND ' : '';
                     $forbiddenAndAllowedSql .= implode(' AND ', $forbiddenPathSql);


### PR DESCRIPTION
Grid-proxy action fails if non admin user wants to access assets list in folder. Assets table has no column key only filename.