### PR TITLE
[Bug] Fixed permission checks in certain constellations

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -989,7 +989,9 @@ class GridHelperService
                     //if any allowed child is found, the current folder can be listed but its content is still blocked
                     $onlyChildren = true;
                 }
-                $forbiddenPathSql[] = '(' . $this->optimizedConcatNotLike($forbiddenPath, $onlyChildren) . $exceptions . ')';
+                $forbiddenPathSql[] =
+                    '(' . $this->optimizedConcatNotLike($forbiddenPath, $onlyChildren) . $exceptions . ')'
+                ;
             }
             foreach ($elementPaths['allowed'] as $allowedPaths) {
                 $allowedPathSql[] = $this->optimizedConcatLike($allowedPaths);

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -989,7 +989,7 @@ class GridHelperService
                     //if any allowed child is found, the current folder can be listed but its content is still blocked
                     $onlyChildren = true;
                 }
-                $forbiddenPathSql[] = $this->optimizedConcatNotLike($forbiddenPath, $onlyChildren) . $exceptions;
+                $forbiddenPathSql[] = '(' . $this->optimizedConcatNotLike($forbiddenPath, $onlyChildren) . $exceptions . ')';
             }
             foreach ($elementPaths['allowed'] as $allowedPaths) {
                 $allowedPathSql[] = $this->optimizedConcatLike($allowedPaths);

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -954,7 +954,7 @@ class GridHelperService
         }
 
         return '(
-            (`path` != "' . $path . '/" AND `key` != "' . $leaf . '")
+            NOT (`path` = "' . $path . '/" AND `key` = "' . $leaf . '")
             AND
             `path` NOT LIKE "' . $fullpath . '/%"
         )';


### PR DESCRIPTION
following permission constellation 

![image](https://github.com/user-attachments/assets/1c4311ad-5c80-44c4-bf15-ab910f80aa33)

did not show any elements located in `/permission/foo`