### PR TITLE
[Task] optimize permission concat

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -928,6 +928,11 @@ class GridHelperService
      */
     private function optimizedConcatLike(string $fullpath): string
     {
+        //special case for the root folder
+        if($fullpath === '/') {
+            return '`path` LIKE "/%"';
+        }
+
         $pathParts = explode('/', $fullpath);
         $leaf = array_pop($pathParts);
         $path = implode('/', $pathParts);
@@ -935,7 +940,7 @@ class GridHelperService
         return '(
             (`path` = "' . $path . '/" AND `key` = "' . $leaf . '")
             OR
-            `path` LIKE "' . $fullpath . '%"
+            `path` LIKE "' . $fullpath . '/%"
         )';
     }
 


### PR DESCRIPTION
Followup to https://github.com/pimcore/admin-ui-classic-bundle/pull/794

Optimize concat a bit to prevent getting unwanted false positives. 

Example constellation would be: 
`foo/bar`
`foo/barsecret`

`"' . $fullpath . '%"` would include second folder, `"' . $fullpath . '/%"` doesn't. 

Currently, it doesn't make a difference, because the `NOT LIKE` queries filter out false positives, but it could bite us in future cases.
