### PR TITLE
Update error modal to handle timedout.

### DIFF
--- a/public/js/pimcore/startup.js
+++ b/public/js/pimcore/startup.js
@@ -199,7 +199,7 @@ Ext.onReady(function () {
 
         var date = new Date();
         var errorMessage = "Timestamp: " + date.toString() + "\n";
-        var errorDetailMessage = "";
+        let errorDetailMessage = "";
 
         if (response.responseText){
             errorDetailMessage += "\n" + response.responseText;

--- a/public/js/pimcore/startup.js
+++ b/public/js/pimcore/startup.js
@@ -182,6 +182,8 @@ Ext.onReady(function () {
     Ext.Ajax.on('requestexception', function (conn, response, options) {
         if(response.aborted){
             console.log("xhr request to " + options.url + " aborted");
+        }else if(response.timedout){
+            console.error("xhr request to " + options.url + " timed out");
         }else{
             console.error("xhr request to " + options.url + " failed");
         }
@@ -197,7 +199,15 @@ Ext.onReady(function () {
 
         var date = new Date();
         var errorMessage = "Timestamp: " + date.toString() + "\n";
-        var errorDetailMessage = "\n" + response.responseText;
+        var errorDetailMessage = "";
+
+        if (response.responseText){
+            errorDetailMessage += "\n" + response.responseText;
+        }
+
+        if (response.timedout){
+            errorDetailMessage += "\nRequest timed out";
+        }
 
         try {
             errorMessage += "Status: " + response.status + " | " + response.statusText + "\n";


### PR DESCRIPTION
Currently a timeout given this unhelpful message:
![image](https://github.com/user-attachments/assets/8c5d3d6f-f9d4-4e28-90be-1db75dfc7809)

`timedout` is mentioned here: https://cdn.sencha.com/ext/commercial/4.2.2/docs/source/Connection.html