### PR TITLE
Fix asset preview performance

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -1661,7 +1661,9 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     /**
      * @Route("/get-folder-content-preview", name="pimcore_admin_asset_getfoldercontentpreview", methods={"GET"})
      */
-    public function getFolderContentPreviewAction(Request $request, EventDispatcherInterface $eventDispatcher, GridHelperService $gridHelperService): JsonResponse
+    public function getFolderContentPreviewAction(Request $request,
+                                                  EventDispatcherInterface $eventDispatcher,
+                                                  GridHelperService $gridHelperService): JsonResponse
     {
         $allParams = array_merge($request->request->all(), $request->query->all());
 

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -976,7 +976,7 @@ class GridHelperService
      *
      * @internal
      */
-    protected function getPermittedPathsByUser(string $type, User $user): string
+    public function getPermittedPathsByUser(string $type, User $user): string
     {
         $allowedTypes = [];
 


### PR DESCRIPTION
Currently the performance of asset preview routes are still very poor with this fix: https://github.com/pimcore/admin-ui-classic-bundle/pull/767/files for non admin users. 

For example total number of assets: 500k it takes about ~13s for select query and additional ~13s for additional count query which barely avoids timeout of 30 seconds. 

@kingjia90 i added also call to grid helper functions for assets preview, which makes the performance the same for listing and preview. Is there any reason why we should not use it for preview like i did in PR?  