### PR TITLE
Consider draft by setting latest available version for the edit mode

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -555,10 +555,12 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     public function getSelectOptions(Request $request): JsonResponse
     {
         $objectId = $request->request->getInt('objectId');
-        $object = DataObject\Concrete::getById($objectId);
-        if (!$object instanceof DataObject\Concrete) {
+        $objectFromDatabase = DataObject\Concrete::getById($objectId);
+        if (!$objectFromDatabase instanceof DataObject\Concrete) {
             return new JsonResponse(['success'=> false, 'message' => 'Object not found.']);
         }
+        // set the latest available version for editmode
+        $object = $this->getLatestVersion($objectFromDatabase);
 
         if ($request->get('changedData')) {
             $this->applyChanges($object, $this->decodeJson($request->get('changedData')));


### PR DESCRIPTION
https://github.com/pimcore/admin-ui-classic-bundle/issues/630
Added the same two code lines which are already used in the saveAction [(L1317 & L1324)](https://github.com/pimcore/admin-ui-classic-bundle/blob/1.x/src/Controller/Admin/DataObject/DataObjectController.php#L1325), inside of the getSelectOptions in line 558.