### PR TITLE
Add concept of column readOnly to advancedManyToManyRelation

### DIFF
--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -152,7 +152,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 if(!columnReadOnly) {
                     var selectData = [];
                     if (fieldConfigColumn.value) {
-                        var selectDataRaw = fieldConfigColumn.value.split(";");
+                        const selectDataRaw = fieldConfigColumn.value.split(";");
                         for (var j = 0; j < selectDataRaw.length; j++) {
                             selectData.push([selectDataRaw[j], t(selectDataRaw[j])]);
                         }

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -119,9 +119,10 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
         let filterType = 'list';
         for (i = 0; i < this.fieldConfig.columns.length; i++) {
+            const fieldConfigColumn = this.fieldConfig.columns[i];
             var width = 100;
-            if (this.fieldConfig.columns[i].width) {
-                width = this.fieldConfig.columns[i].width;
+            if (fieldConfigColumn.width) {
+                width = fieldConfigColumn.width;
             }
 
             var cellEditor = null;
@@ -130,7 +131,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
             filterType = 'list';
 
-            if (this.fieldConfig.columns[i].type == "number") {
+            if (fieldConfigColumn.type == "number") {
                 if(!readOnly) {
                     cellEditor = function () {
                         return new Ext.form.NumberField({});
@@ -138,15 +139,15 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 }
 
                 renderer = Ext.util.Format.numberRenderer();
-            } else if (this.fieldConfig.columns[i].type == "text" && !readOnly) {
+            } else if (fieldConfigColumn.type == "text" && !readOnly) {
                 cellEditor = function () {
                     return new Ext.form.TextField({});
                 };
-            } else if (this.fieldConfig.columns[i].type == "select") {
+            } else if (fieldConfigColumn.type == "select") {
                 if(!readOnly) {
                     var selectData = [];
-                    if (this.fieldConfig.columns[i].value) {
-                        var selectDataRaw = this.fieldConfig.columns[i].value.split(";");
+                    if (fieldConfigColumn.value) {
+                        var selectDataRaw = fieldConfigColumn.value.split(";");
                         for (var j = 0; j < selectDataRaw.length; j++) {
                             selectData.push([selectDataRaw[j], t(selectDataRaw[j])]);
                         }
@@ -178,13 +179,13 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
                     return t(value);
                 }
-            } else if (this.fieldConfig.columns[i].type == "multiselect") {
+            } else if (fieldConfigColumn.type == "multiselect") {
                 if(!readOnly) {
                     cellEditor = function (fieldInfo) {
                         return new pimcore.object.helpers.metadataMultiselectEditor({
                             fieldInfo: fieldInfo
                         });
-                    }.bind(this, this.fieldConfig.columns[i]);
+                    }.bind(this, fieldConfigColumn);
                 }
 
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
@@ -200,7 +201,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                         return value;
                     }
                 }
-            } else if (this.fieldConfig.columns[i].type === "bool" || this.fieldConfig.columns[i].type === "columnbool") {
+            } else if (fieldConfigColumn.type === "bool" || fieldConfigColumn.type === "columnbool") {
                 renderer = function (value, metaData, record, rowIndex, colIndex, store) {
                     if (this.fieldConfig.noteditable) {
                         metaData.tdCls += ' grid_cbx_noteditable';
@@ -210,15 +211,15 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 }.bind(this);
 
                 listeners = {
-                    "mousedown": this.cellMousedown.bind(this, this.fieldConfig.columns[i].key, this.fieldConfig.columns[i].type, readOnly)
+                    "mousedown": this.cellMousedown.bind(this, fieldConfigColumn.key, fieldConfigColumn.type, readOnly)
                 };
 
                 filterType = 'boolean';
 
                 if (readOnly) {
                     columns.push(Ext.create('Ext.grid.column.Check', {
-                        text: t(this.fieldConfig.columns[i].label),
-                        dataIndex: this.fieldConfig.columns[i].key,
+                        text: t(fieldConfigColumn.label),
+                        dataIndex: fieldConfigColumn.key,
                         width: width,
                         renderer: renderer,
                         filter: {
@@ -230,8 +231,8 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             }
 
             var columnConfig = {
-                text: t(this.fieldConfig.columns[i].label),
-                dataIndex: this.fieldConfig.columns[i].key,
+                text: t(fieldConfigColumn.label),
+                dataIndex: fieldConfigColumn.key,
                 renderer: renderer,
                 listeners: listeners,
                 width: width,

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -102,6 +102,9 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
     },
 
+    isColumnReadOnly: function (fieldConfigColumn){
+        return false;
+    },
 
     createLayout: function (readOnly) {
         var autoHeight = false;
@@ -131,20 +134,22 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
 
             filterType = 'list';
 
+            const columnReadOnly = readOnly || this.isColumnReadOnly(fieldConfigColumn);
+
             if (fieldConfigColumn.type == "number") {
-                if(!readOnly) {
+                if(!columnReadOnly) {
                     cellEditor = function () {
                         return new Ext.form.NumberField({});
                     };
                 }
 
                 renderer = Ext.util.Format.numberRenderer();
-            } else if (fieldConfigColumn.type == "text" && !readOnly) {
+            } else if (fieldConfigColumn.type == "text" && !columnReadOnly) {
                 cellEditor = function () {
                     return new Ext.form.TextField({});
                 };
             } else if (fieldConfigColumn.type == "select") {
-                if(!readOnly) {
+                if(!columnReadOnly) {
                     var selectData = [];
                     if (fieldConfigColumn.value) {
                         var selectDataRaw = fieldConfigColumn.value.split(";");
@@ -180,7 +185,7 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                     return t(value);
                 }
             } else if (fieldConfigColumn.type == "multiselect") {
-                if(!readOnly) {
+                if(!columnReadOnly) {
                     cellEditor = function (fieldInfo) {
                         return new pimcore.object.helpers.metadataMultiselectEditor({
                             fieldInfo: fieldInfo
@@ -211,12 +216,12 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
                 }.bind(this);
 
                 listeners = {
-                    "mousedown": this.cellMousedown.bind(this, fieldConfigColumn.key, fieldConfigColumn.type, readOnly)
+                    "mousedown": this.cellMousedown.bind(this, fieldConfigColumn.key, fieldConfigColumn.type, columnReadOnly)
                 };
 
                 filterType = 'boolean';
 
-                if (readOnly) {
+                if (columnReadOnly) {
                     columns.push(Ext.create('Ext.grid.column.Check', {
                         text: t(fieldConfigColumn.label),
                         dataIndex: fieldConfigColumn.key,


### PR DESCRIPTION
Introduce concept of column level readOnly to advancedManyToManyRelation.

Eventually this can be a config but for now this change allows users to subclass `pimcore.object.tags.advancedManyToManyRelation` and change the behavior.