### PR TITLE
Fix: Add missing method “getComposerPackageName()” to get the correct bundle name and version

### DIFF
--- a/src/PimcoreAdminBundle.php
+++ b/src/PimcoreAdminBundle.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\SerializerPass;
 use Pimcore\Bundle\AdminBundle\DependencyInjection\Compiler\TranslatorPass;
 use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataProviderInterface;
 use Pimcore\Extension\Bundle\AbstractPimcoreBundle;
+use Pimcore\Extension\Bundle\Traits\PackageVersionTrait;
 use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,14 @@ use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
 
 class PimcoreAdminBundle extends AbstractPimcoreBundle implements DependentBundleInterface
 {
+
+    use PackageVersionTrait;
+
+    public function getComposerPackageName(): string
+    {
+        return 'pimcore/admin-ui-classic-bundle';
+    }
+
     public function build(ContainerBuilder $container): void
     {
         // auto-tag GDPR data providers


### PR DESCRIPTION
This addition is necessary to query the correct composer bundle name and version programmatically.