### PR TITLE
Fixed ExtJS chart warning in console

### DIFF
--- a/public/js/pimcore/layout/portlets/modificationStatistic.js
+++ b/public/js/pimcore/layout/portlets/modificationStatistic.js
@@ -51,6 +51,7 @@ pimcore.layout.portlets.modificationStatistic = Class.create(pimcore.layout.port
             height: 275,
             items: {
                 xtype: 'cartesian',
+                downloadServerUrl: '/disabled-server-url/',
                 store: store,
                 legend: {
                     docked: 'right'


### PR DESCRIPTION
resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/777

Related: https://github.com/pimcore/pimcore/pull/18070

Explanation: the server URL is not needed at all, but there's no other way of deactivating the warning message. 