### PR TITLE
Relations: Do not load nice path if "fullpath" is not a visible field

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -2743,7 +2743,7 @@ pimcore.helpers.requestNicePathData = function (source, targets, config, fieldCo
         return;
     }
 
-    if (!config.loadEditModeData && (typeof targets === "undefined" || !fieldConfig.pathFormatterClass || (typeof fieldConfig.visibleFields === "string" && fieldConfig.visibleFields.split(',').indexOf('fullpath') === -1))) {
+    if (!config.loadEditModeData && (typeof targets === "undefined" || !fieldConfig.pathFormatterClass || (typeof fieldConfig.visibleFields === "string" && fieldConfig.visibleFields !== '' && fieldConfig.visibleFields.split(',').indexOf('fullpath') === -1))) {
         return;
     }
 

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -2743,7 +2743,7 @@ pimcore.helpers.requestNicePathData = function (source, targets, config, fieldCo
         return;
     }
 
-    if (!config.loadEditModeData && (typeof targets === "undefined" || !fieldConfig.pathFormatterClass) || (typeof fieldConfig.visibleFields === "string" && fieldConfig.visibleFields.split(',').indexOf('fullpath') === -1)) {
+    if (!config.loadEditModeData && (typeof targets === "undefined" || !fieldConfig.pathFormatterClass || (typeof fieldConfig.visibleFields === "string" && fieldConfig.visibleFields.split(',').indexOf('fullpath') === -1))) {
         return;
     }
 

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -2743,7 +2743,7 @@ pimcore.helpers.requestNicePathData = function (source, targets, config, fieldCo
         return;
     }
 
-    if (!config.loadEditModeData && (typeof targets === "undefined" || !fieldConfig.pathFormatterClass)) {
+    if (!config.loadEditModeData && (typeof targets === "undefined" || !fieldConfig.pathFormatterClass) || (typeof fieldConfig.visibleFields === "string" && fieldConfig.visibleFields.split(',').indexOf('fullpath') === -1)) {
         return;
     }
 


### PR DESCRIPTION
Steps to reproduce bug (it is not really a bug but waste of resources / performance):
1. Create data object class with a many-to-many object relation, 
  - set a `Path formatter`, 
  - as `Allowed classes` select the class itself, 
  - select `key` as the only visible field, 
  - keep `Enable Async Load in Admin` disabled
2. Create an object of this class
3. Assign the object itself to the relation field
4. Reload object

In network panel you will see a request for `get-nice-path` which will return the nice path from the path formatter. But this value does not get displayed anywhere (because `fullpath` is not configured as a `visible field`).

This PR adds a check if `fullpath` is actually configured as a `visible field` and if not, the nice path does not get requested.