### PR TITLE
[Assets] Ignore .DS_Store when importing assets from zip archive

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -2169,7 +2169,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
             for ($i = $offset; $i < ($offset + $limit); $i++) {
                 $path = $zip->getNameIndex($i);
 
-                if (str_starts_with($path, '__MACOSX/') || str_ends_with($path, '/Thumbs.db')) {
+                if (str_starts_with($path, '__MACOSX/') || str_ends_with($path, '/Thumbs.db') || str_ends_with($path, '/.DS_Store')) {
                     continue;
                 }
 


### PR DESCRIPTION
In analogy to Windows' `Thumbs.db` which gets ignored when importing files via zip archive, the MacOS pendant `.DS_Store` should also be ignored.