### PR TITLE
[Improvement] Add drag and drop to relations editable for documents

### DIFF
--- a/public/js/pimcore/document/editables/relations.js
+++ b/public/js/pimcore/document/editables/relations.js
@@ -81,7 +81,12 @@ pimcore.document.editables.relations = Class.create(pimcore.document.editable, {
             store: this.store,
             bodyStyle: "color:#000",
             selModel: Ext.create('Ext.selection.RowModel', {}),
-
+            viewConfig: {
+                plugins: {
+                    ptype: 'gridviewdragdrop',
+                    draggroup: 'element'
+                },
+            },
             columns: {
                 defaults: {
                     sortable: false


### PR DESCRIPTION
This pull request adds drag and drop to the relations editable for documents so they work the same as relations in objects.

![image](https://github.com/user-attachments/assets/4362cf7a-9c2c-433b-b40b-e711f8d62cce)

Now you're able to drag and drop relations which is quite handy if you want to reorder a bigger list as using the arrows takes some time.
