### PR TITLE
add 'empty' option to dynamic selects in grid view

### DIFF
--- a/public/js/pimcore/object/tags/select.js
+++ b/public/js/pimcore/object/tags/select.js
@@ -123,6 +123,10 @@ pimcore.object.tags.select = Class.create(pimcore.object.tags.abstract, {
             data: options
         });
 
+        if (!field.layout.mandatory) {
+            options.unshift({'value': '', 'key': '(' + t('empty') + ')'});
+        }
+
         let editorConfig = this.initEditorConfig(field);
 
         editorConfig = Object.assign(editorConfig, {


### PR DESCRIPTION
similar to the already fixed bug (https://github.com/pimcore/pimcore/pull/11675, https://github.com/pimcore/pimcore/issues/11604) for static selects (configure) and the missing 'empty' option, this also fixes the same bug for dynamic selects (select options, provider).

was only added to the `getGridColumnEditor` function (https://github.com/pimcore/admin-ui-classic-bundle/blob/2.x/public/js/pimcore/object/tags/select.js#L153-L155) but should also be added to the `getCellEditor` function (https://github.com/pimcore/admin-ui-classic-bundle/blob/2.x/public/js/pimcore/object/tags/select.js#L110C5-L144) that is used for dynamic selects.