### PR TITLE
Advanced Many-to-Many (Object) Relations: Support opening assigned element via double-click

### DIFF
--- a/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyObjectRelation.js
@@ -489,7 +489,14 @@ pimcore.object.tags.advancedManyToManyObjectRelation = Class.create(pimcore.obje
             plugins: [
                 this.cellEditing,
                 'gridfilters'
-            ]
+            ],
+            listeners: {
+                celldblclick: function (grid, cell, cellIndex, record) {
+                    if (cellIndex < visibleFields.length) {
+                        this.gridRowDblClickHandler(grid, record);
+                    }
+                }.bind(this)
+            }
         });
 
         if (!readOnly) {

--- a/public/js/pimcore/object/tags/advancedManyToManyRelation.js
+++ b/public/js/pimcore/object/tags/advancedManyToManyRelation.js
@@ -464,7 +464,14 @@ pimcore.object.tags.advancedManyToManyRelation = Class.create(pimcore.object.tag
             plugins: [
                 this.cellEditing,
                 'gridfilters'
-            ]
+            ],
+            listeners: {
+                celldblclick: function (grid, cell, cellIndex, record) {
+                    if (cellIndex < visibleFields.length) {
+                        this.gridRowDblClickHandler(grid, record);
+                    }
+                }.bind(this)
+            }
         });
 
         this.component.on("rowcontextmenu", this.onRowContextmenu.bind(this));


### PR DESCRIPTION
In editing panel, for non-advanced many-to-many (object) relations it is possible since a long time to open the referenced element via double click. For *advanced* many-to-many (object) relations this does currently not work. This PR adds this feature: When you double-click a column which is no meta column for the relation, the assigned element gets opened.

Steps to reproduce:
1. Create data object class with an advanced many-to-many object relation, set allowed class to the class itself, add a meta / custom field `meta`
2. Create object of this class
3. Create another object of this class
4. Open object from 3. and assign the object from 2. to the relation
5. Double-click a cell on the relation table except the meta column `meta`

With PR: Object from 2. will open.
Without PR: Nothing happens.

Have used target branch `1.7` because imho it is a UX bug. If you disagree and favor to put it into `2.x`, also fine for me.