### PR TITLE
Reverse relation fields: support column filtering

### DIFF
--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -769,7 +769,10 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
                         this.requestNicePathData(this.store.data, true);
                     }.bind(this)
                 }
-            }
+            },
+            plugins: [
+                'gridfilters'
+            ]
         });
 
         return this.component;

--- a/public/js/pimcore/object/tags/reverseObjectRelation.js
+++ b/public/js/pimcore/object/tags/reverseObjectRelation.js
@@ -199,6 +199,9 @@ pimcore.object.tags.reverseObjectRelation = Class.create(pimcore.object.tags.man
             listeners: {
                 rowdblclick: this.gridRowDblClickHandler,
             },
+            plugins: [
+                'gridfilters'
+            ]
         });
 
         this.component.on("rowcontextmenu", this.onRowContextmenu);


### PR DESCRIPTION
In analogy to #659 this PR adds column filtering also for reverse relation fields:
<img width="1076" alt="Bildschirmfoto 2025-03-18 um 08 03 10" src="https://github.com/user-attachments/assets/a623f1ad-3396-4e19-bac8-6de8c8fc9459" />

Moreover column filtering did not work for fields which are configured to be `not editable`. With this PR this is possible (as filtering is no data change).
