### PR TITLE
Fix: Translate dashboard titles in toolbar and panel instead of displaying the “key”

### DIFF
--- a/public/js/pimcore/layout/portal.js
+++ b/public/js/pimcore/layout/portal.js
@@ -124,7 +124,7 @@ pimcore.layout.portal = Class.create({
             this.panel = Ext.create('Portal.view.PortalPanel', {
                 id: "pimcore_portal_" + this.key,
                 layout: 'column',
-                title: this.key == "welcome" ? t("welcome") : this.key,
+                title: t(this.key),
                 border: true,
                 bodyCls: 'x-portal-body',
                 iconCls: "pimcore_icon_welcome",

--- a/public/js/pimcore/layout/toolbar.js
+++ b/public/js/pimcore/layout/toolbar.js
@@ -92,7 +92,7 @@ pimcore.layout.toolbar = Class.create({
                          var data = Ext.decode(response.responseText);
                          for (var i = 0; i < data.length; i++) {
                              this.dashboardMenu.menu.add({
-                                 text: data[i],
+                                 text: t(data[i]),
                                  iconCls: "pimcore_nav_icon_dashboards",
                                  itemId: 'pimcore_menu_file_dashboards_custom_' + data[i],
                                  handler: function (key) {


### PR DESCRIPTION
Currently, additional dashboards display the “key” as a visual name without the option to translate it. This option has been added.