### PR TITLE
BugFix: Calculated Value Bool Type

### DIFF
--- a/public/js/pimcore/object/tags/calculatedValue.js
+++ b/public/js/pimcore/object/tags/calculatedValue.js
@@ -65,6 +65,8 @@ pimcore.object.tags.calculatedValue = Class.create(pimcore.object.tags.abstract,
             this.component = new Ext.form.field.Display(input);
         } else if (this.fieldConfig.elementType === 'date') {
             this.component = new Ext.form.DateField(input);
+        } else if(this.fieldConfig.elementType === 'boolean'){
+            this.component = new Ext.form.field.Checkbox(input);
         } else {
             this.component = new Ext.form.field.Text(input);
         }


### PR DESCRIPTION
When using the calculated value bool type it is using the input type instead of a checkbox.