### PR TITLE
bugfix: hide marker and predefinedDataTemplates from image url, avoid long uris

### DIFF
--- a/public/js/pimcore/document/editables/image.js
+++ b/public/js/pimcore/document/editables/image.js
@@ -353,6 +353,8 @@ pimcore.document.editables.image = Class.create(pimcore.document.editable, {
         let merged = Ext.merge(this.datax, additionalConfig);
         merged = Ext.clone(merged);
         delete merged["hotspots"];
+        delete merged["marker"];
+        delete merged["predefinedDataTemplates"];
         delete merged["path"];
         return merged;
 


### PR DESCRIPTION
While `hotspots` data is removed from the image-thumbnail-url, `marker` and `predefinedDataTemplates` are still appended, leading to very long image urls. This might force servers to throw `414 URI Too Long`.

This PR will strip the mentioned indices from the thumbnail meta data.