### PR TITLE
fix: First unit not showing up in a dropdown

### DIFF
--- a/public/js/pimcore/object/quantityvalue/unitsettings.js
+++ b/public/js/pimcore/object/quantityvalue/unitsettings.js
@@ -187,7 +187,7 @@ pimcore.object.quantityValue.unitsettings = Class.create({
                     try {
                         baseUnitStore.reload({
                             page: this.store.currentPage,
-                            start: 1,
+                            start: 0,
                             limit: 9999
                         });
                         Ext.apply(baseUnitStore, {pageSize: this.pagingtoolbar.pageSize});


### PR DESCRIPTION
This fixes the issue with the first quantity value unit not showing up in a dropdown select when attempting to set a base unit to another unit.

I have read the CLA Document and I hereby sign the CLA.