### PR TITLE
Dispatching event within errorHandler function while executing upload asset via asset tree

### DIFF
--- a/public/js/pimcore/asset/tree.js
+++ b/public/js/pimcore/asset/tree.js
@@ -266,10 +266,22 @@
                      pimcore.elementservice.refreshNodeAllTrees("asset", parentNode.get("id"));
                  }
              }.bind(this);
- 
+
              var errorHandler = function (e) {
-                 var res = Ext.decode(e["responseText"]);
-                 pimcore.helpers.showNotification(t("error"), res.message ? res.message : t("error"), "error", e["responseText"]);
+                 const res = Ext.decode(e["responseText"]);
+                 const addAssetError = new CustomEvent(pimcore.events.assetTreeAddAssetError, {
+                     detail: res,
+                     cancelable: true
+                 });
+
+                 /*
+                     The default return value of dispatchEvent is true, but if you add event.preventDefault() in the listener,
+                     it will return false and the default action will not be triggered.
+                  */
+                 const addAssetErrorCancelled = document.dispatchEvent(addAssetError);
+                 if (addAssetErrorCancelled) {
+                     pimcore.helpers.showNotification(t("error"), res.message ? res.message : t("error"), "error", e["responseText"]);
+                 }
                  finishedErrorHandler();
              }.bind(this);
  

--- a/public/js/pimcore/events.js
+++ b/public/js/pimcore/events.js
@@ -162,6 +162,12 @@
   * url returning the metadata definitions is passed as parameter
   */
  pimcore.events.prepareAssetMetadataGridConfigurator = "pimcore.gridConfigurator.assetMetadata.prepare";
+
+ /**
+  * upload via asset tree and handle the error
+  * response is passed as parameter
+  */
+ pimcore.events.assetTreeAddAssetError = "pimcore.events.assetTree.addAssetError";
  
  /**
   * before context menu is opened


### PR DESCRIPTION
We have a customer who would like to have a confirmation dialog at the upload event. I have added an event for this and implemented it in the error handler function that is called when the asset is uploaded via the asset tree.

The background is the intermediate duplicate check and throwing an exception if the asset (checksum identical) already exists in the system. The exception is filled with data accordingly and then evaluated in a JS plugin (customized).