### PR TITLE
[Grid] Column filter for relational fields with width > 300 hides search icon

### DIFF
--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -418,6 +418,8 @@ pimcore.element.helpers.gridColumnConfig = {
                 containerType: "filterByRelationWindow"
             });
 
+            editor.fieldConfig.width = 300;
+
             const formPanel = Ext.create('Ext.form.Panel', {
                 xtype: "form",
                 border: false,


### PR DESCRIPTION
Steps to reproduce:

1. Create class with many-to-one relation field `Brand`
    Set `width` of field to `500`. 
2. Create object of this class
3. Open grid view of `/`, show field `Brand`
4. Use column filter for `Brand` -> Filter by relation

As the width of the popup window is only 500px, the input field is so wide that the looking glass icon does not fit anymore:
<img width="705" alt="Bildschirmfoto 2025-04-07 um 16 35 18" src="https://github.com/user-attachments/assets/fc2893cd-b111-40f0-bf3a-da9d17e91779" />

If you set the field width to 600, the problem gets even worse: No buttons are shown at all:
<img width="703" alt="Bildschirmfoto 2025-04-07 um 16 37 16" src="https://github.com/user-attachments/assets/7c69d2b1-5c8b-49eb-a263-76ea7c83652e" />

This PR ignores the set `width` in the relation filter dialogue but uses always 300px - the same value as if no `width` was configured for the field, see
https://github.com/pimcore/admin-ui-classic-bundle/blob/f08380863d34fb8aa8284ecb62d385c271408068/public/js/pimcore/object/tags/manyToOneRelation.js#L157-L161

<img width="706" alt="Bildschirmfoto 2025-04-07 um 16 42 20" src="https://github.com/user-attachments/assets/050e4770-1132-4acc-aae4-e90916dc03d6" />