### PR TITLE
[Improvement]: Remove delete button from element view toolbar

### DIFF
--- a/public/js/pimcore/asset/asset.js
+++ b/public/js/pimcore/asset/asset.js
@@ -230,9 +230,6 @@ pimcore.asset.asset = Class.create(pimcore.element.abstract, {
 
                 if (pimcore.helpers.checkIfNewHeadbarLayoutIsEnabled()) {
                     this.toolbarSubmenu.menu.add(deleteConfig);
-                } else {
-                    this.toolbarButtons.remove = new Ext.Button(deleteConfig);
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
 

--- a/public/js/pimcore/asset/folder.js
+++ b/public/js/pimcore/asset/folder.js
@@ -246,22 +246,6 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
                 buttons.push(this.toolbarButtons.publish);
             }
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t('delete'),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: function () {
-                    var options = this.listfolder.onRawDeleteSelectedRows();
-                    if (!options) {
-                        options = {
-                            "elementType" : "asset",
-                            "id": this.id
-                        };
-                    }
-                    pimcore.elementservice.deleteElement(options);
-                }.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -296,8 +280,6 @@ pimcore.asset.folder = Class.create(pimcore.asset.asset, {
                             pimcore.elementservice.deleteElement(options);
                         }.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
             if (this.isAllowed("rename") && !this.data.locked && this.data.id != 1) {

--- a/public/js/pimcore/document/folder.js
+++ b/public/js/pimcore/document/folder.js
@@ -197,13 +197,6 @@ pimcore.document.folder = Class.create(pimcore.document.document, {
                 handler: this.save.bind(this)
             });
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t('delete_folder'),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: this.remove.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -235,8 +228,6 @@ pimcore.document.folder = Class.create(pimcore.document.document, {
                         scale: "medium",
                         handler: this.remove.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
 

--- a/public/js/pimcore/document/hardlink.js
+++ b/public/js/pimcore/document/hardlink.js
@@ -252,13 +252,6 @@ pimcore.document.hardlink = Class.create(pimcore.document.document, {
                 })
             }
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t('delete'),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: this.remove.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -302,8 +295,6 @@ pimcore.document.hardlink = Class.create(pimcore.document.document, {
                         scale: "medium",
                         handler: this.remove.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
 
@@ -363,11 +354,6 @@ pimcore.document.hardlink = Class.create(pimcore.document.document, {
 
             this.toolbar.on("afterrender", function () {
                 window.setTimeout(function () {
-                    // it's not possible to delete the root-node
-                    if (this.id == 1) {
-                        this.toolbarButtons.remove.hide();
-                    }
-
                     if (!this.data.published) {
                         this.toolbarButtons.unpublish.hide();
                     }
@@ -581,4 +567,3 @@ pimcore.document.hardlink = Class.create(pimcore.document.document, {
         }
     }
 });
-

--- a/public/js/pimcore/document/link.js
+++ b/public/js/pimcore/document/link.js
@@ -257,13 +257,6 @@ pimcore.document.link = Class.create(pimcore.document.document, {
                 })
             }
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t('delete'),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: this.remove.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -300,8 +293,6 @@ pimcore.document.link = Class.create(pimcore.document.document, {
                         scale: "medium",
                         handler: this.remove.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
             if (this.isAllowed("rename") && !this.data.locked) {
@@ -360,11 +351,6 @@ pimcore.document.link = Class.create(pimcore.document.document, {
 
             this.toolbar.on("afterrender", function () {
                 window.setTimeout(function () {
-                    // it's not possible to delete the root-node
-                    if (this.id == 1) {
-                        this.toolbarButtons.remove.hide();
-                    }
-
                     if (!this.data.published) {
                         this.toolbarButtons.unpublish.hide();
                     }
@@ -628,4 +614,3 @@ pimcore.document.link = Class.create(pimcore.document.document, {
         }
     }
 });
-

--- a/public/js/pimcore/document/page_snippet.js
+++ b/public/js/pimcore/document/page_snippet.js
@@ -289,13 +289,6 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
                 })
             }
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t('delete'),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: this.remove.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -343,8 +336,6 @@ pimcore.document.page_snippet = Class.create(pimcore.document.document, {
                         scale: "medium",
                         handler: this.remove.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
 

--- a/public/js/pimcore/object/folder.js
+++ b/public/js/pimcore/object/folder.js
@@ -295,22 +295,6 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
                 handler: this.save.bind(this, "publish")
             });
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t('delete'),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: function () {
-                    var options = this.search.onRawDeleteSelectedRows();
-                    if (!options) {
-                        options = {
-                            "elementType" : "object",
-                            "id": this.id
-                        };
-                    }
-                    pimcore.elementservice.deleteElement(options);
-                }.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -351,8 +335,6 @@ pimcore.object.folder = Class.create(pimcore.object.abstract, {
                             pimcore.elementservice.deleteElement(options);
                         }.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
 

--- a/public/js/pimcore/object/object.js
+++ b/public/js/pimcore/object/object.js
@@ -521,13 +521,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                 })
             }
 
-            this.toolbarButtons.remove = new Ext.Button({
-                tooltip: t("delete"),
-                iconCls: "pimcore_material_icon_delete pimcore_material_icon",
-                scale: "medium",
-                handler: this.remove.bind(this)
-            });
-
             this.toolbarButtons.rename = new Ext.Button({
                 tooltip: t('rename'),
                 iconCls: "pimcore_material_icon_rename pimcore_material_icon",
@@ -571,8 +564,6 @@ pimcore.object.object = Class.create(pimcore.object.abstract, {
                         scale: "medium",
                         handler: this.remove.bind(this)
                     });
-                } else {
-                    buttons.push(this.toolbarButtons.remove);
                 }
             }
 


### PR DESCRIPTION
Resolves #904 

The user is expected to delete items only using the context menu that opens when you mouse right-click on an item in the sidebar element tree.