### PR TITLE
[Documents] Areablock: Support controlsTrigger "click"

### DIFF
--- a/public/js/pimcore/document/editables/areablock.js
+++ b/public/js/pimcore/document/editables/areablock.js
@@ -152,7 +152,7 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
                             }
                         });
 
-                        var buttonContainer = Ext.get(component).selectNode('.pimcore_area_buttons', false);
+                        let buttonContainer = Ext.get(component).selectNode('.pimcore_area_buttons', false);
                         buttonContainer.show();
 
                         if (activeBlockEl != component) {

--- a/public/js/pimcore/document/editables/areablock.js
+++ b/public/js/pimcore/document/editables/areablock.js
@@ -56,7 +56,7 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
         }
 
         // click outside, hide all block buttons
-        if(this.config['controlsTrigger'] === 'hover') {
+        if(this.config['controlsTrigger'] === 'hover' || this.config['controlsTrigger'] === 'click') {
             Ext.getBody().on('click', function (event) {
                 if (Ext.get(id) && !Ext.get(id).isAncestor(event.target)) {
                     Ext.get(id).query('.pimcore_area_buttons', false).forEach(function (el) {

--- a/public/js/pimcore/document/editables/areablock.js
+++ b/public/js/pimcore/document/editables/areablock.js
@@ -107,7 +107,6 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
 
                 if(this.config['controlsTrigger'] === 'hover') {
                     Ext.get(this.elements[i]).on('mouseenter', function (event) {
-
                         if (Ext.dd.DragDropMgr.dragCurrent) {
                             return;
                         }
@@ -137,6 +136,30 @@ pimcore.document.editables.areablock = Class.create(pimcore.document.area_abstra
                             hideTimeout = null;
                         }, 10000);
                     });
+                } else if (this.config['controlsTrigger'] === 'click') {
+                    Ext.get(this.elements[i]).on('click', function (event) {
+                        let component = Ext.get(event.target);
+                        if(!component.hasCls('.pimcore_block_entry')) {
+                            component = component.up('.pimcore_block_entry');
+                        }
+                        if (Ext.dd.DragDropMgr.dragCurrent) {
+                            return;
+                        }
+
+                        Ext.get(this.id).query('.pimcore_area_buttons', false).forEach(function (el) {
+                            if (component != el.dom) {
+                                el.hide();
+                            }
+                        });
+
+                        var buttonContainer = Ext.get(component).selectNode('.pimcore_area_buttons', false);
+                        buttonContainer.show();
+
+                        if (activeBlockEl != component) {
+                            Ext.menu.Manager.hideAll();
+                        }
+                        activeBlockEl = component;
+                    }.bind(this));
                 }
             }
         }


### PR DESCRIPTION
Currently the area block controls only support `controlsTrigger` values:
- `hover`: show area block controls when hovering the area brick with mouse cursor
- `fixed`: show all area brick controls

When you have a lot of area bricks, `hover` can be difficult to use as you could accidentically move the mouse over the wrong element. And `fixed` causes a lot of clutter with all the control bars being visible.

For this reason this PR adds `controlsTrigger: "click"`. This way the control bar gets shown if you click into an area brick.
For example we implemented absolutely positioned area bricks for a web-to-print application with the `click` approach:

https://github.com/user-attachments/assets/e9911ac0-9efd-4ee0-b989-4c0c8ddb67b6