### PR TITLE
Fix invalid 2FA path name

### DIFF
--- a/templates/admin/login/two_factor_authentication.html.twig
+++ b/templates/admin/login/two_factor_authentication.html.twig
@@ -11,7 +11,7 @@
         </div>
     {% endif %}
 
-    <form method="post" action="{{ path('pimcore_admin_2fa-verify') }}">
+    <form method="post" action="{{ path('pimcore_admin_2fa_verify') }}">
         <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="password" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
         <input type="hidden" name="csrfToken" value="{{ pimcore_csrf.getCsrfToken(app.request.session) }}">
 


### PR DESCRIPTION
2FA login route name changed but was not adapted in template. Therefore, 2FA logins fail.

https://github.com/pimcore/admin-ui-classic-bundle/blob/10ea29130a41a9fefbcfc57b082f0ec5e3637a9b/src/Controller/Admin/LoginController.php#L398