### PR TITLE
fix: HTML-encode parameter list in email log

### DIFF
--- a/public/js/pimcore/settings/email/log.js
+++ b/public/js/pimcore/settings/email/log.js
@@ -273,7 +273,7 @@ pimcore.settings.email.log = Class.create({
 
                                         var data = record.data.data;
                                         if (data.type == 'simple') {
-                                            return data.value;
+                                            return Ext.util.Format.htmlEncode(data.value);
                                         } else {
                                             //when the objectPath is set -> the object is still available otherwise it was
                                             // deleted in the meantime


### PR DESCRIPTION
This issue was introduced in https://github.com/pimcore/pimcore/pull/18386

Parameters can include untrusted user input and must be HTML-encoded when displayed in the admin UI to prevent rendering issues or security vulnerabilities such as HTML injection.

Steps to reproduce:
- Create an email template with a template variable in subject.
- Insert html/js code into parameter. E.g., `Test <b>bold</b>`
- Navigate to the send email log and list parameters

Expected behaviour:
Parameter value output shouldn't render html tags. E.g., `Test <b>bold</b>`

Actual behaviour:
Html tags rendered. E.g., `Test bold`
