### PR TITLE
(Bugfix) Creation of dynamic property is deprecated

### DIFF
--- a/public/js/pimcore/settings/user/workspace/asset.js
+++ b/public/js/pimcore/settings/user/workspace/asset.js
@@ -32,10 +32,10 @@ pimcore.settings.user.workspace.asset = Class.create({
 
         var availableRights = ["list","view","publish","delete","rename","create","settings","versions","properties"];
         var gridPlugins = [];
-        var storeFields = ["path"];
+        var storeFields = ["cpath"];
 
         var typesColumns = [
-            {text: t("path"), width: 200, sortable: false, dataIndex: 'path',
+            {text: t("path"), width: 200, sortable: false, dataIndex: 'cpath',
                         editor: new Ext.form.TextField({}),
                         renderer: Ext.util.Format.htmlEncode,
                         tdCls: "pimcore_property_droptarget"
@@ -99,7 +99,7 @@ pimcore.settings.user.workspace.asset = Class.create({
             trackMouseOver: true,
             columnLines: true,
             stripeRows: true,
-            autoExpandColumn: "path",
+            autoExpandColumn: "cpath",
             autoHeight: true,
             style: "margin-bottom:20px;",
             plugins: [
@@ -159,7 +159,7 @@ pimcore.settings.user.workspace.asset = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("path", data.path);
+                            var index = this.grid.getStore().findExact("cpath", data.path);
                             if (index >= 0) {
                                 return false;
                             }
@@ -169,7 +169,7 @@ pimcore.settings.user.workspace.asset = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("path", data.path);
+                            rec.set("cpath", data.path);
 
                             this.updateRows();
 
@@ -186,7 +186,7 @@ pimcore.settings.user.workspace.asset = Class.create({
 
     onAdd: function (btn, ev) {
         this.grid.store.insert(0, {
-            path: ""
+            cpath: ""
         });
 
         this.updateRows();

--- a/public/js/pimcore/settings/user/workspace/asset.js
+++ b/public/js/pimcore/settings/user/workspace/asset.js
@@ -159,7 +159,7 @@ pimcore.settings.user.workspace.asset = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("cpath", data.cpath);
+                            var index = this.grid.getStore().findExact("cpath", data.path);
                             if (index >= 0) {
                                 return false;
                             }
@@ -169,7 +169,7 @@ pimcore.settings.user.workspace.asset = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("cpath", data.cpath);
+                            rec.set("cpath", data.path);
 
                             this.updateRows();
 

--- a/public/js/pimcore/settings/user/workspace/asset.js
+++ b/public/js/pimcore/settings/user/workspace/asset.js
@@ -159,7 +159,7 @@ pimcore.settings.user.workspace.asset = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("cpath", data.path);
+                            var index = this.grid.getStore().findExact("cpath", data.cpath);
                             if (index >= 0) {
                                 return false;
                             }
@@ -169,7 +169,7 @@ pimcore.settings.user.workspace.asset = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("cpath", data.path);
+                            rec.set("cpath", data.cpath);
 
                             this.updateRows();
 

--- a/public/js/pimcore/settings/user/workspace/document.js
+++ b/public/js/pimcore/settings/user/workspace/document.js
@@ -33,10 +33,10 @@ pimcore.settings.user.workspace.document = Class.create({
         var availableRights = ["list","view","save","publish","unpublish","delete","rename","create","settings",
                                                             "versions","properties"];
         var gridPlugins = [];
-        var storeFields = ["path"];
+        var storeFields = ["cpath"];
 
         var typesColumns = [
-            {text: t("path"), width: 200, sortable: false, dataIndex: 'path',
+            {text: t("path"), width: 200, sortable: false, dataIndex: 'cpath',
                     editor: new Ext.form.TextField({}),
                     renderer: Ext.util.Format.htmlEncode,
                     tdCls: "pimcore_property_droptarget"
@@ -100,7 +100,7 @@ pimcore.settings.user.workspace.document = Class.create({
             trackMouseOver: true,
             columnLines: true,
             stripeRows: true,
-            autoExpandColumn: "path",
+            autoExpandColumn: "cpath",
             autoHeight: true,
             style: "margin-bottom:20px;",
             plugins: [
@@ -160,7 +160,7 @@ pimcore.settings.user.workspace.document = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("path", data.path);
+                            var index = this.grid.getStore().findExact("cpath", data.path);
                             if (index >= 0) {
                                 return false;
                             }
@@ -170,7 +170,7 @@ pimcore.settings.user.workspace.document = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("path", data.path);
+                            rec.set("cpath", data.path);
 
                             this.updateRows();
 
@@ -187,7 +187,7 @@ pimcore.settings.user.workspace.document = Class.create({
 
     onAdd: function (btn, ev) {
         this.grid.store.insert(0, {
-            path: ""
+            cpath: ""
         });
 
         this.updateRows();

--- a/public/js/pimcore/settings/user/workspace/document.js
+++ b/public/js/pimcore/settings/user/workspace/document.js
@@ -160,7 +160,7 @@ pimcore.settings.user.workspace.document = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("cpath", data.cpath);
+                            var index = this.grid.getStore().findExact("cpath", data.path);
                             if (index >= 0) {
                                 return false;
                             }
@@ -170,7 +170,7 @@ pimcore.settings.user.workspace.document = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("cpath", data.cpath);
+                            rec.set("cpath", data.path);
 
                             this.updateRows();
 

--- a/public/js/pimcore/settings/user/workspace/document.js
+++ b/public/js/pimcore/settings/user/workspace/document.js
@@ -160,7 +160,7 @@ pimcore.settings.user.workspace.document = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("cpath", data.path);
+                            var index = this.grid.getStore().findExact("cpath", data.cpath);
                             if (index >= 0) {
                                 return false;
                             }
@@ -170,7 +170,7 @@ pimcore.settings.user.workspace.document = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("cpath", data.path);
+                            rec.set("cpath", data.cpath);
 
                             this.updateRows();
 

--- a/public/js/pimcore/settings/user/workspace/object.js
+++ b/public/js/pimcore/settings/user/workspace/object.js
@@ -192,7 +192,7 @@ pimcore.settings.user.workspace.object = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("cpath", data.cpath);
+                            var index = this.grid.getStore().findExact("cpath", data.path);
                             if (index >= 0) {
                                 return false;
                             }
@@ -202,7 +202,7 @@ pimcore.settings.user.workspace.object = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("cpath", data.cpath);
+                            rec.set("cpath", data.path);
 
                             this.updateRows();
 

--- a/public/js/pimcore/settings/user/workspace/object.js
+++ b/public/js/pimcore/settings/user/workspace/object.js
@@ -34,10 +34,10 @@ pimcore.settings.user.workspace.object = Class.create({
                                                                 "versions","properties"];
 
         var gridPlugins = [];
-        var storeFields = ["path"];
+        var storeFields = ["cpath"];
 
         var typesColumns = [
-            {text: t("path"), width: 200, sortable: false, dataIndex: 'path',
+            {text: t("path"), width: 200, sortable: false, dataIndex: 'cpath',
                                 editor: new Ext.form.TextField({}),
                                 renderer: Ext.util.Format.htmlEncode,
                                 tdCls: "pimcore_property_droptarget"
@@ -81,10 +81,10 @@ pimcore.settings.user.workspace.object = Class.create({
                         lView: data.data.lView,
                         lEdit: data.data.lEdit,
                         layouts: data.data.layouts,
-                        path: data.data.path
+                        cpath: data.data.cpath
                     };
 
-                    var dialog = new pimcore.settings.user.workspace.special(callback, specialData, data.data.path);
+                    var dialog = new pimcore.settings.user.workspace.special(callback, specialData, data.data.cpath);
                     dialog.show();
                 }.bind(this)
             }]
@@ -132,7 +132,7 @@ pimcore.settings.user.workspace.object = Class.create({
             trackMouseOver: true,
             columnLines: true,
             stripeRows: true,
-            autoExpandColumn: "path",
+            autoExpandColumn: "cpath",
             autoHeight: true,
             style: "margin-bottom:20px;",
             plugins: [
@@ -192,7 +192,7 @@ pimcore.settings.user.workspace.object = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("path", data.path);
+                            var index = this.grid.getStore().findExact("cpath", data.path);
                             if (index >= 0) {
                                 return false;
                             }
@@ -202,7 +202,7 @@ pimcore.settings.user.workspace.object = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("path", data.path);
+                            rec.set("cpath", data.path);
 
                             this.updateRows();
 
@@ -219,7 +219,7 @@ pimcore.settings.user.workspace.object = Class.create({
 
     onAdd: function (btn, ev) {
         this.grid.store.insert(0, {
-            path: ""
+            cpath: ""
         });
 
         this.updateRows();

--- a/public/js/pimcore/settings/user/workspace/object.js
+++ b/public/js/pimcore/settings/user/workspace/object.js
@@ -192,7 +192,7 @@ pimcore.settings.user.workspace.object = Class.create({
                             var data = record.data;
 
                             // check for duplicate records
-                            var index = this.grid.getStore().findExact("cpath", data.path);
+                            var index = this.grid.getStore().findExact("cpath", data.cpath);
                             if (index >= 0) {
                                 return false;
                             }
@@ -202,7 +202,7 @@ pimcore.settings.user.workspace.object = Class.create({
                             }
 
                             var rec = this.grid.getStore().getAt(myRowIndex);
-                            rec.set("cpath", data.path);
+                            rec.set("cpath", data.cpath);
 
                             this.updateRows();
 

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -325,11 +325,11 @@ class UserController extends AdminAbstractController implements KernelController
                 foreach ($workspaces as $type => $spaces) {
                     $newWorkspaces = [];
                     foreach ($spaces as $space) {
-                        if (in_array($space['path'], $processedPaths[$type])) {
-                            throw new \Exception('Error saving workspaces as multiple entries found for path "' . $space['path'] .'" in '.$translator->trans((string)$type, [], 'admin') . 's');
+                        if (in_array($space['cpath'], $processedPaths[$type])) {
+                            throw new \Exception('Error saving workspaces as multiple entries found for path "' . $space['cpath'] .'" in '.$translator->trans((string)$type, [], 'admin') . 's');
                         }
 
-                        $element = Element\Service::getElementByPath($type, $space['path']);
+                        $element = Element\Service::getElementByPath($type, $space['cpath']);
                         if ($element) {
                             $className = '\\Pimcore\\Model\\User\\Workspace\\' . Element\Service::getBaseClassNameForElement($type);
                             $workspace = new $className();
@@ -340,7 +340,7 @@ class UserController extends AdminAbstractController implements KernelController
                             $workspace->setUserId($user->getId());
 
                             $newWorkspaces[] = $workspace;
-                            $processedPaths[$type][] = $space['path'];
+                            $processedPaths[$type][] = $space['cpath'];
                         }
                     }
                     $user->{'setWorkspaces' . ucfirst($type)}($newWorkspaces);

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -394,8 +394,11 @@ class UserController extends AdminAbstractController implements KernelController
             foreach ($workspaces as $wKey => $workspace) {
                 $el = Element\Service::getElementById($type, $workspace->getCid());
                 if ($el) {
-                    // direct injection => not nice but in this case ok ;-)
-                    $workspace->path = $el->getRealFullPath();
+                    if ($el instanceof User\Workspace\Asset || $el instanceof User\Workspace\DataObject || $el instanceof User\Workspace\Document) {
+                        if (method_exists($el, 'setCpath')) {
+                            $workspace->setCpath($el->getRealFullPath());
+                        }
+                    }
                     $workspaces[$wKey] = $workspace->getObjectVars();
                 }
             }

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -709,8 +709,11 @@ class UserController extends AdminAbstractController implements KernelController
             foreach ($workspaces as $wKey => $workspace) {
                 $el = Element\Service::getElementById($type, $workspace->getCid());
                 if ($el) {
-                    // direct injection => not nice but in this case ok ;-)
-                    $workspace->path = $el->getRealFullPath();
+                    if ($el instanceof User\Workspace\Asset || $el instanceof User\Workspace\DataObject || $el instanceof User\Workspace\Document) {
+                        if (method_exists($el, 'setCpath')) {
+                            $workspace->setCpath($el->getRealFullPath());
+                        }
+                    }
                     $workspaces[$wKey] = $workspace->getObjectVars();
                 }
             }

--- a/src/Tool.php
+++ b/src/Tool.php
@@ -59,7 +59,7 @@ final class Tool
             'hu' => 'hu', 'hy' => 'am', 'id' => 'id', 'ig' => 'ng', 'is' => 'is', 'it' => 'it', 'ja' => 'jp',
             'ka' => 'ge', 'os' => 'ge', 'kea' => 'cv', 'kk' => 'kz', 'kl' => 'gl', 'km' => 'kh', 'ko' => 'kr',
             'lg' => 'ug', 'lo' => 'la', 'lt' => 'lt', 'mg' => 'mg', 'mk' => 'mk', 'mn' => 'mn', 'ms' => 'my',
-            'mt' => 'mt', 'my' => 'mm', 'nb' => 'no', 'ne' => 'np', 'nl' => 'nl', 'nn' => 'no', 'pl' => 'pl',
+            'mt' => 'mt', 'my' => 'mm', 'nb' => 'no', 'ne' => 'np', 'nl' => 'nl', 'no' => 'no', 'nn' => 'no', 'pl' => 'pl',
             'pt' => 'pt', 'ro' => 'ro', 'ru' => 'ru', 'sg' => 'cf', 'sk' => 'sk', 'sl' => 'si', 'sq' => 'al',
             'sr' => 'rs', 'sv' => 'se', 'swc' => 'cd', 'th' => 'th', 'to' => 'to', 'tr' => 'tr', 'tzm' => 'ma',
             'uk' => 'ua', 'uz' => 'uz', 'vi' => 'vn', 'zh' => 'cn', 'gd' => 'gb-sct', 'gd-gb' => 'gb-sct',


### PR DESCRIPTION
as pimcore (platform-version v2024.4) is compatible with php 8.3 and 8.4, an issue is appearing with the message 
Deprecated: Creation of dynamic property Pimcore\Model\User\Workspace\Asset::$path is deprecated in /var/www/html/vendor/pimcore/admin-ui-classic-bundle/src/Controller/Admin/UserController.php on line 713
and blocking the capacity to modify roles with has paths definitions in the workspaces