### PR TITLE
Marking classification fields as dirty when changed in the grid-view

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -209,6 +209,8 @@ trait DataObjectActionsTrait
                             }
                         }
 
+                        $object->markFieldDirty($field);
+
                         $activeGroups = $classificationStoreData->getActiveGroups() ?: [];
                         $activeGroups[$groupId] = true;
                         $classificationStoreData->setActiveGroups($activeGroups);

--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1513,6 +1513,7 @@ class DataObjectHelperController extends AdminAbstractController
                                     $dataDefinition->getDataFromEditmode($value),
                                     $csLanguage
                                 );
+                                $object->markFieldDirty($field);
                             }
                         }
                     } elseif (count($parts) > 1) {


### PR DESCRIPTION
When changing a value in the classificationstore grid, it was not being marked as dirty