### PR TITLE
Support having the same language with multiple locales for preview

### DIFF
--- a/src/Service/PreviewGenerator.php
+++ b/src/Service/PreviewGenerator.php
@@ -82,7 +82,7 @@ class PreviewGenerator implements PreviewGeneratorInterface
 
         $locales = [];
         foreach (Tool::getValidLanguages() as $locale) {
-            $label = \Locale::getDisplayLanguage($locale, $userLocale);
+            $label = sprintf('%s (%s)', \Locale::getDisplayLanguage($locale, $userLocale), $locale);
             $locales[$label] = $locale;
         }
 


### PR DESCRIPTION
Otherwise it is not possible to differ between locales of the same language.
E.g. having de_DE, de_CH, de_AT will always lead to just having 'German' as select option