### PR TITLE
[Workflow Transitions] Apply default value for additional fields

### DIFF
--- a/public/js/pimcore/workflow/transitionPanel.js
+++ b/public/js/pimcore/workflow/transitionPanel.js
@@ -272,8 +272,10 @@ pimcore.workflow.transitionPanel = Class.create({
                         field.setHeight(100);
                     }
 
-                    if (typeof field.applyDefaultValue !== "undefined") {
-                        field.applyDefaultValue();
+                    if (typeof field.setValue !== "undefined") {
+                        field.setValue(c.defaultValue);
+                    } else {
+                        field.config.items[0]?.setValue(c.defaultValue);
                     }
                 } catch(e) {
                     console.error('Could not add additional field');

--- a/public/js/pimcore/workflow/transitionPanel.js
+++ b/public/js/pimcore/workflow/transitionPanel.js
@@ -272,6 +272,9 @@ pimcore.workflow.transitionPanel = Class.create({
                         field.setHeight(100);
                     }
 
+                    if (typeof field.applyDefaultValue !== "undefined") {
+                        field.applyDefaultValue();
+                    }
                 } catch(e) {
                     console.error('Could not add additional field');
                     console.info(e);


### PR DESCRIPTION
Currently default values for additional fields in workflows do not get applied. This PR changes this by calling `applyDefaultValue()`, similar to https://github.com/pimcore/admin-ui-classic-bundle/blob/6ad887e762b2c3b5b02527b0d61080394436d2b8/public/js/pimcore/object/helpers/edit.js#L340-L342