### PR TITLE
BugFix: Classification Store Attribute Not Displaying Correct Value In Grid

### DIFF
--- a/src/Service/GridData/DataObject.php
+++ b/src/Service/GridData/DataObject.php
@@ -180,7 +180,7 @@ class DataObject extends Element
                     }
 
                     // because the key for the classification store has not a direct getter, you have to check separately if the data is inheritable
-                    if (str_starts_with($key, '~') && empty($data[$key]['value'])) {
+                    if (str_starts_with($key, '~')) {
                         $curClassAttributeValue = $data[$key] ?? null;
                         $isValueEmpty = is_array($curClassAttributeValue) ? empty($curClassAttributeValue['value'] ?? null) : empty($curClassAttributeValue);
 

--- a/src/Service/GridData/DataObject.php
+++ b/src/Service/GridData/DataObject.php
@@ -181,12 +181,17 @@ class DataObject extends Element
 
                     // because the key for the classification store has not a direct getter, you have to check separately if the data is inheritable
                     if (str_starts_with($key, '~') && empty($data[$key]['value'])) {
-                        $type = $keyParts[1];
+                        $curClassAttributeValue = $data[$key] ?? null;
+                        $isValueEmpty = is_array($curClassAttributeValue) ? empty($curClassAttributeValue['value'] ?? null) : empty($curClassAttributeValue);
 
-                        if ($type === 'classificationstore') {
-                            if (!empty($inheritedData = self::getInheritedData($object, $key, $requestedLanguage))) {
-                                $data[$dataKey] = $inheritedData['value'];
-                                $data['inheritedFields'][$dataKey] = ['inherited' => $inheritedData['parent']->getId() != $object->getId(), 'objectid' => $inheritedData['parent']->getId()];
+                        if ($isValueEmpty) {
+                            $type = $keyParts[1];
+
+                            if ($type === 'classificationstore') {
+                                if (!empty($inheritedData = self::getInheritedData($object, $key, $requestedLanguage))) {
+                                    $data[$dataKey] = $inheritedData['value'];
+                                    $data['inheritedFields'][$dataKey] = ['inherited' => $inheritedData['parent']->getId() != $object->getId(), 'objectid' => $inheritedData['parent']->getId()];
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When inheritance is enabled, the classification store attribute value is not being displayed correctly in the grid. 

Check to see if classification store attribute is an array before trying to access the `value` key. If not array, check to see if attribute has a value (similar to the logic when getting the inherited data: https://github.com/pimcore/admin-ui-classic-bundle/blob/1.7/src/Service/GridData/DataObject.php#L352)