### PR TITLE
[Bug, EC] PEES-578: Datahub Simple Rest API bundle flattening numeric fields values to a blank string when wrapped in an operator

### DIFF
--- a/src/DataObject/GridColumnConfig/Operator/Alias.php
+++ b/src/DataObject/GridColumnConfig/Operator/Alias.php
@@ -38,7 +38,7 @@ final class Alias extends AbstractOperator
             $childResult = $c->getLabeledValue($element);
             $isArrayType = $childResult->isArrayType ?? null;
             $childValues = $childResult->value;
-            if ($childValues && !$isArrayType) {
+            if (isset($childValues) && !$isArrayType) {
                 $childValues = [$childValues];
             }
 


### PR DESCRIPTION
partially resolves https://github.com/pimcore/service-operations/issues/132