### PR TITLE
[Grid Options] Fixes for saving grid configuration with "save filters"

### DIFF
--- a/public/js/pimcore/element/helpers/gridConfigDialog.js
+++ b/public/js/pimcore/element/helpers/gridConfigDialog.js
@@ -285,7 +285,7 @@ pimcore.element.helpers.gridConfigDialog = Class.create({
 
         this.saveFilters = new Ext.form.field.Checkbox(
             {
-                fieldLabel: "Save filters",
+                fieldLabel: t("save_filters"),
                 inputValue: true,
                 name: "saveFilters",
                 value: this.settings.saveFilters

--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -350,6 +350,13 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             tbar: this.getToolbar(fromConfig, save)
         });
 
+        if (this.filter) {
+            this.filter.forEach(filt => {
+                this.filterUpdateFunction(this.grid, this.toolbarFilterInfo, this.clearFilterButton);
+            });
+        }
+
+
         this.grid.on("columnmove", function () {
             this.saveColumnConfigButton.show()
         }.bind(this));

--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -283,7 +283,19 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                 let col = gridColumns[i];
                 if (col.filter) {
                     needGridFilter = true;
-                    break;
+
+                    if (this.filter) {
+                        var filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
+                        if(filterValue) {
+                            if (typeof col.filter !== "object") {
+                                col.filter = { type: col.filter };
+                            }
+
+                            col.filter.value = filterValue;
+                        }
+                    } else {
+                        break;
+                    }
                 }
             }
         }
@@ -337,13 +349,6 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
             cls: 'pimcore_object_grid_panel',
             tbar: this.getToolbar(fromConfig, save)
         });
-
-        if (this.filter) {
-            this.filter.forEach(filt => {
-                this.store.setFilters(new Ext.util.Filter(filt))
-                this.filterUpdateFunction(this.grid, this.toolbarFilterInfo, this.clearFilterButton);
-            });
-        }
 
         this.grid.on("columnmove", function () {
             this.saveColumnConfigButton.show()

--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -285,8 +285,8 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                     needGridFilter = true;
 
                     if (this.filter) {
-                        var filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
-                        if(filterValue) {
+                        const filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
+                        if (filterValue) {
                             if (typeof col.filter !== "object") {
                                 col.filter = { type: col.filter };
                             }

--- a/src/Model/GridConfig.php
+++ b/src/Model/GridConfig.php
@@ -45,7 +45,7 @@ class GridConfig extends AbstractModel
 
     protected bool $setAsFavourite = false;
 
-    protected bool $saveFilters = false;
+    protected ?bool $saveFilters = null;
 
     protected string $type = 'object';
 
@@ -199,12 +199,22 @@ class GridConfig extends AbstractModel
 
     public function isSaveFilters(): bool
     {
+        if ($this->saveFilters === null) {
+            $config = json_decode($this->getConfig());
+
+            if (isset($config->filter)) {
+                $this->saveFilters = (bool) $config->filter;
+            } else {
+                $this->saveFilters = false;
+            }
+        }
+
         return $this->saveFilters;
     }
 
-    public function setSaveFilters(?bool $saveFilters): void
+    public function setSaveFilters(bool $saveFilters): void
     {
-        $this->saveFilters = (bool)$saveFilters;
+        $this->saveFilters = $saveFilters;
     }
 
     /**

--- a/src/Model/GridConfig.php
+++ b/src/Model/GridConfig.php
@@ -202,9 +202,9 @@ class GridConfig extends AbstractModel
         return $this->saveFilters;
     }
 
-    public function setSaveFilters(bool $saveFilters): void
+    public function setSaveFilters(?bool $saveFilters): void
     {
-        $this->saveFilters = $saveFilters;
+        $this->saveFilters = (bool)$saveFilters;
     }
 
     /**

--- a/src/Model/GridConfig/Dao.php
+++ b/src/Model/GridConfig/Dao.php
@@ -57,7 +57,7 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
-        if (!$gridconfigs['saveFilters']){
+        if (!$gridconfigs['saveFilters']) {
             $configData = json_decode($data['config'], true);
             unset($configData['filter']);
             $data['config'] = json_encode($configData);

--- a/src/Model/GridConfig/Dao.php
+++ b/src/Model/GridConfig/Dao.php
@@ -57,6 +57,12 @@ class Dao extends Model\Dao\AbstractDao
             }
         }
 
+        if (!$gridconfigs['saveFilters']){
+            $configData = json_decode($data['config'], true);
+            unset($configData['filter']);
+            $data['config'] = json_encode($configData);
+        }
+
         $lastInsertId = Helper::upsert($this->db, 'gridconfigs', $data, $this->getPrimaryKey('gridconfigs'));
         if ($lastInsertId !== null && !$this->model->getId()) {
             $this->model->setId((int) $lastInsertId);

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -581,6 +581,7 @@ restrict_to_locales: 'Restrict to locales'
 predefined: Predefined
 save_as_copy: 'Save as copy'
 set_as_favourite: 'Set as favourite'
+save_filters: Save filters
 grid_configuration: 'Grid Configuration'
 shared_users: 'Shared Users'
 shared_roles: 'Shared Roles'


### PR DESCRIPTION
Steps to reproduce bug:
1. Open data object grid for a folder
2. So some filtering by column filters
3. Edit "Grid Options", enter name "Filter Saving Test", go to tab "Save & Share", enable "Save filters" and click "Save copy & Share"
4. Reload grid
5. Select grid configuration "Filter Saving Test" from "Grid Options" dropdown

Expected behaviours:
1. Column filters should be set
2. When going to "Grid Options" again, the "Save filters" checkbox should be checked

Actual behaviour:
1. Although saved filters get applied, column filters are not visibly set (in UI it looks as if there were no filters active - beside the "Filters active!" hint above the grid)
2. When clicking "Grid Options" button again, in "Save & Share" tab, the "Save filters" checkbox is disabled.

Reasoning:
1. Presetting column filter values
https://github.com/pimcore/admin-ui-classic-bundle/blob/7bf40f83bc1e93bd58decc2db98a85015a5d8461/public/js/pimcore/object/folder/search.js#L341-L346
This applies the saved filters to the store. But there is no connection to the column filters here. For this reason, the filters get applied but not shown in the column filters. Instead the [ExtJS docs](https://docs.sencha.com/extjs/7.4.0/classic/ Ext.grid.filters.Filters.html) suggest:
```javascript
columns: [{
        dataIndex: 'show',
        text: 'Show',
        flex: 1,
        filter: {
            type: 'string',
            value: 'star',
        }
    }]
```
With this approach the preset value gets applied to the column filter and thus as well to the store.

2. Saving "Save filter" checkbox
The reason why the checkbox was not saved surprised me very much: Although the `Dao` object contains `setSaveFilters()` and `getSaveFilters()`, the database table `gridconfigs` is missing a corresponding column. When saving the grid config in
https://github.com/pimcore/admin-ui-classic-bundle/blob/7bf40f83bc1e93bd58decc2db98a85015a5d8461/src/Controller/Admin/DataObject/DataObjectHelperController.php#L872
The value for `saveFilters` column gets set.
In https://github.com/pimcore/admin-ui-classic-bundle/blob/7bf40f83bc1e93bd58decc2db98a85015a5d8461/src/Controller/Admin/DataObject/DataObjectHelperController.php#L877
the grid config is tried to be saved. But as there is no column for this field in
https://github.com/pimcore/admin-ui-classic-bundle/blob/7bf40f83bc1e93bd58decc2db98a85015a5d8461/src/Model/GridConfig/Dao.php#L51
it gets simply ignored.
As the `admin-ui-classic` bundle does not have any migrations, I have added this in https://github.com/pimcore/pimcore/pull/18528.

This PR fixes this. Additionally it adds a translation for `Save filters` checkbox label which was hard-coded before.