### PR TITLE
Fix: wrong check of classname against classid in perspectiveCfg.classes

### DIFF
--- a/public/js/pimcore/object/tree.js
+++ b/public/js/pimcore/object/tree.js
@@ -555,7 +555,23 @@ pimcore.registerNS("pimcore.object.tree");
                      var pasteMenu = [];
 
                      if (perspectiveCfg.inTreeContextMenu("object.paste")) {
-                         if (pimcore.cachedObjectId && (typeof perspectiveCfg.classes === "undefined" || typeof pimcore.copiedObject.get('className') === "undefined" || pimcore.copiedObject.get('className') in perspectiveCfg.classes)) {
+                         var classId = null;
+
+                         // Determine ClassId if copiedObject exists
+                         if (typeof pimcore.copiedObject !== 'undefined' && pimcore.copiedObject !== null) {
+                             if (typeof pimcore.copiedObject.get('className') !== "undefined") {
+                                 var className = pimcore.copiedObject.get('className');
+                                 if (className) {
+                                     var objectTypesStore = pimcore.globalmanager.get("object_types_store");
+                                     var classRecord = objectTypesStore.findRecord('text', className);
+                                     if (classRecord) {
+                                         classId = classRecord.get('id');
+                                     }
+                                 }
+                             }
+                         }
+
+                         if (pimcore.cachedObjectId && (typeof perspectiveCfg.classes === "undefined" || classId === null || classId in perspectiveCfg.classes)) {
                              pasteMenu.push({
                                  text: t("paste_recursive_as_child"),
                                  iconCls: "pimcore_icon_paste",

--- a/public/js/pimcore/object/tree.js
+++ b/public/js/pimcore/object/tree.js
@@ -555,15 +555,15 @@ pimcore.registerNS("pimcore.object.tree");
                      var pasteMenu = [];
 
                      if (perspectiveCfg.inTreeContextMenu("object.paste")) {
-                         var classId = null;
+                         let classId = null;
 
                          // Determine ClassId if copiedObject exists
                          if (typeof pimcore.copiedObject !== 'undefined' && pimcore.copiedObject !== null) {
                              if (typeof pimcore.copiedObject.get('className') !== "undefined") {
-                                 var className = pimcore.copiedObject.get('className');
+                                 let className = pimcore.copiedObject.get('className');
                                  if (className) {
-                                     var objectTypesStore = pimcore.globalmanager.get("object_types_store");
-                                     var classRecord = objectTypesStore.findRecord('text', className);
+                                     let objectTypesStore = pimcore.globalmanager.get("object_types_store");
+                                     let classRecord = objectTypesStore.findRecord('text', className);
                                      if (classRecord) {
                                          classId = classRecord.get('id');
                                      }


### PR DESCRIPTION
Since commit #7b7c5e2 the className in the perspectiveCfg is checked. This only works if the className is identical to the classId.

This PR always determines the classId to compare the correct values with each other. perspectiveCfg.classes contains the classIds