### PR TITLE
fix(json-translations-system): used array_replace instead of array_merge which results wrong key => value pairs for numeric keys

### DIFF
--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -93,7 +93,7 @@ class MiscController extends AdminAbstractController
         }
 
         foreach (['admin', 'admin_ext'] as $domain) {
-            $translations = array_merge($translations, $translator->getCatalogue($language)->all($domain));
+            $translations = array_replace($translations, $translator->getCatalogue($language)->all($domain));
 
             foreach ($fallbackLanguages as $fallbackLanguage) {
                 $translator->lazyInitialize($domain, $fallbackLanguage);


### PR DESCRIPTION
# Issue

In Pimcore it is possible to translate elements in the Pimcore Admin Interface using Admin Translation. For example, if a folder is to be named differently than in the original.
 
Now we have discovered the following phenomenon and unfortunately I cannot determine the cause. The fact is, however, that it is a translation problem.
 
We use CoreShop and there, as with the Ecommerce Framework, a folder structure is created for the orders or shopping carts --> year/month/day
 
Lev had tested the order process and noticed the following when checking the admin interface. A folder with the key “200” was displayed within the folder structure, both under 2025/06/ and under 2025/07. After closer examination, it was the folders with the key “11”. The path is correct if you look at the folder information.
 
Strangely enough, after emptying the Pimcore cache (bin/console pi:ca:cl), the designation “11” could be seen again, but now other numerical designations such as ‘10’ were displayed as “200”.

<img width="878" height="242" alt="image" src="https://github.com/user-attachments/assets/822abafc-01d8-4472-8435-4e2dda4b80dc" />

<img width="2052" height="1330" alt="image" src="https://github.com/user-attachments/assets/51982926-a0d2-4417-ab44-203f1ce7f62d" />

# Solution
By using array_replace instead of array_merge, I could fix the problem.
