### PR TITLE
[Bug, EC] PEES-661: Select options do not load in localized field inside Custom Layout

### DIFF
--- a/public/js/pimcore/object/classes/data/countrymultiselect.js
+++ b/public/js/pimcore/object/classes/data/countrymultiselect.js
@@ -154,6 +154,11 @@ pimcore.object.classes.data.countrymultiselect = Class.create(pimcore.object.cla
 
     applyData: function ($super) {
         $super();
+
+        if(this.isInCustomLayoutEditor()) {
+            return;
+        }
+
         delete this.datax.options;
     },
 

--- a/public/js/pimcore/object/classes/data/multiselect.js
+++ b/public/js/pimcore/object/classes/data/multiselect.js
@@ -296,6 +296,10 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
 
         $super();
 
+        if(this.isInCustomLayoutEditor()) {
+            return;
+        }
+
         var options = [];
 
         var valueEditor = this.specificPanel.getComponent("valueeditor");

--- a/public/js/pimcore/object/classes/data/select.js
+++ b/public/js/pimcore/object/classes/data/select.js
@@ -286,6 +286,10 @@ pimcore.object.classes.data.select = Class.create(pimcore.object.classes.data.da
 
         $super();
 
+        if(this.isInCustomLayoutEditor()) {
+            return;
+        }
+
         let options = [];
 
         let valueEditor = this.specificPanel.getComponent("valueeditor") ?? null;


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/186

### Additional Information
The problem isn´t related to the `not editable` option at all. When you select a field in the custom layout editor (e.g. when you want to set the `not editable` option) the `applyData` method will be called. It tries to get the options from the `valueeditor` component which is not available in custom layout editor. 