### PR TITLE
Remove unused `database_administration` translation

### DIFF
--- a/translations/admin_ext.en.yaml
+++ b/translations/admin_ext.en.yaml
@@ -602,7 +602,6 @@ background_color: Background Color
 use_current_player_position_as_preview: Use current player position as preview
 system_infos_and_tools: System Info & Tools
 server_info: Server Info
-database_administration: Database Administration
 important_use_imagick_pecl_extensions_for_best_results_gd_is_just_a_fallback_with_less_quality: >-
     IMPORTANT: Use imagick PECL extension for best results, GDlib is just a
     fallback with limited functionality and less quality!


### PR DESCRIPTION
Usage has been removed in pimcore/pimcore#13921.