### PR TITLE
[Bug]: Fix option editor

### DIFF
--- a/public/js/pimcore/object/classes/data/multiselect.js
+++ b/public/js/pimcore/object/classes/data/multiselect.js
@@ -238,7 +238,7 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
     },
 
     showoptioneditor: function (store) {
-        let editor = new pimcore.object.helpers.gridEditor(store);
+        let editor = new pimcore.object.helpers.optionEditor(store);
         editor.edit();
     },
 
@@ -529,7 +529,7 @@ pimcore.object.classes.data.multiselect = Class.create(pimcore.object.classes.da
     },
 
     showgrideditor: function (valueStore) {
-        const editor = new pimcore.object.helpers.gridEditor(valueStore, ['value']);
+        const editor = new pimcore.object.helpers.optionEditor(valueStore, ['value']);
         editor.edit();
     }
 });

--- a/public/js/pimcore/object/classes/data/select.js
+++ b/public/js/pimcore/object/classes/data/select.js
@@ -323,7 +323,7 @@ pimcore.object.classes.data.select = Class.create(pimcore.object.classes.data.da
     },
 
     showgrideditor: function (valueStore) {
-        const editor = new pimcore.object.helpers.gridEditor(valueStore);
+        const editor = new pimcore.object.helpers.optionEditor(valueStore);
         editor.edit();
     }
 });

--- a/public/js/pimcore/object/helpers/optionEditor.js
+++ b/public/js/pimcore/object/helpers/optionEditor.js
@@ -14,11 +14,11 @@
  * pimcore.object.tags.localizedfields
  */
 
-pimcore.registerNS("pimcore.object.helpers.gridEditor");
+pimcore.registerNS("pimcore.object.helpers.optionEditor");
 /**
  * @private
  */
-pimcore.object.helpers.gridEditor = Class.create({
+pimcore.object.helpers.optionEditor = Class.create({
 
     initialize: function (
         store,

--- a/templates/admin/index/index.html.twig
+++ b/templates/admin/index/index.html.twig
@@ -307,7 +307,7 @@
     "pimcore/object/helpers/gridTabAbstract.js",
     "pimcore/object/helpers/metadataMultiselectEditor.js",
     "pimcore/object/helpers/customLayoutEditor.js",
-    "pimcore/object/helpers/gridEditor.js",
+    "pimcore/object/helpers/optionEditor.js",
     "pimcore/object/helpers/imageGalleryDropZone.js",
     "pimcore/object/helpers/imageGalleryPanel.js",
     "pimcore/object/helpers/selectField.js",


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/204
Followup https://github.com/pimcore/admin-ui-classic-bundle/pull/252

The rename was not necessary, breaking assets metadata and https://github.com/pimcore/admin-ui-classic-bundle/blob/2.1/public/js/pimcore/object/selectoptionsitems/definition.js#L548