### PR TITLE
[Bug]: Fix  missing Cast site parameter to integer in PreviewGenerator

### DIFF
--- a/src/Service/PreviewGenerator.php
+++ b/src/Service/PreviewGenerator.php
@@ -34,7 +34,9 @@ class PreviewGenerator implements PreviewGeneratorInterface
             $filteredParameters = $this->filterParameters($object, $params);
 
             $locale = $filteredParameters[PreviewGeneratorInterface::PARAMETER_LOCALE] ?? Tool::getDefaultLanguage();
-            $site = array_key_exists(PreviewGeneratorInterface::PARAMETER_SITE, $filteredParameters) ? Site::getById($filteredParameters[PreviewGeneratorInterface::PARAMETER_SITE]) : (new Site\Listing())->current();
+            $site = array_key_exists(PreviewGeneratorInterface::PARAMETER_SITE, $filteredParameters)
+                ? Site::getById((int)$filteredParameters[PreviewGeneratorInterface::PARAMETER_SITE])
+                : (new Site\Listing())->current();
 
             return $linkGenerator->generate($object, [
                 PreviewGeneratorInterface::PARAMETER_LOCALE => $locale,


### PR DESCRIPTION
Fixes 
<img width="904" height="695" alt="image" src="https://github.com/user-attachments/assets/933c1809-00d0-4991-8e75-615c3c91c403" />

query->all() is not mapping correctly and returning strings
https://github.com/pimcore/admin-ui-classic-bundle/blob/a8a482b544f79b708baa07e4439fcd851efbfe48/src/Controller/Admin/DataObject/DataObjectController.php#L1908