### PR TITLE
[Bug] Fix strlen(): Argument #1 ($string) must be of type string, array given in SubString Operator

### DIFF
--- a/src/DataObject/GridColumnConfig/Operator/Substring.php
+++ b/src/DataObject/GridColumnConfig/Operator/Substring.php
@@ -69,9 +69,25 @@ final class Substring extends AbstractOperator
                     if (!$childValue) {
                         continue;
                     }
-                    // try to implode if it's a plain array of strings
-                    if (is_array($childValue)){
-                        $childValue = implode(' ', array_map('strval', array_values($childValue)));
+
+                    if (!is_string($childValue)) {
+                        if (is_array($childValue)) {
+                            $childValue = implode(
+                                ' ',
+                                array_map(
+                                    fn($v) => is_scalar($v) ? (string)$v : '',
+                                    array_values($childValue)
+                                )
+                            );
+                        } elseif (is_object($childValue)) {
+                            // Convert object safely, prefer __toString if available
+                            $childValue = method_exists($childValue, '__toString')
+                                ? (string) $childValue
+                                : '';
+                        } else {
+                            // fallback for other types (int, float, bool, null)
+                            $childValue = (string) $childValue;
+                        }
                     }
 
                     $showEllipses = $useEllipses && mb_strlen($childValue) > ($start + $length);
@@ -91,7 +107,7 @@ final class Substring extends AbstractOperator
             if ($isArrayType) {
                 $result->value = $valueArray;
             } else {
-                $result->value = $valueArray[0];
+                $result->value = $valueArray[0] ?? '';
             }
         }
 

--- a/src/DataObject/GridColumnConfig/Operator/Substring.php
+++ b/src/DataObject/GridColumnConfig/Operator/Substring.php
@@ -80,12 +80,11 @@ final class Substring extends AbstractOperator
                                 )
                             );
                         } elseif (is_object($childValue)) {
-                            // Convert object safely, prefer __toString if available
                             $childValue = method_exists($childValue, '__toString')
                                 ? (string) $childValue
                                 : '';
                         } else {
-                            // fallback for other types (int, float, bool, null)
+                            // fallback for other types (int, float, bool)
                             $childValue = (string) $childValue;
                         }
                     }

--- a/src/DataObject/GridColumnConfig/Operator/Substring.php
+++ b/src/DataObject/GridColumnConfig/Operator/Substring.php
@@ -58,7 +58,6 @@ final class Substring extends AbstractOperator
             }
 
             if (is_array($childValues)) {
-
                 $start = $this->getStart();
                 $length = $this->getLength();
                 $useEllipses = $this->getEllipses();

--- a/src/DataObject/GridColumnConfig/Operator/Substring.php
+++ b/src/DataObject/GridColumnConfig/Operator/Substring.php
@@ -58,18 +58,25 @@ final class Substring extends AbstractOperator
             }
 
             if (is_array($childValues)) {
-                /** @var string $childValue */
+
+                $start = $this->getStart();
+                $length = $this->getLength();
+                $useEllipses = $this->getEllipses();
+
+                /** @var string|array $childValue */
                 foreach ($childValues as $childValue) {
-                    $showEllipses = false;
-                    if ($childValue && $this->getEllipses()) {
-                        $start = $this->getStart() ? $this->getStart() : 0;
-                        $length = $this->getLength() ? $this->getLength() : 0;
-                        if (strlen($childValue) > ($start + $length)) {
-                            $showEllipses = true;
-                        }
+
+                    if (!$childValue) {
+                        continue;
+                    }
+                    // try to implode if it's a plain array of strings
+                    if (is_array($childValue)){
+                        $childValue = implode(' ', array_map('strval', array_values($childValue)));
                     }
 
-                    $childValue = substr($childValue, $this->getStart(), $this->getLength());
+                    $showEllipses = $useEllipses && mb_strlen($childValue) > ($start + $length);
+
+                    $childValue = mb_substr($childValue, $start, $length);
                     if ($showEllipses) {
                         $childValue .= '...';
                     }

--- a/src/DataObject/GridColumnConfig/Operator/Substring.php
+++ b/src/DataObject/GridColumnConfig/Operator/Substring.php
@@ -104,12 +104,12 @@ final class Substring extends AbstractOperator
             $output = implode(
                 ' ',
                 array_map(
-                    fn($v) => is_scalar($v) ? (string)$v : '',
-                    array_values($value)
+                    fn($v) => is_scalar($v) || $v instanceof \Stringable ? (string)$v : '',
+                    $value
                 )
             );
         } elseif (is_object($value)) {
-            $output = method_exists($value, '__toString')
+            $output = $value instanceof \Stringable
                 ? (string) $value
                 : '';
         } else {

--- a/src/DataObject/GridColumnConfig/Operator/Substring.php
+++ b/src/DataObject/GridColumnConfig/Operator/Substring.php
@@ -71,22 +71,7 @@ final class Substring extends AbstractOperator
                     }
 
                     if (!is_string($childValue)) {
-                        if (is_array($childValue)) {
-                            $childValue = implode(
-                                ' ',
-                                array_map(
-                                    fn($v) => is_scalar($v) ? (string)$v : '',
-                                    array_values($childValue)
-                                )
-                            );
-                        } elseif (is_object($childValue)) {
-                            $childValue = method_exists($childValue, '__toString')
-                                ? (string) $childValue
-                                : '';
-                        } else {
-                            // fallback for other types (int, float, bool)
-                            $childValue = (string) $childValue;
-                        }
+                        $childValue = $this->convertToString($childValue);
                     }
 
                     $showEllipses = $useEllipses && mb_strlen($childValue) > ($start + $length);
@@ -111,6 +96,28 @@ final class Substring extends AbstractOperator
         }
 
         return $result;
+    }
+
+    private function convertToString(mixed $value): string
+    {
+        if (is_array($value)) {
+            $output = implode(
+                ' ',
+                array_map(
+                    fn($v) => is_scalar($v) ? (string)$v : '',
+                    array_values($value)
+                )
+            );
+        } elseif (is_object($value)) {
+            $output = method_exists($value, '__toString')
+                ? (string) $value
+                : '';
+        } else {
+            // fallback for other types (int, float, bool)
+            $output = (string) $value;
+        }
+
+        return $output;
     }
 
     public function getStart(): int


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/919

Enhancing "tolerance/gracefulness" for unsupported combinations, eg. trying to implode in case is an array of strings or convert objects with `__toString()` (usually would be returning the path) to a string.
Changing to more UTF8-safe multi-byte character functions