### PR TITLE
Fix error of reset editables

### DIFF
--- a/src/Controller/Admin/Document/DocumentControllerBase.php
+++ b/src/Controller/Admin/Document/DocumentControllerBase.php
@@ -180,7 +180,7 @@ abstract class DocumentControllerBase extends AdminAbstractController implements
                 $document->getEditables();
             } else {
                 // ensure no editables (e.g. from session, version, ...) are still referenced
-                $document->setEditables(null);
+                $document->setEditables([]);
             }
 
             if ($request->get('data')) {


### PR DESCRIPTION
**Bug:**

**Steps:**

(1) Create german page with editables.
(2) Create english page with different editables and content.
(3) Add german page as main content document to the english page and apply (and confirm).
(4) Editables and content of german page are shown on english page.
(5) Save and Publish english page.

**Expected Behaviour:**

English page shows content of german page (inheritance by main content document relation).

**Actual Behaviour:**

English page shows the old content before adding german page as main content document

This bug occurs only for pages which not implement the TargetingDocumentInterface.


**AI comments to this line of code:**

Ambiguous Intent: Passing null to setEditables() is not self-documenting. It's unclear if null means "clear all editables," "reset," or "remove references."

Type Safety: If setEditables() expects an array or iterable, passing null can lead to subtle bugs, especially if the internal implementation doesn't explicitly handle null.

Inconsistent Usage: Elsewhere in the code (e.g., changeMainDocumentAction), editables are cleared with an empty array: $doc->setEditables([]);. Mixing null and [] for the same effect is inconsistent.