### PR TITLE
Upgrade PHPSpreadsheet to version ^5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "cbschuld/browser.php": "^1.9.6",
     "endroid/qr-code": "^6.0.1",
     "nesbot/carbon": "^3.8.4",
-    "phpoffice/phpspreadsheet": "^2.2 || ^3.3",
+    "phpoffice/phpspreadsheet": "^5.1",
     "pimcore/pimcore": "^12.2",
     "symfony/webpack-encore-bundle": "^1.17 || ^2.0"
   },


### PR DESCRIPTION


The PHPSpreadsheet files used within the admin bundle are:
PhpOffice\PhpSpreadsheet\Reader\Csv
PhpOffice\PhpSpreadsheet\Writer\Exception
PhpOffice\PhpSpreadsheet\Writer\Xlsx

I've compared the diff between version 3.10.1 (as would be used with the ^3.3 set in the current composer.json) against the latest PHPSpreadsheet version 5.1.0, found here:
https://github.com/PHPOffice/PhpSpreadsheet/compare/3.10.1...5.1.0?diff=split

I did not see any changes that would affect the function calls used here:
https://github.com/pimcore/admin-ui-classic-bundle/blob/v2.1.3/src/Helper/GridHelperService.php#L949

PHPSpreadsheet's minimum PHP version is ^8.1 as set in their composer:
https://github.com/PHPOffice/PhpSpreadsheet/blob/5.1.0/composer.json#L69

Where the current admin bundle's PHP version is set to ~8.3.0 || ~8.4.0, which is compatible.

I have not tested this update, but I do not see why PHPSpreadsheet shouldn't be updated.