### PR TITLE
[Bug]: Not possible to edit many-to-one relation on objectbrick using object grid

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
+++ b/src/Controller/Admin/DataObject/DataObjectActionsTrait.php
@@ -255,7 +255,9 @@ trait DataObjectActionsTrait
                     $localizedFields = $brick->getLocalizedfields();
                     $localizedFields->setLocalizedValue($brickKey, $value);
                 } else {
-                    $brick->setObjectVar($brickKey, $value);
+                    $brickKeySetter = 'set' . ucfirst($brickKey);
+                    $brick->$brickKeySetter($value);
+                    $brick->markFieldDirty($brickKey);
                 }
             } else {
                 if ($languagePermissions) {


### PR DESCRIPTION
Resolves #999 

We had 2 problems here: 
- Field wasnt marked as dirty and therefore wasnt recognized as changed field when calculating the delta for relations.
- Using `setObjectVar` doesnt load lazy objects. Depending on whether lazy objects have been loaded already, the grid would save the correct or wrong value. Use the correct setter instead.