### PR TITLE
Use array_replace to keep numeric and non-numeric array keys

### DIFF
--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -155,7 +155,7 @@ class MiscController extends AdminAbstractController
         // languages
         $languages = \Pimcore\Tool::getValidLanguages();
         $adminLanguages = \Pimcore\Tool\Admin::getLanguages();
-        $languages = array_unique(array_merge($languages, $adminLanguages));
+        $languages = array_unique(array_replace($languages, $adminLanguages));
 
         $response = $this->render('@PimcoreAdmin/admin/misc/admin_css.html.twig', [
             'customviews' => $cvData,


### PR DESCRIPTION
This is a fix for the issue described here: https://github.com/pimcore/admin-ui-classic-bundle/issues/1002