### PR TITLE
[Bug]: Add fixed table layout to outer container

### DIFF
--- a/public/extjs/css/PimcoreApp-all_1.css
+++ b/public/extjs/css/PimcoreApp-all_1.css
@@ -1134,6 +1134,7 @@ td.x-frame-br {
 
 .x-autocontainer-outerCt {
     display: table;
+    table-layout: fixed;
 }
 
 .x-mobile-safari .x-autocontainer-outerCt {


### PR DESCRIPTION
In the demo, if you open a News Data Object (or any with a Field Collection and a Wysiwyg in it), expand the window (or just collapse the side bar like the alternative element tree) and resize back or smaller, it would display a scrollbar.

Not entirely sure about the fix, but seems helping preventing on growing more than the 100% allowed width.

<img width="1700" height="681" alt="image" src="https://github.com/user-attachments/assets/da9c7ccb-4511-45fa-a8bd-de0fc9b5f1c0" />
