### PR TITLE
Allow line breaks in Areabrick dialog descriptions

### DIFF
--- a/public/js/pimcore/document/editables/area_abstract.js
+++ b/public/js/pimcore/document/editables/area_abstract.js
@@ -109,7 +109,7 @@ pimcore.document.area_abstract = Class.create(pimcore.document.editable, {
 
                 if (config['description']) {
                     var descriptionHTML = '<div style="font-size: 14px; margin-bottom: 10px;">'
-                        + config['description']
+                        + nl2br(config['description'])
                         + '</div>';
 
                     templateHTML = descriptionHTML + templateHTML;


### PR DESCRIPTION
We are currently upgrading our project to Pimcore 11 and would like to use the new description in the Areabrick dialogs. Unfortunately, only plain text is displayed, even line breaks are ignored. Can we please keep the line breaks?