### PR TITLE
Use Attribute instead of Annotation to define route. Add pimcore_admin_element_islocked

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -766,8 +766,7 @@ pimcore.helpers.lockManager = function (cid, ctype, csubtype, data) {
                     }
                 });
             } else {
-                pimcore.helpers.closeElement(lock[0], lock[1]);
-                pimcore.helpers.openElement(lock[0], lock[1], lock[2]);
+                pimcore.layout.refresh();
             }
         }.bind(this, arguments));
 };

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -361,6 +361,21 @@ pimcore.helpers.closeElement = function (id, type) {
     }
 };
 
+pimcore.helpers.refreshElement = function () {
+    var tabpanel = Ext.getCmp("pimcore_panel_tabs");
+    var activeTab = tabpanel.getActiveTab();
+
+    if (activeTab) {
+        // for document
+        if (activeTab.initialConfig.document) {
+            activeTab.initialConfig.document.reload();
+        }
+        else if (activeTab.initialConfig.object) {
+            activeTab.initialConfig.object.reload();
+        }
+    }
+};
+
 pimcore.helpers.getElementTypeByObject = function (object) {
     var type = null;
     if (object instanceof pimcore.document.document) {
@@ -723,20 +738,7 @@ pimcore.helpers.handleF5 = function (keyCode, e) {
 
     e.stopEvent();
 
-    var tabpanel = Ext.getCmp("pimcore_panel_tabs");
-    var activeTab = tabpanel.getActiveTab();
-
-    if (activeTab) {
-        // for document
-        if (activeTab.initialConfig.document) {
-            activeTab.initialConfig.document.reload();
-            return;
-        }
-        else if (activeTab.initialConfig.object) {
-            activeTab.initialConfig.object.reload();
-            return;
-        }
-    }
+    pimcore.helpers.refreshElement();
 
     var date = new Date();
     location.href = Routing.generate('pimcore_admin_index', {'_dc': date.getTime()});
@@ -766,7 +768,7 @@ pimcore.helpers.lockManager = function (cid, ctype, csubtype, data) {
                     }
                 });
             } else {
-                pimcore.layout.refresh();
+                pimcore.helpers.refreshElement();
             }
         }.bind(this, arguments));
 };

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -376,6 +376,8 @@ pimcore.helpers.refreshElement = function () {
             return true;
         }
     }
+    
+    return false;
 };
 
 pimcore.helpers.getElementTypeByObject = function (object) {

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -369,9 +369,11 @@ pimcore.helpers.refreshElement = function () {
         // for document
         if (activeTab.initialConfig.document) {
             activeTab.initialConfig.document.reload();
+            return true;
         }
         else if (activeTab.initialConfig.object) {
             activeTab.initialConfig.object.reload();
+            return true;
         }
     }
 };
@@ -738,7 +740,9 @@ pimcore.helpers.handleF5 = function (keyCode, e) {
 
     e.stopEvent();
 
-    pimcore.helpers.refreshElement();
+    if (pimcore.helpers.refreshElement()){
+        return;
+    }
 
     var date = new Date();
     location.href = Routing.generate('pimcore_admin_index', {'_dc': date.getTime()});

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -40,7 +40,7 @@ class ElementController extends AdminAbstractController
 {
     use ElementEditLockHelperTrait;
 
-    #[Route('/element/lock-element', name: 'pimcore_admin_element_lockelement', methods: ['PUT'])]
+    #[Route('/element/lock-element', name: 'pimcore_admin_element_islocked', methods: ['GET'])]
     public function isLockedAction(Request $request): JsonResponse
     {
         $isLocked = Element\Editlock::isLocked(
@@ -56,9 +56,7 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true, 'editLock' => null]);
     }
 
-    /**
-     * @Route("/element/lock-element", name="pimcore_admin_element_lockelement", methods={"PUT"})
-     */
+    #[Route('/element/lock-element', name: 'pimcore_admin_element_lockelement', methods:['PUT'])]
     public function lockElementAction(Request $request): Response
     {
         Element\Editlock::lock($request->request->getInt('id'), $request->request->get('type'), $request->getSession()->getId());


### PR DESCRIPTION
Pimcore 12.2.1 with admin-ui-classic-bundle 2.2.0 fails to check if an element is locked because the route `pimcore_admin_element_islocked` was never defined in ElementController:

<img width="601" height="91" alt="image" src="https://github.com/user-attachments/assets/61b22be2-1367-418f-bc70-9262f678fcc0" />



As Symfony Annotation is deprecated the route definition for `lockElementAction` does not work


Related to https://github.com/pimcore/admin-ui-classic-bundle/pull/724