### PR TITLE
Bugfix: Asset Numeric IN Filtering

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -840,6 +840,16 @@ class GridHelperService
                         $operator = '=';
                     } elseif ($filterOperator == 'in') {
                         $operator = 'IN';
+                        
+                        $filterValue = $filter['value'] ?? '';
+                        if (!is_array($filterValue)) {
+                            $matches = preg_split('/[^0-9\.]+/', $filterValue, -1, PREG_SPLIT_NO_EMPTY);
+                            if (is_array($matches) && count($matches) > 0) {
+                                $filter['value'] = array_unique(array_map(floatval(...), $matches));
+                            } else {
+                                continue;
+                            }
+                        }
                     }
                 } elseif ($filterType == 'date') {
                     $filter['value'] = strtotime($filter['value']);
@@ -869,17 +879,8 @@ class GridHelperService
                         continue;
                     }
 
-                    if (!is_array($value)) {
-                        $matches = preg_split('/[^0-9\.]+/', $value, -1, PREG_SPLIT_NO_EMPTY);
-                        if (is_array($matches) && count($matches) > 0) {
-                            $value = array_unique(array_map(floatval(...), $matches));
-                        } else {
-                            continue;
-                        }
-                    }
-
                     $quoted = array_map(function ($val) use ($db) {
-                        return $db->quote($val);
+                        return $db->quote((string)$val);
                     }, $value);
                     $value = '(' . implode(',', $quoted) . ')';
                 } elseif ($operator == 'BETWEEN') {

--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -838,6 +838,8 @@ class GridHelperService
                         $operator = '>';
                     } elseif ($filterOperator == 'eq') {
                         $operator = '=';
+                    } elseif ($filterOperator == 'in') {
+                        $operator = 'IN';
                     }
                 } elseif ($filterType == 'date') {
                     $filter['value'] = strtotime($filter['value']);
@@ -866,6 +868,16 @@ class GridHelperService
                     if (empty($value)) {
                         continue;
                     }
+
+                    if (!is_array($value)) {
+                        $matches = preg_split('/[^0-9\.]+/', $value, -1, PREG_SPLIT_NO_EMPTY);
+                        if (is_array($matches) && count($matches) > 0) {
+                            $value = array_unique(array_map(floatval(...), $matches));
+                        } else {
+                            continue;
+                        }
+                    }
+
                     $quoted = array_map(function ($val) use ($db) {
                         return $db->quote($val);
                     }, $value);


### PR DESCRIPTION
When filtering assets, specifically numeric fields like `id`, the values were not being applied with the IN filter in the query. This makes it so users could not filter by multiple asset ids like they could with data objects.

When filtering via numeric values, it now checks if its a `in` filter operator, then attempts to check to see if the value is already an array. If not, it uses similar logic to data object numeric parsing to split on all non-numeric values to get an array. Also added a cast on the `db->quote` value to make sure all values are strings.