### PR TITLE
Asset folder preview: do not render preview images on-the-fly if they…

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -1213,12 +1213,17 @@ class AssetController extends ElementControllerBase implements KernelControllerE
 
         if ($request->get('treepreview')) {
             $thumbnailConfig = Asset\Image\Thumbnail\Config::getPreviewConfig();
-            if ($request->get('origin') === 'treeNode' && !$image->getThumbnail($thumbnailConfig)->exists()) {
-                \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
-                    new AssetPreviewImageMessage($image->getId())
-                );
+            $exists = $image->getThumbnail($thumbnailConfig)->exists();
+            if(!$exists) {
+                if ($request->get('origin') === 'treeNode') {
+                    \Pimcore::getContainer()->get('messenger.bus.pimcore-core')->dispatch(
+                        new AssetPreviewImageMessage($image->getId())
+                    );
 
-                throw $this->createNotFoundException(sprintf('Tree preview thumbnail not available for asset %s', $image->getId()));
+                    throw $this->createNotFoundException(sprintf('Tree preview thumbnail not available for asset %s', $image->getId()));
+                } elseif($request->get('origin') === 'folderPreview') {
+                    return new BinaryFileResponse(PIMCORE_WEB_ROOT . '/bundles/pimcoreadmin/img/video-loading.gif');
+                }
             }
         }
 
@@ -1744,7 +1749,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
                     'type' => $asset->getType(),
                     'filename' => $asset->getFilename(),
                     'filenameDisplay' => htmlspecialchars($filenameDisplay ?? ''),
-                    'url' => $this->elementService->getThumbnailUrl($asset),
+                    'url' => $this->elementService->getThumbnailUrl($asset, ['origin' => 'folderPreview']),
                     'idPath' => $data['idPath'] = Element\Service::getIdPath($asset),
                 ];
             }


### PR DESCRIPTION
… do not exist yet - as this could potentially break the entire hosting infrastructure when dealing with huge image files (>500MB)

This PR shows a placeholder instead: 

<img width="542" height="422" alt="image" src="https://github.com/user-attachments/assets/a21f8f2f-5432-4e27-b715-c79dd7b71130" />
