### PR TITLE
Bugfix: Update regex, and add new translation with regex params.

### DIFF
--- a/public/js/pimcore/object/objectbrick.js
+++ b/public/js/pimcore/object/objectbrick.js
@@ -182,13 +182,12 @@ pimcore.object.objectbrick = Class.create(pimcore.object.fieldcollection, {
     },
 
     addField: function () {
-        Ext.MessageBox.prompt(' ', t('enter_the_name_of_the_new_item'),
+        Ext.MessageBox.prompt(' ', t('enter_the_name_of_the_new_object_brick'),
                                                     this.addFieldComplete.bind(this), null, null, "");
     },
 
     addFieldComplete: function (button, value, object) {
-
-        var isValidName = /^[a-zA-Z][a-zA-Z0-9]*$/;
+        const isValidName = /^[a-zA-Z]\w*$/;
 
         if (button == "ok" && value.length > 2 && isValidName.test(value) && !in_arrayi(value, this.forbiddenNames)) {
             Ext.Ajax.request({

--- a/translations/admin.en.yaml
+++ b/translations/admin.en.yaml
@@ -1028,3 +1028,4 @@ invalid_option: 'Invalid Option field [ {field} ]: Please choose a valid option 
 respect_timezone: 'Respect timezone'
 delete_quantity_value_unit_confirmation: 'Deleting this unit will impact all related elements that reference it. Are you sure you want to proceed?'
 no_preview_available: 'Sorry, no preview available'
+enter_the_name_of_the_new_object_brick: 'Enter the name of the new brick (a-z, A-Z, 0-9, must start with letter)'


### PR DESCRIPTION
The object brick regex does not match the regex that is used in the backend. The object brick checks to see if its a forbidden name(https://github.com/pimcore/pimcore/blob/12.2/models/DataObject/Objectbrick/Definition.php#L514), which the object brick class extends field collection which points to: https://github.com/pimcore/pimcore/blob/12.x/models/DataObject/Fieldcollection/Definition.php#L262-L273.

As well, added a more detailed version of the translation which specifies the requirements when adding a new brick.