### PR TITLE
BugFix: Fix openTabs limiting logic to always keep only the last 10 items

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -961,9 +961,7 @@ pimcore.helpers.openMemorizedTabs = function () {
     var openTabs = pimcore.helpers.getOpenTab();
 
     // limit to the latest 10
-    openTabs.reverse();
-    openTabs.splice(10, 1000);
-    openTabs.reverse();
+    openTabs = openTabs.slice(-10);
 
     var openedTabs = [];
 


### PR DESCRIPTION
Previously, the logic for limiting `openTabs` relied on `reverse() + splice(10, 1000) + reverse()`.  
This worked only if the total number of open tabs never exceeded 1010.  
If a user accumulated more than 1000 tabs (e.g. 1140 over a year of usage), the result would incorrectly keep 140 tabs instead of just the last 10.

This PR replaces that logic with a simpler and correct approach:
```js
openTabs = openTabs.slice(-10);
