### PR TITLE
[Bug]: Firefox content security policy warning in console

### DIFF
--- a/src/Security/ContentSecurityPolicyHandler.php
+++ b/src/Security/ContentSecurityPolicyHandler.php
@@ -82,7 +82,7 @@ class ContentSecurityPolicyHandler implements LoggerAwareInterface
             self::DEFAULT_OPT => self::SELF,
             self::IMG_OPT => '* data: blob:',
             self::MEDIA_OPT => self::SELF . ' data:',
-            self::SCRIPT_OPT => self::SELF . " 'nonce-" . $this->getNonce() . "' 'unsafe-inline' 'unsafe-eval'",
+            self::SCRIPT_OPT => self::SELF . " 'nonce-" . $this->getNonce() . "' 'unsafe-eval'",
             self::STYLE_OPT => self::SELF . " 'unsafe-inline'",
             self::FRAME_OPT => self::SELF . ' data:',
             self::FRAME_ANCHESTORS => self::SELF,


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/988

<img width="824" height="48" alt="image" src="https://github.com/user-attachments/assets/e979421c-7bb7-4510-849e-6b425045a9f4" />

NB: in dev mode, the WebProfiler still forcefully adds it, see https://github.com/pimcore/admin-ui-classic-bundle/issues/988#issuecomment-3400498590