### PR TITLE
[IMPROVEMENT] Classification store: add title to key/group search popup

### DIFF
--- a/public/js/pimcore/object/classificationstore/keySelectionWindow.js
+++ b/public/js/pimcore/object/classificationstore/keySelectionWindow.js
@@ -369,6 +369,7 @@ pimcore.object.classificationstore.keySelectionWindow = Class.create({
         var postFix;
         var route;
         var nameWidth = 200;
+        var titleWidth = 200;
         var descWidth = 590;
 
         if (this.config.isCollectionSearch) {
@@ -444,6 +445,14 @@ pimcore.object.classificationstore.keySelectionWindow = Class.create({
                 width: nameWidth,
                 sortable: true,
                 dataIndex: 'name',
+                renderer: pimcore.helpers.grid.getTranslationColumnRenderer.bind(this)
+            });
+
+            gridColumns.push({
+                text: t("title"),
+                width: titleWidth,
+                sortable: true,
+                dataIndex: 'title',
                 renderer: pimcore.helpers.grid.getTranslationColumnRenderer.bind(this)
             });
 


### PR DESCRIPTION
Added title column to key/group search

<img width="960" height="406" alt="Screenshot_79" src="https://github.com/user-attachments/assets/60ff562b-b635-444a-821d-f054686933f1" />

