### PR TITLE
[Bug, EC] PEES-773: Fix Grid Export does not respect the "Type to show"

### DIFF
--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -954,6 +954,10 @@ pimcore.element.helpers.gridColumnConfig = {
             params["only_direct_children"] = this.checkboxOnlyDirectChildren.getValue();
         }
 
+        if (typeof this.selectObjectType !=='undefined') {
+            params['filter_by_object_type'] = this.selectObjectType.getValue();
+        }
+        
         //only unreferenced filter
         if (this.checkboxOnlyUnreferenced) {
             params["only_unreferenced"] = this.checkboxOnlyUnreferenced.getValue();


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/260

Before PR, the option whether should display all objects, only objects or only variants was not passed, exporting all regardless.