### PR TITLE
[Bug]: Fix quantity value IN search

### DIFF
--- a/src/Helper/GridHelperService.php
+++ b/src/Helper/GridHelperService.php
@@ -239,7 +239,13 @@ class GridHelperService
                         $operator = 'in';
                         $matches = preg_split('/[^0-9\.]+/', $filter['value'][0][0] ?? [], -1, PREG_SPLIT_NO_EMPTY);
                         if (is_array($matches) && count($matches) > 0) {
-                            $filter['value'][0][0] = implode(',', array_unique(array_map(floatval(...), $matches)));
+                            $uniqueIds = array_unique(array_map(floatval(...), $matches));
+                            if (count($uniqueIds) > 1) {
+                                $filter['value'][0][0] = implode(',', $uniqueIds);
+                            } else {
+                                $filter['value'][0][0] = $uniqueIds[0];
+                                $operator = '=';
+                            }
                         } else {
                             continue;
                         }


### PR DESCRIPTION
When using this filter
<img width="526" height="306" alt="image" src="https://github.com/user-attachments/assets/517e58be-43f7-4726-8bb0-a13bd1b714f4" /> 
on a quantity value (or RGB color dataype), it is false positively seen as array of ids entering in this block, due to the nature of `array(value,unit)` and breaking as it would try to compare with an `IN` operator on a single value.

This change generally makes also sure if there's just one element in the list to opt for equal operator instead of `IN`