### PR TITLE
Backport and fix diffVersionAction: added DocumentRendererInterface in action params.

### DIFF
--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -1014,8 +1014,13 @@ class DocumentController extends ElementControllerBase implements KernelControll
     /**
      * @Route("/diff-versions/from/{from}/to/{to}", name="pimcore_admin_document_document_diffversions", requirements={"from": "\d+", "to": "\d+"}, methods={"GET"})
      */
-    public function diffVersionsAction(Request $request, int $from, int $to, DocumentRendererInterface $documentRenderer, RouterInterface $router): Response
-    {
+    public function diffVersionsAction(
+        Request $request,
+        int $from,
+        int $to,
+        DocumentRendererInterface $documentRenderer,
+        RouterInterface $router
+    ): Response {
         // return with error if prerequisites do not match
         if (!HtmlToImage::isSupported() || !class_exists('Imagick')) {
             return $this->render('@PimcoreAdmin/admin/document/document/diff_versions_unsupported.html.twig');

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -33,7 +33,7 @@ use Pimcore\Cache\RuntimeCache;
 use Pimcore\Config;
 use Pimcore\Controller\KernelControllerEventInterface;
 use Pimcore\Db;
-use Pimcore\Document\Renderer\DocumentRenderer;
+use Pimcore\Document\Renderer\DocumentRendererInterface;
 use Pimcore\Event\Traits\RecursionBlockingEventDispatchHelperTrait;
 use Pimcore\Image\HtmlToImage;
 use Pimcore\Logger;
@@ -1014,7 +1014,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
     /**
      * @Route("/diff-versions/from/{from}/to/{to}", name="pimcore_admin_document_document_diffversions", requirements={"from": "\d+", "to": "\d+"}, methods={"GET"})
      */
-    public function diffVersionsAction(Request $request, int $from, int $to, DocumentRenderer $documentRenderer, RouterInterface $router): Response
+    public function diffVersionsAction(Request $request, int $from, int $to, DocumentRendererInterface $documentRenderer, RouterInterface $router): Response
     {
         // return with error if prerequisites do not match
         if (!HtmlToImage::isSupported() || !class_exists('Imagick')) {


### PR DESCRIPTION
In general, it's PR backport #897.

If added custom DocumentRendererInterface implementation - during diff action fails with error:

`Pimcore\Bundle\AdminBundle\Controller\Admin\Document\DocumentController::diffVersionsAction(): Argument #4 ($documentRenderer) must be of type Pimcore\Document\Renderer\DocumentRenderer, App\Model\Document\Renderer\DocumentRenderer given, called in /var/www/pimcore.local/www/vendor/symfony/http-kernel/HttpKernel.php on line 181`

Please review,