### PR TITLE
[Bug, EC] PEES-824: Bug: Default Value When Using Field Collections

### DIFF
--- a/public/js/pimcore/object/tags/fieldcollections.js
+++ b/public/js/pimcore/object/tags/fieldcollections.js
@@ -468,7 +468,7 @@ pimcore.object.tags.fieldcollections = Class.create(pimcore.object.tags.abstract
                 containerName: this.fieldConfig.name,
                 containerKey: type,
                 index: index,
-                applyDefaults: true,
+                applyDefaults: !ignoreChange,
             },
             false,
             false,


### PR DESCRIPTION
Resolves https://pimcore.atlassian.net/browse/PEES-824, https://github.com/pimcore/service-operations/issues/285


If previously default value were not set, do not applyDefaults on them on load/init