### PR TITLE
[Grid] Bugfix: Save relation filter in grid config

### DIFF
--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -461,6 +461,12 @@ pimcore.element.helpers.gridColumnConfig = {
                         handler: function () {
                             this.filterByRelationWindow.close();
                             this.grid.store.filters.removeByKey("x-gridfilter-"+fieldInfo.dataIndex);
+
+                            Ext.each(this.grid.getColumns(), function (column) {
+                                if (column.dataIndex === fieldInfo.dataIndex) {
+                                    column.removeClass('x-grid-filters-filtered-column');
+                                }
+                            });
                         }.bind(this)
                     },
                     {
@@ -484,8 +490,8 @@ pimcore.element.helpers.gridColumnConfig = {
                                     );
 
                                     Ext.each(this.grid.getColumns(), function(column) {
-                                        if(column.getDataIndex() === fieldInfo.dataIndex) {
-                                            column.setText('<i>'+column.text+'</i>');
+                                        if(column.dataIndex === fieldInfo.dataIndex) {
+                                            column.addCls('x-grid-filters-filtered-column');
                                         }
                                     });
 

--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -482,6 +482,13 @@ pimcore.element.helpers.gridColumnConfig = {
                                     this.grid.filters.getStore().addFilter(
                                         fieldInfo.getRelationFilter(fieldInfo.dataIndex, editor)
                                     );
+
+                                    Ext.each(this.grid.getColumns(), function(column) {
+                                        if(column.getDataIndex() === fieldInfo.dataIndex) {
+                                            column.setText('<i>'+column.text+'</i>');
+                                        }
+                                    });
+
                                     this.filterByRelationWindow.close();
                                 } catch (e) {
                                     console.error("Error applying relation filter:", e);

--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -294,13 +294,11 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                             col.filter.value = filterValue;
                         }
                     }
-                } else {
-                    if (this.filter) {
-                        const filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
+                } else if (this.filter) {
+                    const filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
 
-                        if(filterValue) {
-                            col.cls = 'x-grid-filters-filtered-column';
-                        }
+                    if(filterValue) {
+                        col.cls = 'x-grid-filters-filtered-column';
                     }
                 }
             }

--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -293,8 +293,14 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
 
                             col.filter.value = filterValue;
                         }
-                    } else {
-                        break;
+                    }
+                } else {
+                    if (this.filter) {
+                        const filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
+
+                        if(filterValue) {
+                            col.text = '<i>'+col.text+'</i>';
+                        }
                     }
                 }
             }
@@ -352,10 +358,11 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
 
         if (this.filter) {
             this.filter.forEach(filt => {
-                this.filterUpdateFunction(this.grid, this.toolbarFilterInfo, this.clearFilterButton);
+                this.store.setFilters(new Ext.util.Filter(filt));
             });
-        }
 
+            this.filterUpdateFunction(this.grid, this.toolbarFilterInfo, this.clearFilterButton);
+        }
 
         this.grid.on("columnmove", function () {
             this.saveColumnConfigButton.show()

--- a/public/js/pimcore/object/folder/search.js
+++ b/public/js/pimcore/object/folder/search.js
@@ -299,7 +299,7 @@ pimcore.object.search = Class.create(pimcore.object.helpers.gridTabAbstract, {
                         const filterValue = this.filter.find(filter => filter.property === col.dataIndex)?.value || null;
 
                         if(filterValue) {
-                            col.text = '<i>'+col.text+'</i>';
+                            col.cls = 'x-grid-filters-filtered-column';
                         }
                     }
                 }

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -88,7 +88,7 @@ class MiscController extends AdminAbstractController
             $fallbackLanguages[] = \Locale::getPrimaryLanguage($language);
         }
         if ($language != 'en') {
-            $fallbackLanguages[] = \Locale::getPrimaryLanguage(Tool::getDefaultLanguage());;
+            $fallbackLanguages[] = \Locale::getPrimaryLanguage(Tool::getDefaultLanguage());
             // add en as a fallback
             $fallbackLanguages[] = 'en';
         }

--- a/src/Controller/Admin/MiscController.php
+++ b/src/Controller/Admin/MiscController.php
@@ -88,6 +88,7 @@ class MiscController extends AdminAbstractController
             $fallbackLanguages[] = \Locale::getPrimaryLanguage($language);
         }
         if ($language != 'en') {
+            $fallbackLanguages[] = \Locale::getPrimaryLanguage(Tool::getDefaultLanguage());;
             // add en as a fallback
             $fallbackLanguages[] = 'en';
         }

--- a/src/Model/GridConfig.php
+++ b/src/Model/GridConfig.php
@@ -212,7 +212,7 @@ class GridConfig extends AbstractModel
         return $this->saveFilters;
     }
 
-    public function setSaveFilters(bool $saveFilters): void
+    public function setSaveFilters(?bool $saveFilters): void
     {
         $this->saveFilters = $saveFilters;
     }


### PR DESCRIPTION
After #963, saving relation filters in a grid config does not work anymore. This PR fixes this (while keeping the enhancements of #963).

Furthermore, this PR adds the functionality that filtered relation columns also get displayed in italic (like "normal" filtered columns).