### PR TITLE
[Bugfix] Display search button in `pimcore.helpers.editmode.openLinkEditPanel` only when search is available

### DIFF
--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -2114,28 +2114,7 @@ pimcore.helpers.editmode.openLinkEditPanel = function (data, callback, config) {
                             internalTypeField,
                             linkTypeField,
                             textField,
-                            {
-                                xtype: "fieldcontainer",
-                                layout: 'hbox',
-                                border: false,
-                                items: [pathField, {
-                                    xtype: "button",
-                                    iconCls: "pimcore_icon_search",
-                                    style: "margin-left: 5px",
-                                    handler: function () {
-                                        pimcore.helpers.itemselector(false, function (item) {
-                                            if (item) {
-                                                internalTypeField.setValue(item.type);
-                                                linkTypeField.setValue('internal');
-                                                pathField.setValue(item.fullpath);
-                                                return true;
-                                            }
-                                        }, {
-                                            type: Ext.Array.intersect(["asset", "document", "object"], allowedTypes)
-                                        });
-                                    }
-                                }]
-                            },
+                            fieldContainer,
                             propertiesFieldSet
                         ]
                     },


### PR DESCRIPTION
The button has been defined twice: once conditionally and once inline. 
The inline definition is removed in favor of the conditional one.
Otherwise, the button is show even is no search implementation is available but does nothing on click.

This was an oversight in pimcore/pimcore#13173.