### PR TITLE
[Bug, EC] PEES-796: Fix relations dialog out of scope

### DIFF
--- a/public/js/pimcore/element/helpers/gridCellEditor.js
+++ b/public/js/pimcore/element/helpers/gridCellEditor.js
@@ -91,9 +91,20 @@ Ext.define('pimcore.element.helpers.gridCellEditor', {
             bodyStyle: "padding: 10px;"
         });
         let width = 700;
-        if (tagType === 'manyToManyObjectRelation' && fieldInfo.layout.width && fieldInfo.layout.width !== '100%') {
+
+        if (tagType === 'manyToOneRelation') {
+            width = sumWidths(
+                formPanel.config.items[0].items.items[0].width,
+                formPanel.config.items[0].labelWidth + 140
+            );
+        } else if (
+            tagType.endsWith('Relation') &&
+            fieldInfo.layout?.width &&
+            fieldInfo.layout?.width !== '100%'
+        ) {
             width = sumWidths(fieldInfo.layout.width, 25);
         }
+
         this.editWin = new Ext.Window({
             modal: false,
             title: t("edit") + " " + fieldInfo.layout.title,

--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -418,8 +418,6 @@ pimcore.element.helpers.gridColumnConfig = {
                 containerType: "filterByRelationWindow"
             });
 
-            editor.fieldConfig.width = 300;
-
             const activeFilter = this.grid.getStore().getFilters().items;
 
             for (let filter of activeFilter) {
@@ -478,11 +476,17 @@ pimcore.element.helpers.gridColumnConfig = {
                 ]
             });
 
-            const title = t("filter_by_relation_field") + " " + fieldInfo.text;
-            let width = 700;
-            if (tagType === 'manyToManyObjectRelation' && fieldInfo.layout.layout.width && fieldInfo.layout.layout.width !== '100%') {
+        const title = t("filter_by_relation_field") + " " + fieldInfo.text;
+        let width = 700;
+
+        if (fieldInfo.layout.layout.width && fieldInfo.layout.layout.width !== '100%') {
+            if (tagType === 'manyToManyObjectRelation') {
                 width = sumWidths(fieldInfo.layout.layout.width, 25);
+            } else if (tagType === 'manyToOneRelation') {
+                width = sumWidths(fieldInfo.layout.layout.width, formPanel.config.items[0].labelWidth + 140);
             }
+        }
+
             this.filterByRelationWindow = new Ext.Window({
                 autoScroll: true,
                 modal: false,
@@ -634,7 +638,7 @@ pimcore.element.helpers.gridColumnConfig = {
             title: title,
             items: [formPanel],
             bodyStyle: "background: #fff;",
-            width: 700,
+            width: 1000,
             maxHeight: 600
         });
         this.batchWin.show();
@@ -986,7 +990,7 @@ pimcore.element.helpers.gridColumnConfig = {
         if (typeof this.selectObjectType !=='undefined') {
             params['filter_by_object_type'] = this.selectObjectType.getValue();
         }
-        
+
         //only unreferenced filter
         if (this.checkboxOnlyUnreferenced) {
             params["only_unreferenced"] = this.checkboxOnlyUnreferenced.getValue();

--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -476,17 +476,21 @@ pimcore.element.helpers.gridColumnConfig = {
                 ]
             });
 
-        const title = t("filter_by_relation_field") + " " + fieldInfo.text;
-        let width = 700;
-
-        // for asset metadata the layout is not set
-        if (fieldInfo.layout?.layout.width && fieldInfo.layout.layout.width !== '100%') {
-            if (tagType === 'manyToManyObjectRelation') {
+            const title = t("filter_by_relation_field") + " " + fieldInfo.text;
+            let width = 700;
+    
+            if (tagType === 'manyToOneRelation') {
+                width = sumWidths(
+                    formPanel.config.items[0].items.items[0].width,
+                    formPanel.config.items[0].labelWidth + 140
+                );
+            } else if (
+                tagType === 'manyToManyObjectRelation' &&
+                fieldInfo.layout?.layout.width &&
+                fieldInfo.layout?.layout.width !== '100%'
+            ) {
                 width = sumWidths(fieldInfo.layout.layout.width, 25);
-            } else if (tagType === 'manyToOneRelation') {
-                width = sumWidths(fieldInfo.layout.layout.width, formPanel.config.items[0].labelWidth + 140);
             }
-        }
 
             this.filterByRelationWindow = new Ext.Window({
                 autoScroll: true,

--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -479,7 +479,8 @@ pimcore.element.helpers.gridColumnConfig = {
         const title = t("filter_by_relation_field") + " " + fieldInfo.text;
         let width = 700;
 
-        if (fieldInfo.layout.layout.width && fieldInfo.layout.layout.width !== '100%') {
+        // for asset metadata the layout is not set
+        if (fieldInfo.layout?.layout.width && fieldInfo.layout.layout.width !== '100%') {
             if (tagType === 'manyToManyObjectRelation') {
                 width = sumWidths(fieldInfo.layout.layout.width, 25);
             } else if (tagType === 'manyToOneRelation') {
@@ -638,7 +639,7 @@ pimcore.element.helpers.gridColumnConfig = {
             title: title,
             items: [formPanel],
             bodyStyle: "background: #fff;",
-            width: 1000,
+            width: 700,
             maxHeight: 600
         });
         this.batchWin.show();


### PR DESCRIPTION
Resolves https://pimcore.atlassian.net/browse/PEES-796, https://github.com/pimcore/service-operations/issues/262

Kind of follow up https://github.com/pimcore/admin-ui-classic-bundle/pull/888#issuecomment-2909559203, that change in the PR was too general/broad and broke all the sizing. It worked just for many to one because it matches this fallback https://github.com/pimcore/admin-ui-classic-bundle/blob/1a6a1aff055f20e475189b98cbe5b180e93bf32c/public/js/pimcore/object/tags/manyToOneRelation.js#L160

Notes: not the cleanest code but it's for sunsetting admin ui and extJS seems really *ugh* to manage sizing, feels like fixing "bad" legacy code with slight less worse one 😅 