### PR TITLE
Update .gitignore to removing templates folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ Thumbs.db
 /bin
 /config
 /kernel
-/templates
 /var
 
 # PHP-CS-Fixer


### PR DESCRIPTION
Remove templates directory from .gitignore as there are files in there that should be tracked: https://github.com/pimcore/admin-ui-classic-bundle/tree/2.x/templates