### PR TITLE
[Bug]: Batch Edit affects parent objects even when grid is filtered to ‘just variant objects

### DIFF
--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -1014,6 +1014,11 @@ pimcore.element.helpers.gridColumnConfig = {
             params["only_unreferenced"] = this.checkboxOnlyUnreferenced.getValue();
         }
 
+        //filter by object and/or variant
+        if (this.selectObjectType) {
+            params['filter_by_object_type'] = this.selectObjectType.getValue();
+        }
+        
         var fields = this.getGridConfig().columns;
         var fieldKeys = Object.keys(fields);
         params["fields[]"] = fieldKeys;


### PR DESCRIPTION
Resolves https://github.com/pimcore/pimcore/issues/18832