### PR TITLE
[Bug]: Prevent self-deletion of admin users in UserController

### DIFF
--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -223,7 +223,8 @@ class UserController extends AdminAbstractController implements KernelController
     #[Route('/user/delete', name: 'pimcore_admin_user_delete', methods: ['DELETE'])]
     public function deleteAction(Request $request): JsonResponse
     {
-        $user = User\AbstractUser::getById((int)$request->get('id'));
+        $userId = (int)$request->get('id');
+        $user = User\AbstractUser::getById($userId);
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission
@@ -231,7 +232,7 @@ class UserController extends AdminAbstractController implements KernelController
         if (
             ($user instanceof User\Folder && !$this->getAdminUser()->isAdmin()) ||
             ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin()) ||
-            ($this->getAdminUser() === $user)
+            ($this->getAdminUser()->getId() === $userId)
         ) {
             throw new \Exception('You are not allowed to delete this user');
         } else {

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -227,7 +227,7 @@ class UserController extends AdminAbstractController implements KernelController
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission
-        // additionally, added guard to prevent from self deleting like in frontend
+        // additionally, added a guard to prevent users from deleting themselves, like in the frontend
         if (
             ($user instanceof User\Folder && !$this->getAdminUser()->isAdmin()) ||
             ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin()) ||

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -227,7 +227,12 @@ class UserController extends AdminAbstractController implements KernelController
 
         // only admins are allowed to delete admins and folders
         // because a folder might contain an admin user, so it is simply not allowed for users with the "users" permission
-        if (($user instanceof User\Folder && !$this->getAdminUser()->isAdmin()) || ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin())) {
+        // additionally, added guard to prevent from self deleting like in frontend
+        if (
+            ($user instanceof User\Folder && !$this->getAdminUser()->isAdmin()) ||
+            ($user instanceof User && $user->isAdmin() && !$this->getAdminUser()->isAdmin()) ||
+            ($this->getAdminUser() === $user)
+        ) {
             throw new \Exception('You are not allowed to delete this user');
         } else {
             if ($user instanceof User\Role\Folder) {


### PR DESCRIPTION
Added a guard clause to prevent self-deletion of admin users. 
Only relevant if the request was sent directly to the API, not through the UI (it's disabled in there)

Not a strict security issue, just a design/logic flaw 
Resolves https://github.com/pimcore/pimcore/security/advisories/GHSA-x4vx-7h2p-c6f7