### PR TITLE
Fix SimpleBackendSearch Error 414 - Request-URI Too Large

### DIFF
--- a/public/js/pimcore/element/selector/searchFacade.js
+++ b/public/js/pimcore/element/selector/searchFacade.js
@@ -49,6 +49,16 @@ pimcore.element.selector.searchFacade = new Class.create({
             return this.getImplementation().getObjectRelationInlineSearchRoute();
         }
         return null;
+    },
+
+    getObjectRelationInlineSearchRouteMethod: function () {
+        if(this.hasImplementation()) {
+            if(typeof this.getImplementation().getObjectRelationInlineSearchRouteMethod === "function") {
+                return this.getImplementation().getObjectRelationInlineSearchRouteMethod();
+            }
+            return 'GET';
+        }
+        return null;
     }
 });
 

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -851,6 +851,14 @@ pimcore.helpers.getObjectRelationInlineSearchRoute = function () {
     return null;
 }
 
+pimcore.helpers.getObjectRelationInlineSearchRouteMethod = function () {
+    if(pimcore.helpers.hasSearchImplementation()) {
+        return pimcore.globalmanager.get('searchImplementationRegistry').getObjectRelationInlineSearchRouteMethod();
+    }
+
+    return null;
+}
+
 pimcore.helpers.activateMaintenance = function () {
 
     Ext.Ajax.request({

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -841,7 +841,7 @@ pimcore.helpers.itemselector = function (multiselect, callback, restrictions, co
 
 pimcore.helpers.hasSearchImplementation = function () {
     return pimcore.globalmanager.get('searchImplementationRegistry').hasImplementation();
-}
+};
 
 pimcore.helpers.getObjectRelationInlineSearchRoute = function () {
     if(pimcore.helpers.hasSearchImplementation()) {
@@ -849,7 +849,7 @@ pimcore.helpers.getObjectRelationInlineSearchRoute = function () {
     }
 
     return null;
-}
+};
 
 pimcore.helpers.getObjectRelationInlineSearchRouteMethod = function () {
     if(pimcore.helpers.hasSearchImplementation()) {

--- a/public/js/pimcore/helpers.js
+++ b/public/js/pimcore/helpers.js
@@ -857,7 +857,7 @@ pimcore.helpers.getObjectRelationInlineSearchRouteMethod = function () {
     }
 
     return null;
-}
+};
 
 pimcore.helpers.activateMaintenance = function () {
 

--- a/public/js/pimcore/object/tags/manyToManyObjectRelation.js
+++ b/public/js/pimcore/object/tags/manyToManyObjectRelation.js
@@ -65,6 +65,9 @@ pimcore.object.tags.manyToManyObjectRelation = Class.create(pimcore.object.tags.
             storeConfig.proxy = {
                 type: 'ajax',
                 url: pimcore.helpers.getObjectRelationInlineSearchRoute(),
+                actionMethods: {
+                    read: pimcore.helpers.getObjectRelationInlineSearchRouteMethod()
+                },
                 extraParams: {
                     fieldConfig: JSON.stringify(this.fieldConfig),
                     data: JSON.stringify(this.data.map(function(element) {

--- a/public/js/pimcore/object/tags/manyToOneRelation.js
+++ b/public/js/pimcore/object/tags/manyToOneRelation.js
@@ -56,6 +56,9 @@ pimcore.object.tags.manyToOneRelation = Class.create(pimcore.object.tags.abstrac
             storeConfig.proxy = {
                 type: 'ajax',
                 url: pimcore.helpers.getObjectRelationInlineSearchRoute(),
+                actionMethods: {
+                    read: pimcore.helpers.getObjectRelationInlineSearchRouteMethod()
+                },
                 extraParams: {
                     fieldConfig: JSON.stringify(this.fieldConfig),
                     data: JSON.stringify(


### PR DESCRIPTION
## Changes in this pull request  
Use POST instead of GET to search for objects for _combo_ to prevent 414 error response if possible.

The change should be backwards compatible, because the used Http-Method is declared by the actual implemenation and defaulting to GET. 

For this PR to take effect, SimpleBackendSearch bundled with pimcore 12.x itself should also be patched, but should not break even without the change.

## Additional info
It may be sufficient to remove the extra parameter _unsavedChanges_ instead, which is most likelly the root cause of this issue, but I don't know it's purpose.
