### PR TITLE
Refine 2FA form

### DIFF
--- a/templates/admin/login/two_factor_authentication.html.twig
+++ b/templates/admin/login/two_factor_authentication.html.twig
@@ -11,7 +11,7 @@
         </div>
     {% endif %}
 
-    <form method="post" action="{{ path('pimcore_admin_2fa_verify') }}" autocomplete="off">
+    <form method="post" action="{{ path('pimcore_admin_2fa_verify') }}">
         <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="text" inputmode="numeric" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
         <input type="hidden" name="csrfToken" value="{{ pimcore_csrf.getCsrfToken(app.request.session) }}">
 

--- a/templates/admin/login/two_factor_authentication.html.twig
+++ b/templates/admin/login/two_factor_authentication.html.twig
@@ -11,8 +11,8 @@
         </div>
     {% endif %}
 
-    <form method="post" action="{{ path('pimcore_admin_2fa_verify') }}">
-        <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="password" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
+    <form method="post" action="{{ path('pimcore_admin_2fa_verify') }}" autocomplete="off">
+        <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="text" inputmode="numeric" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
         <input type="hidden" name="csrfToken" value="{{ pimcore_csrf.getCsrfToken(app.request.session) }}">
 
         <button type="submit">{{ 'Login'|trans([],'admin') }}</button>

--- a/templates/admin/login/two_factor_setup.html.twig
+++ b/templates/admin/login/two_factor_setup.html.twig
@@ -16,7 +16,7 @@
         <p>{{ '2fa_alert_text'|trans([], 'admin')|raw }}</p>
     </div>
 
-    <form method="post" action="{{ path('pimcore_admin_2fa_setup') }}" autocomplete="off">
+    <form method="post" action="{{ path('pimcore_admin_2fa_setup') }}">
         <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="text" inputmode="numeric" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
         <input type="hidden" name="csrfToken" value="{{ pimcore_csrf.getCsrfToken(app.request.session) }}">
 

--- a/templates/admin/login/two_factor_setup.html.twig
+++ b/templates/admin/login/two_factor_setup.html.twig
@@ -16,8 +16,8 @@
         <p>{{ '2fa_alert_text'|trans([], 'admin')|raw }}</p>
     </div>
 
-    <form method="post" action="{{ path('pimcore_admin_2fa_setup') }}">
-        <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="password" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
+    <form method="post" action="{{ path('pimcore_admin_2fa_setup') }}" autocomplete="off">
+        <input name="_auth_code" id="_auth_code" autocomplete="one-time-code" type="text" inputmode="numeric" placeholder="{{ '2fa_code'|trans([],'admin') }}" required autofocus>
         <input type="hidden" name="csrfToken" value="{{ pimcore_csrf.getCsrfToken(app.request.session) }}">
 
         <button type="submit">{{ 'Login'|trans([],'admin') }}</button>


### PR DESCRIPTION
Currently, the browser's password manager always asks whether the 2FA code should be saved— however, this is *never* what you want, as it is a *one-time* code that changes every two minutes.

Therefore, we should change the `type` to `text`.
In addition, the `input mode` should be set to `numeric` so that the correct keyboard is displayed on mobile devices.