### PR TITLE
Update PHP-CS-Fixer workflow

### DIFF
--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,10 +1,13 @@
 name: "PHP-CS-Fixer"
 
 on:
+    workflow_dispatch:
     push:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
+            - "*_actions"
+            - "feature-*"
 
 permissions:
     contents: write

--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -1,13 +1,10 @@
 name: "PHP-CS-Fixer"
 
 on:
-    workflow_dispatch:
     push:
         branches:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
-            - "*_actions"
-            - "feature-*"
 
 permissions:
     contents: write
@@ -15,9 +12,10 @@ permissions:
 jobs:
     php-style:
         uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
+        if: github.repository_owner == 'pimcore'
         secrets:
             PHP_CS_FIXER_GITHUB_TOKEN: ${{ secrets.PHP_CS_FIXER_GITHUB_TOKEN }}
         with:
-            head_ref: ${{ github.event.pull_request.head.ref }}
-            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            head_ref: ${{ github.head_ref || github.ref_name }}
+            repository: ${{ github.repository }}
             config_file: .php-cs-fixer.dist.php


### PR DESCRIPTION
This PR standardizes PHP style workflows to use the reusable PHP-CS-Fixer workflow from pimcore/workflows-collection-public.