### PR TITLE
[BUG] Changes to LocalizedFields will not be saved

### DIFF
--- a/public/js/pimcore/object/edit.js
+++ b/public/js/pimcore/object/edit.js
@@ -91,7 +91,6 @@ pimcore.object.edit = Class.create({
                         newValue = newValue.map((item, index) => {
                             if('oIndex' in item)
                                 item.oIndex = index;
-                            return item;
                         });
                     }
                     values[currentField.getName()] = newValue;

--- a/public/js/pimcore/object/edit.js
+++ b/public/js/pimcore/object/edit.js
@@ -91,6 +91,7 @@ pimcore.object.edit = Class.create({
                         newValue = newValue.map((item, index) => {
                             if('oIndex' in item)
                                 item.oIndex = index;
+                            return item;
                         });
                     }
                     values[currentField.getName()] = newValue;

--- a/public/js/pimcore/object/tags/localizedfields.js
+++ b/public/js/pimcore/object/tags/localizedfields.js
@@ -535,6 +535,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
             // languageElements is empty. Preserve the original data to avoid wiping it when the
             // whole block becomes dirty due to an unrelated add/remove of a sibling block item.
             if (
+                    ignoreIsDirty &&
                     (!this.languageElements[currentLanguage] || this.languageElements[currentLanguage].length === 0) &&
                     this.data[currentLanguage]
                ) {
@@ -548,7 +549,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
 
             for (var s = 0; s < this.languageElements[currentLanguage].length; s++) {
                 try {
-                    if (this.languageElements[currentLanguage][s].isDirty()) {
+                    if (ignoreIsDirty || this.languageElements[currentLanguage][s].isDirty()) {
                         localizedData[currentLanguage][this.languageElements[currentLanguage][s].getName()]
                             = this.languageElements[currentLanguage][s].getValue();
                     }

--- a/public/js/pimcore/object/tags/localizedfields.js
+++ b/public/js/pimcore/object/tags/localizedfields.js
@@ -539,7 +539,6 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
                     this.data[currentLanguage]
                ) {
                 localizedData[currentLanguage] = Ext.clone(this.data[currentLanguage]);
-                continue;
             }
 
             if (!this.languageElements[currentLanguage]) {

--- a/public/js/pimcore/object/tags/localizedfields.js
+++ b/public/js/pimcore/object/tags/localizedfields.js
@@ -539,6 +539,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
                     this.data[currentLanguage]
                ) {
                 localizedData[currentLanguage] = Ext.clone(this.data[currentLanguage]);
+                continue;
             }
 
             if (!this.languageElements[currentLanguage]) {
@@ -547,7 +548,7 @@ pimcore.object.tags.localizedfields = Class.create(pimcore.object.tags.abstract,
 
             for (var s = 0; s < this.languageElements[currentLanguage].length; s++) {
                 try {
-                    if (ignoreIsDirty || this.languageElements[currentLanguage][s].isDirty()) {
+                    if (this.languageElements[currentLanguage][s].isDirty()) {
                         localizedData[currentLanguage][this.languageElements[currentLanguage][s].getName()]
                             = this.languageElements[currentLanguage][s].getValue();
                     }


### PR DESCRIPTION
Resolves https://github.com/pimcore/admin-ui-classic-bundle/issues/1116
Follow-up https://github.com/pimcore/admin-ui-classic-bundle/issues/1110


With multiple localized field definitions, referenced localizedfields instances can be unrendered and were contributing stale full-language data, which could override real dirty values in the save payload.
Now that fallback only applies in the block/fieldcollection scenario it was intended for, so edited localized values are no longer dropped from save requests in normal object editing.