### PR TITLE
 [Feature, EC] PEES-644: Bug: Classification Store Requires Classes Permission

### DIFF
--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1455,6 +1455,10 @@ class ClassificationstoreController extends AdminAbstractController implements K
         }
 
         $unrestrictedActions = [
+            'getKeyDefinitions',           // GET /get-key-definitions  (already present, keep)
+            'getStores',                   // GET /getstores
+            'propertiesGet',               // GET /properties
+            'storedata',                   // GET store data for editor panel
             'collectionsActionGet',        // checkPermission('objects')
             'groupsActionGet',             // checkPermission('objects')
             'keysActionGet',               // checkPermission('objects')

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1455,13 +1455,19 @@ class ClassificationstoreController extends AdminAbstractController implements K
         }
 
         $unrestrictedActions = [
-            'collectionsActionGet',
-            'groupsActionGet',
-            'relationsActionGet',
-            'addGroupsAction',
-            'addCollectionsAction',
-            'searchRelationsAction',
+            'collectionsActionGet',        // checkPermission('objects')
+            'groupsActionGet',             // checkPermission('objects')
+            'keysActionGet',               // checkPermission('objects')
+            'addCollectionRelation',       // checkPermission('classificationstore')
+            'deleteCollectionRelation',    // checkPermission('classificationstore')
+            'createGroup',                 // checkPermission('classificationstore')
+            'deleteGroup',                 // checkPermission('classificationstore')
+            'createCollection',            // checkPermission('classificationstore')
+            'deleteCollection',            // checkPermission('classificationstore')
+            'createStore',                 // checkPermission('classificationstore')
+            'deleteRelation',              // checkPermission('classificationstore')
         ];
+        
         $this->checkActionPermission($event, 'classificationstore', $unrestrictedActions);
     }
 

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1458,6 +1458,11 @@ class ClassificationstoreController extends AdminAbstractController implements K
             'propertiesGetAction',              // GET /properties
             'collectionsActionGet',             // checkPermission('objects')
             'groupsActionGet',                  // checkPermission('objects')
+            'relationsActionGet',               // checkPermission('objects')
+            'addGroupsAction',                  // checkPermission('classificationstore')
+            'addCollectionsAction',             // checkPermission('classificationstore')
+            'searchRelationsAction',            // no internal permission check — must remain here
+            'propertiesGetAction',              // checkPermission('classificationstore')
             'deleteCollectionRelationAction',   // checkPermission('classificationstore')
             'createGroupAction',                // checkPermission('classificationstore')
             'deleteGroupAction',                // checkPermission('classificationstore')

--- a/src/Controller/Admin/DataObject/ClassificationstoreController.php
+++ b/src/Controller/Admin/DataObject/ClassificationstoreController.php
@@ -1455,21 +1455,16 @@ class ClassificationstoreController extends AdminAbstractController implements K
         }
 
         $unrestrictedActions = [
-            'getKeyDefinitions',           // GET /get-key-definitions  (already present, keep)
-            'getStores',                   // GET /getstores
-            'propertiesGet',               // GET /properties
-            'storedata',                   // GET store data for editor panel
-            'collectionsActionGet',        // checkPermission('objects')
-            'groupsActionGet',             // checkPermission('objects')
-            'keysActionGet',               // checkPermission('objects')
-            'addCollectionRelation',       // checkPermission('classificationstore')
-            'deleteCollectionRelation',    // checkPermission('classificationstore')
-            'createGroup',                 // checkPermission('classificationstore')
-            'deleteGroup',                 // checkPermission('classificationstore')
-            'createCollection',            // checkPermission('classificationstore')
-            'deleteCollection',            // checkPermission('classificationstore')
-            'createStore',                 // checkPermission('classificationstore')
-            'deleteRelation',              // checkPermission('classificationstore')
+            'propertiesGetAction',              // GET /properties
+            'collectionsActionGet',             // checkPermission('objects')
+            'groupsActionGet',                  // checkPermission('objects')
+            'deleteCollectionRelationAction',   // checkPermission('classificationstore')
+            'createGroupAction',                // checkPermission('classificationstore')
+            'deleteGroupAction',                // checkPermission('classificationstore')
+            'createCollectionAction',           // checkPermission('classificationstore')
+            'deleteCollectionAction',           // checkPermission('classificationstore')
+            'createStoreAction',                // checkPermission('classificationstore')
+            'deleteRelationAction',             // checkPermission('classificationstore')
         ];
         
         $this->checkActionPermission($event, 'classificationstore', $unrestrictedActions);


### PR DESCRIPTION
Resolves https://pimcore.atlassian.net/browse/PEES-644


no logic changes, it corrects an overly broad catch-all guard that was silently blocking legitimate users.