### PR TITLE
Add authorization checks to version-management endpoints

### DIFF
--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -881,6 +881,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         if (!$asset) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
+        $this->checkVersionAuthorization($version);
 
         $currentAsset = Asset::getById($asset->getId());
         if ($currentAsset->isAllowed('publish')) {

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -881,7 +881,7 @@ class AssetController extends ElementControllerBase implements KernelControllerE
         if (!$asset) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
-        $this->checkVersionAuthorization($version);
+        $this->checkVersionAuthorization($version, 'asset');
 
         $currentAsset = Asset::getById($asset->getId());
         if ($currentAsset->isAllowed('publish')) {

--- a/src/Controller/Admin/Asset/AssetController.php
+++ b/src/Controller/Admin/Asset/AssetController.php
@@ -876,12 +876,15 @@ class AssetController extends ElementControllerBase implements KernelControllerE
     {
         $id = (int)$request->get('id');
         $version = Model\Version::getById($id);
-        $asset = $version?->loadData();
-
-        if (!$asset) {
+        if (!$version) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
         $this->checkVersionAuthorization($version, 'asset');
+
+        $asset = $version->loadData();
+        if (!$asset) {
+            throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
+        }
 
         $currentAsset = Asset::getById($asset->getId());
         if ($currentAsset->isAllowed('publish')) {

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1509,11 +1509,15 @@ class DataObjectController extends ElementControllerBase implements KernelContro
     {
         $id = (int)$request->get('id');
         $version = Model\Version::getById($id);
-        $object = $version?->loadData();
-        if (!$object) {
+        if (!$version) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
         $this->checkVersionAuthorization($version, 'object');
+
+        $object = $version->loadData();
+        if (!$object) {
+            throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
+        }
 
         $currentObject = DataObject::getById($object->getId());
         if ($currentObject->isAllowed('publish')) {

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1513,6 +1513,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         if (!$object) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
+        $this->checkVersionAuthorization($version);
         $object = $version->loadData();
 
         $currentObject = DataObject::getById($object->getId());

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1514,7 +1514,6 @@ class DataObjectController extends ElementControllerBase implements KernelContro
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
         $this->checkVersionAuthorization($version, 'object');
-        $object = $version->loadData();
 
         $currentObject = DataObject::getById($object->getId());
         if ($currentObject->isAllowed('publish')) {

--- a/src/Controller/Admin/DataObject/DataObjectController.php
+++ b/src/Controller/Admin/DataObject/DataObjectController.php
@@ -1513,7 +1513,7 @@ class DataObjectController extends ElementControllerBase implements KernelContro
         if (!$object) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
-        $this->checkVersionAuthorization($version);
+        $this->checkVersionAuthorization($version, 'object');
         $object = $version->loadData();
 
         $currentObject = DataObject::getById($object->getId());

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -704,7 +704,6 @@ class DocumentController extends ElementControllerBase implements KernelControll
         if (!$document) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
-        $this->checkVersionAuthorization($version, 'document');
 
         $currentDocument = Document::getById($document->getId());
         if ($currentDocument->isAllowed('publish')) {

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -683,11 +683,15 @@ class DocumentController extends ElementControllerBase implements KernelControll
     {
         $id = (int)$request->get('id');
         $version = Version::getById($id);
-        $document = $version?->loadData();
-        if (!$document) {
+        if (!$version) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
         $this->checkVersionAuthorization($version, 'document');
+
+        $document = $version->loadData();
+        if (!$document) {
+            throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
+        }
         Document\Service::saveElementToSession($document, $request->getSession()->getId());
 
         return new Response();

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -687,6 +687,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         if (!$document) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
+        $this->checkVersionAuthorization($version, 'document');
         Document\Service::saveElementToSession($document, $request->getSession()->getId());
 
         return new Response();
@@ -703,7 +704,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         if (!$document) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
-        $this->checkVersionAuthorization($version);
+        $this->checkVersionAuthorization($version, 'document');
 
         $currentDocument = Document::getById($document->getId());
         if ($currentDocument->isAllowed('publish')) {

--- a/src/Controller/Admin/Document/DocumentController.php
+++ b/src/Controller/Admin/Document/DocumentController.php
@@ -703,6 +703,7 @@ class DocumentController extends ElementControllerBase implements KernelControll
         if (!$document) {
             throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
+        $this->checkVersionAuthorization($version);
 
         $currentDocument = Document::getById($document->getId());
         if ($currentDocument->isAllowed('publish')) {

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -492,6 +492,11 @@ class ElementController extends AdminAbstractController
         $data = $this->decodeJson($request->get('data'));
 
         $version = Version::getById($data['id']);
+        if (!$version) {
+            throw $this->createNotFoundException('Version with id [' . $data['id'] . "] doesn't exist");
+        }
+
+        $this->checkVersionAuthorization($version);
 
         if ($data['public'] != $version->getPublic() || $data['note'] != $version->getNote()) {
             $version->setPublic($data['public']);
@@ -500,6 +505,20 @@ class ElementController extends AdminAbstractController
         }
 
         return $this->adminJson(['success' => true]);
+    }
+
+    /**
+     * Ensures the current admin user has 'versions' permission on the element a version
+     * belongs to. Version-management endpoints act on an attacker-suppliable version id,
+     * so this must be checked per-request rather than relying on the /admin firewall
+     * (which only requires ROLE_PIMCORE_USER for every backend user).
+     */
+    private function checkVersionAuthorization(Version $version): void
+    {
+        $element = Element\Service::getElementById($version->getCtype(), $version->getCid());
+        if (!$element || !$element->isAllowed('versions')) {
+            throw $this->createAccessDeniedException('Permission denied, version id [' . $version->getId() . ']');
+        }
     }
 
     /**
@@ -617,6 +636,7 @@ class ElementController extends AdminAbstractController
     {
         $version = Version::getById((int) $request->get('id'));
         if ($version) {
+            $this->checkVersionAuthorization($version);
             $version->delete();
         }
 
@@ -626,7 +646,13 @@ class ElementController extends AdminAbstractController
     #[Route('/element/delete-version', name: 'pimcore_admin_element_deleteversion', methods: ['DELETE'])]
     public function deleteVersionAction(Request $request): JsonResponse
     {
-        $version = Model\Version::getById((int) $request->get('id'));
+        $id = (int) $request->get('id');
+        $version = Model\Version::getById($id);
+        if (!$version) {
+            throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
+        }
+
+        $this->checkVersionAuthorization($version);
         $version->delete();
 
         return $this->adminJson(['success' => true]);
@@ -638,6 +664,15 @@ class ElementController extends AdminAbstractController
         $elementId = ParameterBagHelper::getInt($request->request, 'id');
         $elementModificationdate = $request->request->get('date');
         $elementType = $request->request->get('type');
+
+        $element = Element\Service::getElementById($elementType, $elementId);
+        if (!$element) {
+            throw $this->createNotFoundException($elementType . ' with id [' . $elementId . "] doesn't exist");
+        }
+
+        if (!$element->isAllowed('versions')) {
+            throw $this->createAccessDeniedException('Permission denied, ' . $elementType . ' id [' . $elementId . ']');
+        }
 
         $versions = new Model\Version\Listing();
         $versions->setCondition('cid = ' . $versions->quote($elementId) .

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -508,20 +508,6 @@ class ElementController extends AdminAbstractController
     }
 
     /**
-     * Ensures the current admin user has 'versions' permission on the element a version
-     * belongs to. Version-management endpoints act on an attacker-suppliable version id,
-     * so this must be checked per-request rather than relying on the /admin firewall
-     * (which only requires ROLE_PIMCORE_USER for every backend user).
-     */
-    private function checkVersionAuthorization(Version $version): void
-    {
-        $element = Element\Service::getElementById($version->getCtype(), $version->getCid());
-        if (!$element || !$element->isAllowed('versions')) {
-            throw $this->createAccessDeniedException('Permission denied, version id [' . $version->getId() . ']');
-        }
-    }
-
-    /**
      * @throws \Exception
      */
     #[Route('/element/get-nice-path', name: 'pimcore_admin_element_getnicepath', methods: ['POST'])]

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -620,11 +620,14 @@ class ElementController extends AdminAbstractController
     #[Route('/element/delete-draft', name: 'pimcore_admin_element_deletedraft', methods: ['DELETE'])]
     public function deleteDraftAction(Request $request): JsonResponse
     {
-        $version = Version::getById((int) $request->get('id'));
-        if ($version) {
-            $this->checkVersionAuthorization($version);
-            $version->delete();
+        $id = (int) $request->get('id');
+        $version = Version::getById($id);
+        if (!$version) {
+            throw $this->createNotFoundException('Version with id [' . $id . "] doesn't exist");
         }
+
+        $this->checkVersionAuthorization($version);
+        $version->delete();
 
         return $this->adminJson(['success' => true]);
     }

--- a/src/Controller/AdminAbstractController.php
+++ b/src/Controller/AdminAbstractController.php
@@ -48,9 +48,18 @@ abstract class AdminAbstractController extends UserAwareController
      * belongs to. Version-management endpoints act on an attacker-suppliable version id,
      * so this must be checked per-request rather than relying on the /admin firewall
      * (which only requires ROLE_PIMCORE_USER for every backend user).
+     *
+     * Type-specific endpoints (e.g. the document/asset/object publish-version actions) must
+     * pass $expectedCtype so a version belonging to one element type can't be used to pass
+     * authorization there and then be applied against an unrelated element of another type
+     * that happens to share the same numeric id.
      */
-    protected function checkVersionAuthorization(Version $version): void
+    protected function checkVersionAuthorization(Version $version, ?string $expectedCtype = null): void
     {
+        if ($expectedCtype !== null && $version->getCtype() !== $expectedCtype) {
+            throw $this->createAccessDeniedException('Permission denied, version id [' . $version->getId() . ']');
+        }
+
         $element = Element\Service::getElementById($version->getCtype(), $version->getCid());
         if (!$element || !$element->isAllowed('versions')) {
             throw $this->createAccessDeniedException('Permission denied, version id [' . $version->getId() . ']');

--- a/src/Controller/AdminAbstractController.php
+++ b/src/Controller/AdminAbstractController.php
@@ -45,7 +45,7 @@ abstract class AdminAbstractController extends UserAwareController
 
     /**
      * Ensures the current admin user has 'versions' permission on the element a version
-     * belongs to. Version-management endpoints act on an attacker-suppliable version id,
+     * belongs to. Version-management endpoints act on an attacker-supplied version id,
      * so this must be checked per-request rather than relying on the /admin firewall
      * (which only requires ROLE_PIMCORE_USER for every backend user).
      *

--- a/src/Controller/AdminAbstractController.php
+++ b/src/Controller/AdminAbstractController.php
@@ -14,7 +14,9 @@ namespace Pimcore\Bundle\AdminBundle\Controller;
 
 use Pimcore\Controller\Traits\JsonHelperTrait;
 use Pimcore\Controller\UserAwareController;
+use Pimcore\Model\Element;
 use Pimcore\Model\User;
+use Pimcore\Model\Version;
 use Pimcore\Security\User\User as UserProxy;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -39,5 +41,19 @@ abstract class AdminAbstractController extends UserAwareController
     protected function getAdminUser(bool $proxyUser = false): UserProxy|User|null
     {
         return $this->getPimcoreUser($proxyUser);
+    }
+
+    /**
+     * Ensures the current admin user has 'versions' permission on the element a version
+     * belongs to. Version-management endpoints act on an attacker-suppliable version id,
+     * so this must be checked per-request rather than relying on the /admin firewall
+     * (which only requires ROLE_PIMCORE_USER for every backend user).
+     */
+    protected function checkVersionAuthorization(Version $version): void
+    {
+        $element = Element\Service::getElementById($version->getCtype(), $version->getCid());
+        if (!$element || !$element->isAllowed('versions')) {
+            throw $this->createAccessDeniedException('Permission denied, version id [' . $version->getId() . ']');
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Version id/date/publish/delete endpoints in `ElementController` acted on attacker-suppliable version ids without verifying the current user has `versions` permission on the owning element.
- Adds a shared `checkVersionAuthorization()` check (and existence checks) to `publishVersionAction`, `deleteVersionAction` (both routes), and the version-listing endpoint.

## Test plan
- [ ] Verify a user without `versions` permission on an element gets an access-denied response when publishing/deleting/listing versions for that element's version ids
- [ ] Verify existing authorized flows (publish/delete/list versions) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)