### PR TITLE
Fix show in tree action

### DIFF
--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -479,6 +479,10 @@ pimcore.element.helpers.gridColumnConfig = {
 
                 if (typeof editor.loadObjectData === 'function' && editor.visibleFields) {
                     // manyToManyObjectRelation: loadObjectData adds to store AND fetches field metadata
+                    // getLayoutEdit() (combo mode) reads selected ids from editor.data, not the store,
+                    // so it needs to be kept in sync before the layout is built.
+                    editor.data = parsedItems;
+
                     parsedItems.forEach(function(item) {
                         editor.loadObjectData(item, editor.visibleFields);
                     });
@@ -496,8 +500,11 @@ pimcore.element.helpers.gridColumnConfig = {
                             }
                         });
                     });
-                } else if (editor.store) {
-                    // manyToManyRelation / advancedManyToManyRelation: load into store, resolve fullpath
+                } else if (editor.store && editor.type !== 'manyToOneRelation') {
+                    // manyToManyRelation / advancedManyToManyRelation: load into store, resolve path.
+                    // advancedManyToManyRelation displays "path", not "fullpath" - use the editor's
+                    // declared pathProperty so both variants are populated correctly.
+                    var pathProperty = editor.pathProperty || 'fullpath';
                     editor.store.loadData(parsedItems, false);
                     editor.store.each(function(rec) {
                         Ext.Ajax.request({
@@ -506,7 +513,7 @@ pimcore.element.helpers.gridColumnConfig = {
                             success: function(response) {
                                 var rdata = Ext.decode(response.responseText);
                                 if (rdata.success) {
-                                    rec.set('fullpath', rdata.fullpath, { dirty: false });
+                                    rec.set(pathProperty, rdata.fullpath, { dirty: false });
                                 }
                             }
                         });

--- a/public/js/pimcore/element/helpers/gridColumnConfig.js
+++ b/public/js/pimcore/element/helpers/gridColumnConfig.js
@@ -477,29 +477,44 @@ pimcore.element.helpers.gridColumnConfig = {
                     }
                 }
 
+                // Combo-mode editors (manyToOneRelation / manyToManyObjectRelation) back their
+                // combo/tag field with a store whose ajax proxy is seeded from editor.data at
+                // construction time - before this filter-restore code has run. Setting editor.data
+                // afterwards doesn't reach that proxy, so the store must be explicitly reloaded with
+                // the real ids/types to get back records with a proper "label".
+                var isComboMode = pimcore.helpers.hasSearchImplementation() && editor.fieldConfig
+                    && editor.fieldConfig.displayMode === 'combo';
+
                 if (typeof editor.loadObjectData === 'function' && editor.visibleFields) {
                     // manyToManyObjectRelation: loadObjectData adds to store AND fetches field metadata
                     // getLayoutEdit() (combo mode) reads selected ids from editor.data, not the store,
                     // so it needs to be kept in sync before the layout is built.
                     editor.data = parsedItems;
 
-                    parsedItems.forEach(function(item) {
-                        editor.loadObjectData(item, editor.visibleFields);
-                    });
-
-                    // loadObjectData skips fullpath — resolve it separately
-                    editor.store.each(function(rec) {
-                        Ext.Ajax.request({
-                            url: Routing.generate('pimcore_admin_element_typepath'),
-                            params: { id: rec.get('id'), type: 'object' },
-                            success: function(response) {
-                                var rdata = Ext.decode(response.responseText);
-                                if (rdata.success) {
-                                    rec.set('fullpath', rdata.fullpath, { dirty: false });
-                                }
-                            }
+                    if (isComboMode) {
+                        editor.store.getProxy().setExtraParam('data', JSON.stringify(parsedItems.map(function(item) {
+                            return { id: item.id, type: item.type || 'object' };
+                        })));
+                        editor.store.load();
+                    } else {
+                        parsedItems.forEach(function(item) {
+                            editor.loadObjectData(item, editor.visibleFields);
                         });
-                    });
+
+                        // loadObjectData skips fullpath — resolve it separately
+                        editor.store.each(function(rec) {
+                            Ext.Ajax.request({
+                                url: Routing.generate('pimcore_admin_element_typepath'),
+                                params: { id: rec.get('id'), type: 'object' },
+                                success: function(response) {
+                                    var rdata = Ext.decode(response.responseText);
+                                    if (rdata.success) {
+                                        rec.set('fullpath', rdata.fullpath, { dirty: false });
+                                    }
+                                }
+                            });
+                        });
+                    }
                 } else if (editor.store && editor.type !== 'manyToOneRelation') {
                     // manyToManyRelation / advancedManyToManyRelation: load into store, resolve path.
                     // advancedManyToManyRelation displays "path", not "fullpath" - use the editor's
@@ -524,19 +539,35 @@ pimcore.element.helpers.gridColumnConfig = {
 
                     if (item) {
                         editor.data = { id: item.id, type: item.type || 'object', path: '' };
-                        Ext.Ajax.request({
-                            url: Routing.generate('pimcore_admin_element_typepath'),
-                            params: { id: item.id, type: item.type || 'object' },
-                            success: function(response) {
-                                var rdata = Ext.decode(response.responseText);
-                                if (rdata.success) {
-                                    editor.data.path = rdata.fullpath;
+
+                        if (isComboMode) {
+                            // combo: valueField is "id" with forceSelection - setting a fullpath
+                            // string here would be rejected/cleared, so keep the value as the id.
+                            editor.store.getProxy().setExtraParam('data', JSON.stringify([
+                                { id: item.id, type: item.type || 'object' }
+                            ]));
+                            editor.store.load({
+                                callback: function() {
                                     if (editor.component) {
-                                        editor.component.setValue(rdata.fullpath);
+                                        editor.component.setValue(item.id);
                                     }
                                 }
-                            }
-                        });
+                            });
+                        } else {
+                            Ext.Ajax.request({
+                                url: Routing.generate('pimcore_admin_element_typepath'),
+                                params: { id: item.id, type: item.type || 'object' },
+                                success: function(response) {
+                                    var rdata = Ext.decode(response.responseText);
+                                    if (rdata.success) {
+                                        editor.data.path = rdata.fullpath;
+                                        if (editor.component) {
+                                            editor.component.setValue(rdata.fullpath);
+                                        }
+                                    }
+                                }
+                            });
+                        }
                     }
                 }
 

--- a/public/js/pimcore/treenodelocator.js
+++ b/public/js/pimcore/treenodelocator.js
@@ -295,16 +295,18 @@ pimcore.treenodelocator = function()
                     }
                 }
 
+                var pagingBounds = self.calculatePagingBounds(offset, limit, total);
+
                 pagingState = {
                     node: node,
                     childNodeId: childNodeId,
                     total: total,
                     limit: limit,
                     offset: offset,
-                    activePage: (offset / limit) + 1,
-                    pageCount: Math.ceil(total / limit),
-                    minPage: 1,
-                    maxPage: Math.ceil(total / limit),
+                    activePage: pagingBounds.activePage,
+                    pageCount: pagingBounds.pageCount,
+                    minPage: pagingBounds.minPage,
+                    maxPage: pagingBounds.maxPage,
                     sortBy: sortBy,
                     elementKey: elementKey,
                     elementType: elementType
@@ -525,6 +527,21 @@ pimcore.treenodelocator = function()
                 pimcore.helpers.removeTreeNodeLoadingIndicator(loadingIndicators[i].type, loadingIndicators[i].id);
             }
             loadingIndicators = [];
+        },
+
+
+        /**
+         * Pure page-bounds calculation for the paging binary search. Kept
+         * side-effect-free and exposed publicly so it can be exercised
+         * directly by tests without needing the full Ext/pimcore environment.
+         */
+        calculatePagingBounds: function (offset, limit, total) {
+            return {
+                activePage: (offset / limit) + 1,
+                pageCount: Math.ceil(total / limit),
+                minPage: 1,
+                maxPage: Math.ceil(total / limit)
+            };
         }
 
     };
@@ -534,9 +551,14 @@ pimcore.treenodelocator = function()
      * Expose public functions
      */
     return {
-        showInTree: self.showInTree
+        showInTree: self.showInTree,
+        calculatePagingBounds: self.calculatePagingBounds
     };
 
 }();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = pimcore.treenodelocator;
+}
 
 

--- a/public/js/pimcore/treenodelocator.js
+++ b/public/js/pimcore/treenodelocator.js
@@ -301,7 +301,7 @@ pimcore.treenodelocator = function()
                     total: total,
                     limit: limit,
                     offset: offset,
-                    activePage: (offset / total) + 1,
+                    activePage: (offset / limit) + 1,
                     pageCount: Math.ceil(total / limit),
                     minPage: 1,
                     maxPage: Math.ceil(total / limit),

--- a/tests/js/treenodelocator-paging.test.js
+++ b/tests/js/treenodelocator-paging.test.js
@@ -1,12 +1,19 @@
 /**
- * Standalone regression test for the "Show in Tree" binary-search paging
- * logic in treenodelocator.js (PEES-1138).
+ * Regression test for the "Show in Tree" binary-search paging logic in
+ * treenodelocator.js (PEES-1138).
  *
  * This bundle has no JS test runner wired up (no jest/mocha/karma, only
  * webpack-encore for building assets), so this is a plain, dependency-free
- * Node script that re-implements the exact bound math from
- * `reportProcessFullPathFailed` / `processPaging` / `switchToPage` and
- * drives it against mock "current page vs target page" scenarios.
+ * Node script. It stubs the minimal global `pimcore.registerNS` and
+ * `require()`s treenodelocator.js directly, so the "fixed" side below calls
+ * the real, shipped `calculatePagingBounds` production function - if that
+ * function is ever reverted to the old `offset / total` formula, this test
+ * fails, since it is no longer just checking a local copy of the formula.
+ *
+ * The binary-search bound-narrowing itself (processPaging()/switchToPage())
+ * is re-implemented locally (`runBinarySearch`), since those functions are
+ * private closures over module state and aren't exposed for direct testing;
+ * only the page-bounds calculation is pulled from the real module.
  *
  * Run with: node tests/js/treenodelocator-paging.test.js
  */
@@ -14,20 +21,16 @@
 'use strict';
 
 const assert = require('assert');
+const path = require('path');
 
-// --- Faithful port of the relevant math from treenodelocator.js ---------
+// Minimal stub so treenodelocator.js's top-level `pimcore.registerNS(...)`
+// call and `pimcore.treenodelocator = ...` assignment don't throw in Node.
+global.pimcore = { registerNS: function () {} };
 
-function buildPagingState(offset, limit, total, activePageFormula) {
-    return {
-        total,
-        limit,
-        offset,
-        activePage: activePageFormula(offset, limit, total),
-        pageCount: Math.ceil(total / limit),
-        minPage: 1,
-        maxPage: Math.ceil(total / limit),
-    };
-}
+const treenodelocator = require(path.join(__dirname, '..', '..', 'public', 'js', 'pimcore', 'treenodelocator.js'));
+
+// --- Binary search harness (local re-implementation of the bound-narrowing
+// in processPaging()/switchToPage(); those are private and not exposed) ----
 
 // direction: -1 = target is before the currently loaded page, +1 = after, 0 = on it
 function direction(cachedPage, targetPage) {
@@ -36,7 +39,6 @@ function direction(cachedPage, targetPage) {
     return 0;
 }
 
-// Faithful port of processPaging()'s bound-narrowing + switchToPage() gate.
 // Returns { found: true, page } on success, { found: false } if the search
 // aborts out-of-bounds (the silent-failure path), or throws if it never
 // converges within a sane number of iterations (safety net for the test).
@@ -75,10 +77,18 @@ function runBinarySearch(pagingState, cachedPageAtStart, targetPage) {
     throw new Error('did not converge within ' + MAX_ITERATIONS + ' iterations');
 }
 
-// --- The two competing formulas ------------------------------------------
-
-const BUGGY_FORMULA = (offset, limit, total) => (offset / total) + 1;
-const FIXED_FORMULA = (offset, limit, total) => (offset / limit) + 1;
+// The pre-fix formula, kept only as a hardcoded historical snapshot for
+// documentation/comparison in the output below - NOT used to validate
+// production code (that's exactly what real regression coverage requires;
+// see file header).
+function buggyPagingBounds(offset, limit, total) {
+    return {
+        activePage: (offset / total) + 1,
+        pageCount: Math.ceil(total / limit),
+        minPage: 1,
+        maxPage: Math.ceil(total / limit),
+    };
+}
 
 // --- Scenarios -------------------------------------------------------------
 //
@@ -108,10 +118,12 @@ const scenarios = [
     {
         name: 'folder already cached on page 2 of 5, target on page 4',
         limit: 20, total: 90, cachedPageAtStart: 2, targetPage: 4,
-        // The buggy formula happens to still land correctly here - this is
-        // exactly the "fails for some cases, not others" intermittency
-        // reported in the ticket. The important, load-bearing assertion is
-        // still that the FIXED formula always converges (checked above).
+        // The old formula happens to still land correctly here - it does NOT
+        // fail deterministically for every non-zero offset, only for some
+        // (see the two scenarios above/below with expectBuggyFinds: false).
+        // This is exactly the "fails for some cases, not others" intermittency
+        // reported in the ticket, and why the fixed-formula assertion below
+        // (which must ALWAYS converge) is the load-bearing one, not this one.
         expectBuggyFinds: true,
     },
     {
@@ -128,24 +140,31 @@ let failures = 0;
 for (const s of scenarios) {
     const offsetAtStart = s.limit * (s.cachedPageAtStart - 1);
 
-    const buggyState = buildPagingState(offsetAtStart, s.limit, s.total, BUGGY_FORMULA);
+    const buggyState = buggyPagingBounds(offsetAtStart, s.limit, s.total);
+    buggyState.total = s.total;
+    buggyState.limit = s.limit;
+    buggyState.offset = offsetAtStart;
     const buggyResult = runBinarySearch(buggyState, s.cachedPageAtStart, s.targetPage);
 
-    const fixedState = buildPagingState(offsetAtStart, s.limit, s.total, FIXED_FORMULA);
+    // Exercises the real, shipped production function.
+    const fixedBounds = treenodelocator.calculatePagingBounds(offsetAtStart, s.limit, s.total);
+    const fixedState = Object.assign({ total: s.total, limit: s.limit, offset: offsetAtStart }, fixedBounds);
     const fixedResult = runBinarySearch(fixedState, s.cachedPageAtStart, s.targetPage);
 
     console.log(`\n[${s.name}]`);
-    console.log(`  buggy formula : ${buggyResult.found ? `found page ${buggyResult.page}` : 'GAVE UP (silent failure)'}`);
-    console.log(`  fixed formula : ${fixedResult.found ? `found page ${fixedResult.page}` : 'GAVE UP (silent failure)'}`);
+    console.log(`  buggy formula (historical)     : ${buggyResult.found ? `found page ${buggyResult.page}` : 'GAVE UP (silent failure)'}`);
+    console.log(`  production calculatePagingBounds: ${fixedResult.found ? `found page ${fixedResult.page}` : 'GAVE UP (silent failure)'}`);
 
     try {
-        // The fixed formula must ALWAYS find the real target page.
-        assert.strictEqual(fixedResult.found, true, 'fixed formula must always converge');
-        assert.strictEqual(fixedResult.page, s.targetPage, 'fixed formula must land on the real target page');
+        // The load-bearing assertion: the real production function must
+        // ALWAYS find the real target page. This is what fails if the fix
+        // in treenodelocator.js is ever reverted.
+        assert.strictEqual(fixedResult.found, true, 'production calculatePagingBounds must always converge');
+        assert.strictEqual(fixedResult.page, s.targetPage, 'production calculatePagingBounds must land on the real target page');
 
-        // Document the buggy formula's behavior matches what we observed/derived
-        // from the ticket (works when offset=0 at search start, breaks otherwise).
-        assert.strictEqual(buggyResult.found, s.expectBuggyFinds, 'buggy formula behavior mismatch vs expectation');
+        // Documents that the historical formula's behavior matches what we
+        // observed/derived from the ticket.
+        assert.strictEqual(buggyResult.found, s.expectBuggyFinds, 'historical buggy-formula behavior mismatch vs expectation');
 
         console.log('  PASS');
     } catch (err) {

--- a/tests/js/treenodelocator-paging.test.js
+++ b/tests/js/treenodelocator-paging.test.js
@@ -1,0 +1,160 @@
+/**
+ * Standalone regression test for the "Show in Tree" binary-search paging
+ * logic in treenodelocator.js (PEES-1138).
+ *
+ * This bundle has no JS test runner wired up (no jest/mocha/karma, only
+ * webpack-encore for building assets), so this is a plain, dependency-free
+ * Node script that re-implements the exact bound math from
+ * `reportProcessFullPathFailed` / `processPaging` / `switchToPage` and
+ * drives it against mock "current page vs target page" scenarios.
+ *
+ * Run with: node tests/js/treenodelocator-paging.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+
+// --- Faithful port of the relevant math from treenodelocator.js ---------
+
+function buildPagingState(offset, limit, total, activePageFormula) {
+    return {
+        total,
+        limit,
+        offset,
+        activePage: activePageFormula(offset, limit, total),
+        pageCount: Math.ceil(total / limit),
+        minPage: 1,
+        maxPage: Math.ceil(total / limit),
+    };
+}
+
+// direction: -1 = target is before the currently loaded page, +1 = after, 0 = on it
+function direction(cachedPage, targetPage) {
+    if (targetPage < cachedPage) return -1;
+    if (targetPage > cachedPage) return 1;
+    return 0;
+}
+
+// Faithful port of processPaging()'s bound-narrowing + switchToPage() gate.
+// Returns { found: true, page } on success, { found: false } if the search
+// aborts out-of-bounds (the silent-failure path), or throws if it never
+// converges within a sane number of iterations (safety net for the test).
+function runBinarySearch(pagingState, cachedPageAtStart, targetPage) {
+    let cachedPage = cachedPageAtStart;
+    const MAX_ITERATIONS = 20;
+
+    for (let i = 0; i < MAX_ITERATIONS; i++) {
+        const dir = direction(cachedPage, targetPage);
+
+        if (dir === 0) {
+            return { found: true, page: cachedPage };
+        }
+
+        let newPage;
+        if (dir === -1) {
+            pagingState.maxPage = pagingState.activePage - 1;
+            newPage = (pagingState.minPage + pagingState.maxPage) / 2;
+        } else {
+            pagingState.minPage = pagingState.activePage + 1;
+            newPage = (pagingState.minPage + pagingState.maxPage) / 2;
+        }
+
+        // switchToPage()
+        newPage = Math.floor(newPage);
+        if (newPage > pagingState.maxPage || newPage < pagingState.minPage) {
+            return { found: false };
+        }
+
+        // switchToPage() sets activePage/offset directly for the *next* round
+        pagingState.offset = pagingState.limit * (newPage - 1);
+        pagingState.activePage = newPage;
+        cachedPage = newPage;
+    }
+
+    throw new Error('did not converge within ' + MAX_ITERATIONS + ' iterations');
+}
+
+// --- The two competing formulas ------------------------------------------
+
+const BUGGY_FORMULA = (offset, limit, total) => (offset / total) + 1;
+const FIXED_FORMULA = (offset, limit, total) => (offset / limit) + 1;
+
+// --- Scenarios -------------------------------------------------------------
+//
+// Each scenario describes: page size, total item count, which page the
+// folder happens to be cached/loaded at when the search starts (this is
+// what the bug depends on), and which page the target actually lives on.
+
+const scenarios = [
+    {
+        name: 'fresh folder, first visit (offset=0), target on page 2 of 4',
+        limit: 20, total: 70, cachedPageAtStart: 1, targetPage: 2,
+        // Matches support's repro and the "atv_..." working example from the ticket.
+        expectBuggyFinds: true,
+    },
+    {
+        name: 'fresh folder, target on last page (2 of 2)',
+        limit: 20, total: 35, cachedPageAtStart: 1, targetPage: 2,
+        // Matches the "flammkopfverl..." working example from the ticket.
+        expectBuggyFinds: true,
+    },
+    {
+        name: 'folder already cached on page 3 of 4, target on page 2 (PEES-1138 repro)',
+        limit: 20, total: 70, cachedPageAtStart: 3, targetPage: 2,
+        // Matches the "duo-s2-pe" failing example from the ticket exactly.
+        expectBuggyFinds: false,
+    },
+    {
+        name: 'folder already cached on page 2 of 5, target on page 4',
+        limit: 20, total: 90, cachedPageAtStart: 2, targetPage: 4,
+        // The buggy formula happens to still land correctly here - this is
+        // exactly the "fails for some cases, not others" intermittency
+        // reported in the ticket. The important, load-bearing assertion is
+        // still that the FIXED formula always converges (checked above).
+        expectBuggyFinds: true,
+    },
+    {
+        name: 'folder already cached on page 4 of 5, target on page 1',
+        limit: 20, total: 90, cachedPageAtStart: 4, targetPage: 1,
+        expectBuggyFinds: false,
+    },
+];
+
+// --- Run ---------------------------------------------------------------
+
+let failures = 0;
+
+for (const s of scenarios) {
+    const offsetAtStart = s.limit * (s.cachedPageAtStart - 1);
+
+    const buggyState = buildPagingState(offsetAtStart, s.limit, s.total, BUGGY_FORMULA);
+    const buggyResult = runBinarySearch(buggyState, s.cachedPageAtStart, s.targetPage);
+
+    const fixedState = buildPagingState(offsetAtStart, s.limit, s.total, FIXED_FORMULA);
+    const fixedResult = runBinarySearch(fixedState, s.cachedPageAtStart, s.targetPage);
+
+    console.log(`\n[${s.name}]`);
+    console.log(`  buggy formula : ${buggyResult.found ? `found page ${buggyResult.page}` : 'GAVE UP (silent failure)'}`);
+    console.log(`  fixed formula : ${fixedResult.found ? `found page ${fixedResult.page}` : 'GAVE UP (silent failure)'}`);
+
+    try {
+        // The fixed formula must ALWAYS find the real target page.
+        assert.strictEqual(fixedResult.found, true, 'fixed formula must always converge');
+        assert.strictEqual(fixedResult.page, s.targetPage, 'fixed formula must land on the real target page');
+
+        // Document the buggy formula's behavior matches what we observed/derived
+        // from the ticket (works when offset=0 at search start, breaks otherwise).
+        assert.strictEqual(buggyResult.found, s.expectBuggyFinds, 'buggy formula behavior mismatch vs expectation');
+
+        console.log('  PASS');
+    } catch (err) {
+        failures++;
+        console.error('  FAIL:', err.message);
+    }
+}
+
+console.log(`\n${scenarios.length - failures}/${scenarios.length} scenarios passed.`);
+if (failures > 0) {
+    process.exit(1);
+}


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/946

## Summary
- Fixes the "Show in Tree" binary-search paging logic in `treenodelocator.js`: `activePage` was computed as `offset / total` instead of `offset / limit`, which corrupts the search bounds whenever the target folder is already loaded on a page other than 1, causing the search to silently give up (PEES-1138).
- Addresses the 3 Copilot review comments left on #1131 regarding the relation-filter grid editor (`gridColumnConfig.js`):
  - `manyToOneRelation` was being swallowed by the `editor.store` branch (it always has a store too), leaving its dedicated handling unreachable.
  - `manyToManyObjectRelation`'s combo-mode editor now keeps `editor.data` in sync, since `getLayoutEdit()` reads selections from it, not the store.
  - Path field now uses the editor's declared `pathProperty` (`"path"` for `advancedManyToManyRelation`, `"fullpath"` for the others) instead of a hardcoded `'fullpath'`.

Replaces #1131, which was opened from a branch that unintentionally carried over unmerged May commits. Same two commits, cherry-picked onto current `2.3`.

## Test plan
- Added a standalone regression test for the paging binary-search math (offline, no test runner in this bundle) reproducing the exact PEES-1138 scenario (folder cached on page 3 of 4, target on page 2) — fails before the fix, passes after.
- Manual verification recommended: page into a multi-page folder to page > 1, then use "Show in Tree" on an object in a different page of that folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)