### PR TITLE
[Bug, EC] PEES-1176: Fix dependencies tab pagination for restricted u…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "endroid/qr-code": "^6.0.1",
         "nesbot/carbon": "^3.8.4",
         "phpoffice/phpspreadsheet": "^2.2 || ^3.3",
-        "pimcore/pimcore": "^12.3",
+        "pimcore/pimcore": "^12.3.12",
         "symfony/webpack-encore-bundle": "^1.17 || ^2.0"
     },
     "conflict": {

--- a/public/js/pimcore/element/dependencies.js
+++ b/public/js/pimcore/element/dependencies.js
@@ -139,18 +139,14 @@ pimcore.element.dependencies = Class.create({
         this.requiresGrid.on("rowclick", this.click.bind(this));
         this.requiresGrid.on("rowcontextmenu", this.onRowContextmenu.bind(this));
 
-        this.requiresStore.load({
-            callback : function(records, operation, success) {
-                if (success) {
-                    var response = operation.getResponse();
-                    this.requiresData = response.responseJson;
-
-                    if (this.requiresData.hasHidden) {
-                        this.requiresNote.show();
-                    }
-                }
-            }.bind(this)
-        });
+        this.requiresStore.on('load', function(store, records, success, operation) {
+            if (success) {
+                var response = operation.getResponse();
+                this.requiresData = response.responseJson;
+                this.requiresNote.setVisible(!!this.requiresData.hasHidden);
+            }
+        }.bind(this));
+        this.requiresStore.load();
 
         this.requiresNote = new Ext.Panel({
             html:t('hidden_dependencies'),
@@ -249,18 +245,14 @@ pimcore.element.dependencies = Class.create({
         this.requiredByGrid.on("rowclick", this.click.bind(this));
         this.requiredByGrid.on("rowcontextmenu", this.onRowContextmenu.bind(this));
 
-        this.requiredByStore.load({
-            callback : function(records, operation, success) {
-                if (success) {
-                    var response = operation.getResponse();
-                    this.requiredByData = response.responseJson;
-
-                    if (this.requiredByData.hasHidden) {
-                        this.requiredByNote.show();
-                    }
-                }
-            }.bind(this)
-        });
+        this.requiredByStore.on('load', function(store, records, success, operation) {
+            if (success) {
+                var response = operation.getResponse();
+                this.requiredByData = response.responseJson;
+                this.requiredByNote.setVisible(!!this.requiredByData.hasHidden);
+            }
+        }.bind(this));
+        this.requiredByStore.load();
 
         this.requiredByNote = new Ext.Panel({
             html:t('hidden_dependencies'),

--- a/public/js/pimcore/overrides.js
+++ b/public/js/pimcore/overrides.js
@@ -931,29 +931,74 @@ Ext.override(Ext.picker.Date, {
     }
 });
 
-//Fix - Ext.toolbar.Paging disables all navigation once a page returns 0 rows, even when
-//store.getTotalCount() indicates more pages exist (e.g. a page that came back empty because
-//every row on it was filtered out by permission checks). Only intervene in that exact case;
-//defer to the original behavior otherwise.
+//Fix - Ext.toolbar.Paging disables all navigation (and resets the page indicator) once a page
+//returns 0 rows, even when store.getTotalCount() indicates more pages exist (e.g. a page that
+//came back empty because every row on it was filtered out by permission checks). This is a
+//full copy of the stock onLoad() (see ext-all-debug.js, Ext.define('Ext.toolbar.Paging', ...))
+//with a single change: "isEmpty" is based on the store's total record count, not how many rows
+//this particular page happened to return, so the rest of the method's normal state handling
+//(refresh button, page input, "change" event) runs exactly as it would for any other page.
 Ext.override(Ext.toolbar.Paging, {
     onLoad: function () {
         var me = this,
-            store = me.store,
-            pageData;
+            pageData, currPage, pageCount, afterText, count, isEmpty, item;
 
-        if (store.getCount() === 0 && store.getTotalCount() > 0) {
+        count = me.store.getCount();
+        isEmpty = count === 0 && me.store.getTotalCount() === 0;
+
+        if (!isEmpty) {
             pageData = me.getPageData();
+            currPage = pageData.currentPage;
+            pageCount = pageData.pageCount;
 
-            me.setChildDisabled('#first', pageData.currentPage <= 1);
-            me.setChildDisabled('#prev', pageData.currentPage <= 1);
-            me.setChildDisabled('#next', pageData.currentPage >= pageData.pageCount);
-            me.setChildDisabled('#last', pageData.currentPage >= pageData.pageCount);
-            me.updateInfo();
+            // Check for invalid current page.
+            if (currPage > pageCount) {
+                // If the current page is beyond the loaded end,
+                // jump back to the loaded end if there is a valid page count.
+                if (pageCount > 0) {
+                    me.store.loadPage(pageCount);
+                }
+                // If no pages, reset the page field.
+                else {
+                    me.getInputItem().reset();
+                }
 
-            return;
+                return;
+            }
+
+            afterText = Ext.String.format(me.afterPageText, isNaN(pageCount) ? 1 : pageCount);
+        } else {
+            currPage = 0;
+            pageCount = 0;
+            afterText = Ext.String.format(me.afterPageText, 0);
         }
 
-        me.callParent(arguments);
+        Ext.suspendLayouts();
+        item = me.child('#afterTextItem');
+
+        if (item) {
+            item.update(afterText);
+        }
+
+        item = me.getInputItem();
+
+        if (item) {
+            item.setDisabled(isEmpty).setValue(currPage);
+        }
+
+        me.setChildDisabled('#first', currPage === 1 || isEmpty);
+        me.setChildDisabled('#prev', currPage === 1 || isEmpty);
+        me.setChildDisabled('#next', currPage === pageCount || isEmpty);
+        me.setChildDisabled('#last', currPage === pageCount || isEmpty);
+        me.setChildDisabled('#refresh', false);
+
+        me.updateInfo();
+
+        Ext.resumeLayouts(true);
+
+        if (!me.calledInternal) {
+            me.fireEvent('change', me, pageData || me.emptyPageData);
+        }
     }
 });
 

--- a/public/js/pimcore/overrides.js
+++ b/public/js/pimcore/overrides.js
@@ -931,6 +931,32 @@ Ext.override(Ext.picker.Date, {
     }
 });
 
+//Fix - Ext.toolbar.Paging disables all navigation once a page returns 0 rows, even when
+//store.getTotalCount() indicates more pages exist (e.g. a page that came back empty because
+//every row on it was filtered out by permission checks). Only intervene in that exact case;
+//defer to the original behavior otherwise.
+Ext.override(Ext.toolbar.Paging, {
+    onLoad: function () {
+        var me = this,
+            store = me.store,
+            pageData;
+
+        if (store.getCount() === 0 && store.getTotalCount() > 0) {
+            pageData = me.getPageData();
+
+            me.setChildDisabled('#first', pageData.currentPage <= 1);
+            me.setChildDisabled('#prev', pageData.currentPage <= 1);
+            me.setChildDisabled('#next', pageData.currentPage >= pageData.pageCount);
+            me.setChildDisabled('#last', pageData.currentPage >= pageData.pageCount);
+            me.updateInfo();
+
+            return;
+        }
+
+        me.callParent(arguments);
+    }
+});
+
 
 /** workaround for [DataObject] Advanced Image Dropzone only works once #9115
  * Issue: on node drop the component gets destroyed. On mouse up it then tries to focus an already destroyed element.

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -705,41 +705,38 @@ class ElementController extends AdminAbstractController
      * $fetchChunk(rawOffset, chunkSize)), skipping hidden rows, to fill one page in
      * visible-item space. $offset/$limit are visible-space indices - what the frontend sends.
      *
-     * How many raw rows need scanning to reach $offset visible ones depends entirely on how
-     * many hidden rows happen to precede them in the data - not on $offset itself - so no
-     * fixed budget can *guarantee* every page is reachable without either scanning without
-     * bound (unbounded per-request cost) or filtering permissions inside the query (a much
-     * larger change - ACL checks aren't expressible in SQL here). This is a deliberate, bounded
-     * trade-off: a run of hidden rows longer than the cap can require paging forward several
-     * times before visible content past it becomes reachable.
+     * Two earlier designs tried to bound total *raw rows scanned* with a single counter scaled
+     * off $offset (or page number) - both let a hidden-row run near the cap boundary silently
+     * and permanently drop a handful of real visible rows, because whether a scan can get past
+     * a given hidden run ended up depending on which page was asking, so a later page's skip
+     * logic could discard rows an earlier page's smaller budget never actually returned.
      *
-     * The budget MUST grow in lockstep with $offset (by exactly $limit per page, i.e.
-     * `offset + limit + cap`) rather than any faster/independent function of the page number.
-     * Every page's scan restarts at raw offset 0 and skips the first $offset visible rows it
-     * finds, trusting that an earlier page with a smaller budget would have already returned
-     * them if they were reachable. If a later page's budget could outgrow $offset's own pace
-     * (e.g. scaling by page number instead), that page's larger budget can reach visible rows
-     * an earlier page's smaller budget never got to - but its own offset-based skip then
-     * discards them as "already shown by that earlier page", when nothing ever actually
-     * returned them. That permanently orphans those rows: they're skipped by every later page
-     * too, since each one skips exactly $offset of whatever it finds, not what previous pages
-     * actually returned. Keeping budget and offset in the same units avoids this.
+     * This tracks hidden rows and visible rows as two INDEPENDENT counters instead:
+     * $hiddenSeen is capped at a fixed constant that does not depend on $offset/$limit at all,
+     * so whether a given hidden run can be crossed is the same answer for every page. Either
+     * every page gets past it (and the normal offset-based skip/collect logic below is safe,
+     * since all of them then see the same visible rows in the same order), or none do (every
+     * page consistently stops at the same point with an empty result) - there's no longer a
+     * page-dependent partial state that strands specific rows between two pages' worth of work.
+     *
+     * A hidden run longer than the cap is still not scannable - that's an inherent limit of
+     * bounded, stateless, non-SQL-filtered pagination - but it now fails the same way for every
+     * page instead of silently losing a few rows right at the boundary.
      *
      * @return array{items: array, hasHidden: bool, total: int}
      */
     private function scanDependencyPage(callable $fetchChunk, int $offset, int $limit): array
     {
         $visibleSeen = 0;
+        $hiddenSeen = 0;
         $hasHidden = false;
         $page = [];
         $rawOffset = 0;
-        $scannedRows = 0;
-        $scanBudget = $offset + $limit + self::REQUIRED_BY_SCAN_CAP;
+        $visibleTarget = $offset + $limit;
         $reachedEnd = false;
 
-        while (count($page) < $limit && $scannedRows < $scanBudget) {
-            $chunkSize = min(max($limit, self::REQUIRED_BY_SCAN_CHUNK), $scanBudget - $scannedRows);
-            $rows = $fetchChunk($rawOffset, $chunkSize);
+        while (count($page) < $limit && $hiddenSeen < self::REQUIRED_BY_SCAN_CAP) {
+            $rows = $fetchChunk($rawOffset, self::REQUIRED_BY_SCAN_CHUNK);
 
             foreach ($rows as $row) {
                 $el = $this->resolveDependencyElement($row);
@@ -748,6 +745,7 @@ class ElementController extends AdminAbstractController
                 }
                 if (!$el->isAllowed('list')) {
                     $hasHidden = true;
+                    $hiddenSeen++;
 
                     continue;
                 }
@@ -758,24 +756,28 @@ class ElementController extends AdminAbstractController
             }
 
             $rawOffset += count($rows);
-            $scannedRows += count($rows);
 
             // Fewer rows than requested means the underlying (possibly filtered) raw set is
             // exhausted - this must be checked even when the requested page already filled,
             // otherwise a result that exactly fills $limit never reaches this and $reachedEnd
             // stays false even though nothing more exists.
-            if (count($rows) < $chunkSize) {
+            if (count($rows) < self::REQUIRED_BY_SCAN_CHUNK) {
                 $reachedEnd = true;
 
+                break;
+            }
+
+            if ($visibleSeen >= $visibleTarget) {
                 break;
             }
         }
 
         // If the scan actually reached the end of the (filtered) raw set, $visibleSeen is the
         // exact total - not $offset + count($page), which overstates it whenever $offset lands
-        // beyond the last visible row (that would report $offset itself as the total). If the
-        // budget was hit first, report enough headroom for at least one more page rather than a
-        // truncated, too-small total that would strand navigation.
+        // beyond the last visible row (that would report $offset itself as the total). Otherwise
+        // (the page filled, or the hidden-row cap was hit first) report enough headroom for at
+        // least one more page rather than a truncated, too-small total that would strand
+        // navigation.
         $total = $reachedEnd ? $visibleSeen : ($offset + $limit + self::REQUIRED_BY_SCAN_CHUNK);
 
         return ['items' => $page, 'hasHidden' => $hasHidden, 'total' => $total];

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -707,13 +707,23 @@ class ElementController extends AdminAbstractController
      *
      * How many raw rows need scanning to reach $offset visible ones depends entirely on how
      * many hidden rows happen to precede them in the data - not on $offset itself - so no
-     * fixed, offset-derived budget can *guarantee* every page is reachable without either
-     * scanning without bound (unbounded per-request cost) or filtering permissions inside the
-     * query (a much larger change - ACL checks aren't expressible in SQL here). This is a
-     * deliberate, bounded trade-off: each page number gets its own full scan cap, so the budget
-     * grows quickly enough that even a large hidden run is typically crossed within the first
-     * couple of page requests, rather than only after many (a flat cap shared across all pages
-     * would need roughly hiddenRunLength/$limit requests to cross the same run).
+     * fixed budget can *guarantee* every page is reachable without either scanning without
+     * bound (unbounded per-request cost) or filtering permissions inside the query (a much
+     * larger change - ACL checks aren't expressible in SQL here). This is a deliberate, bounded
+     * trade-off: a run of hidden rows longer than the cap can require paging forward several
+     * times before visible content past it becomes reachable.
+     *
+     * The budget MUST grow in lockstep with $offset (by exactly $limit per page, i.e.
+     * `offset + limit + cap`) rather than any faster/independent function of the page number.
+     * Every page's scan restarts at raw offset 0 and skips the first $offset visible rows it
+     * finds, trusting that an earlier page with a smaller budget would have already returned
+     * them if they were reachable. If a later page's budget could outgrow $offset's own pace
+     * (e.g. scaling by page number instead), that page's larger budget can reach visible rows
+     * an earlier page's smaller budget never got to - but its own offset-based skip then
+     * discards them as "already shown by that earlier page", when nothing ever actually
+     * returned them. That permanently orphans those rows: they're skipped by every later page
+     * too, since each one skips exactly $offset of whatever it finds, not what previous pages
+     * actually returned. Keeping budget and offset in the same units avoids this.
      *
      * @return array{items: array, hasHidden: bool, total: int}
      */
@@ -724,8 +734,7 @@ class ElementController extends AdminAbstractController
         $page = [];
         $rawOffset = 0;
         $scannedRows = 0;
-        $pageNumber = intdiv($offset, max($limit, 1)) + 1;
-        $scanBudget = $pageNumber * self::REQUIRED_BY_SCAN_CAP;
+        $scanBudget = $offset + $limit + self::REQUIRED_BY_SCAN_CAP;
         $reachedEnd = false;
 
         while (count($page) < $limit && $scannedRows < $scanBudget) {

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -705,11 +705,15 @@ class ElementController extends AdminAbstractController
      * $fetchChunk(rawOffset, chunkSize)), skipping hidden rows, to fill one page in
      * visible-item space. $offset/$limit are visible-space indices - what the frontend sends.
      *
-     * The scan budget scales with $offset so that legitimately paging forward always has
-     * enough headroom to make progress, rather than hitting a flat cap that becomes an
-     * unreachable wall for deep pages; each chunk request is itself bounded by the remaining
-     * budget so a single oversized $limit (e.g. the grid's "show all" option) can't blow past
-     * the cap before it's accounted for.
+     * How many raw rows need scanning to reach $offset visible ones depends entirely on how
+     * many hidden rows happen to precede them in the data - not on $offset itself - so no
+     * fixed, offset-derived budget can *guarantee* every page is reachable without either
+     * scanning without bound (unbounded per-request cost) or filtering permissions inside the
+     * query (a much larger change - ACL checks aren't expressible in SQL here). This is a
+     * deliberate, bounded trade-off: each page number gets its own full scan cap, so the budget
+     * grows quickly enough that even a large hidden run is typically crossed within the first
+     * couple of page requests, rather than only after many (a flat cap shared across all pages
+     * would need roughly hiddenRunLength/$limit requests to cross the same run).
      *
      * @return array{items: array, hasHidden: bool, total: int}
      */
@@ -720,17 +724,13 @@ class ElementController extends AdminAbstractController
         $page = [];
         $rawOffset = 0;
         $scannedRows = 0;
-        $scanBudget = $offset + $limit + self::REQUIRED_BY_SCAN_CAP;
+        $pageNumber = intdiv($offset, max($limit, 1)) + 1;
+        $scanBudget = $pageNumber * self::REQUIRED_BY_SCAN_CAP;
         $reachedEnd = false;
 
         while (count($page) < $limit && $scannedRows < $scanBudget) {
             $chunkSize = min(max($limit, self::REQUIRED_BY_SCAN_CHUNK), $scanBudget - $scannedRows);
             $rows = $fetchChunk($rawOffset, $chunkSize);
-            if (empty($rows)) {
-                $reachedEnd = true;
-
-                break;
-            }
 
             foreach ($rows as $row) {
                 $el = $this->resolveDependencyElement($row);
@@ -750,12 +750,24 @@ class ElementController extends AdminAbstractController
 
             $rawOffset += count($rows);
             $scannedRows += count($rows);
+
+            // Fewer rows than requested means the underlying (possibly filtered) raw set is
+            // exhausted - this must be checked even when the requested page already filled,
+            // otherwise a result that exactly fills $limit never reaches this and $reachedEnd
+            // stays false even though nothing more exists.
+            if (count($rows) < $chunkSize) {
+                $reachedEnd = true;
+
+                break;
+            }
         }
 
-        // If the scan actually reached the end of the (filtered) raw set, the total is exact.
-        // Otherwise the budget was hit first - report enough headroom for at least one more
-        // page rather than a truncated, too-small total that would strand navigation.
-        $total = $reachedEnd ? ($offset + count($page)) : ($offset + $limit + self::REQUIRED_BY_SCAN_CHUNK);
+        // If the scan actually reached the end of the (filtered) raw set, $visibleSeen is the
+        // exact total - not $offset + count($page), which overstates it whenever $offset lands
+        // beyond the last visible row (that would report $offset itself as the total). If the
+        // budget was hit first, report enough headroom for at least one more page rather than a
+        // truncated, too-small total that would strand navigation.
+        $total = $reachedEnd ? $visibleSeen : ($offset + $limit + self::REQUIRED_BY_SCAN_CHUNK);
 
         return ['items' => $page, 'hasHidden' => $hasHidden, 'total' => $total];
     }
@@ -893,10 +905,13 @@ class ElementController extends AdminAbstractController
                     $limit
                 );
 
-                // Authoritative, briefly-cached permission-filtered total and hidden-dependency
-                // flag (see Model\Element\Service::getRequiredByVisibleTotalCount()/
-                // getRequiredByHasHiddenDependencies()) so both are accurate and stable on
-                // every page, not just an artifact of what this one page's scan happened to see.
+                // Briefly-cached permission-filtered total and hidden-dependency flag (see
+                // Model\Element\Service::getRequiredByVisibleTotalCount()/
+                // getRequiredByHasHiddenDependencies()), sourced from a scan spanning up to
+                // ~5000 rows rather than whatever this one page's own (much shorter) scan
+                // happened to see - exact within that scan, not an unconditional guarantee: a
+                // raw dependency set larger than that shares the same bounded-scan trade-off as
+                // scanDependencyPage() above and falls back conservatively rather than exactly.
                 $total = Model\Element\Service::getRequiredByVisibleTotalCount($dependencies);
                 $hasHidden = Model\Element\Service::getRequiredByHasHiddenDependencies($dependencies);
 

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -675,6 +675,31 @@ class ElementController extends AdminAbstractController
         return $this->adminJson(['success' => true]);
     }
 
+    private const REQUIRED_BY_SCAN_CHUNK = 200;
+
+    private const REQUIRED_BY_SCAN_CAP = 5000;
+
+    private function resolveDependencyElement(array $row): Asset|Document|DataObject\AbstractObject|null
+    {
+        return match ($row['type']) {
+            'asset' => Asset::getById((int) $row['id']),
+            'object' => DataObject::getById((int) $row['id']),
+            'document' => Document::getById((int) $row['id']),
+            default => null,
+        };
+    }
+
+    private function dependencyToFrontendArray(Element\ElementInterface $element): array
+    {
+        return [
+            'id' => $element->getId(),
+            'path' => $element->getRealFullPath(),
+            'type' => Element\Service::getElementType($element),
+            'subtype' => $element->getType(),
+            'published' => Element\Service::isPublished($element),
+        ];
+    }
+
     #[Route('/element/get-requires-dependencies', name: 'pimcore_admin_element_getrequiresdependencies', methods: ['GET'])]
     public function getRequiresDependenciesAction(Request $request): JsonResponse
     {
@@ -722,13 +747,31 @@ class ElementController extends AdminAbstractController
             }
 
             if ($element instanceof Model\Element\ElementInterface) {
-                $dependenciesResult = Model\Element\Service::getRequiresDependenciesForFrontend($dependencies, $offset, $limit);
+                // getRequires() without offset/limit returns the full in-memory set that
+                // getDependencies() already loaded unconditionally, so filtering it fully
+                // before slicing costs nothing extra and gives an exact total immediately.
+                $all = $dependencies->getRequires();
 
-                $dependenciesResult['start'] = $offset;
-                $dependenciesResult['limit'] = $limit;
-                $dependenciesResult['total'] = $dependencies->getRequiresTotalCount();
+                $visible = [];
+                $hasHidden = false;
+                foreach ($all as $row) {
+                    $el = $this->resolveDependencyElement($row);
+                    if ($el instanceof Element\ElementInterface) {
+                        if ($el->isAllowed('list')) {
+                            $visible[] = $this->dependencyToFrontendArray($el);
+                        } else {
+                            $hasHidden = true;
+                        }
+                    }
+                }
 
-                return $this->adminJson($dependenciesResult);
+                return $this->adminJson([
+                    'requires' => array_slice($visible, $offset, $limit),
+                    'hasHidden' => $hasHidden,
+                    'start' => $offset,
+                    'limit' => $limit,
+                    'total' => count($visible),
+                ]);
             }
         }
 
@@ -782,13 +825,61 @@ class ElementController extends AdminAbstractController
             }
 
             if ($element instanceof Model\Element\ElementInterface) {
-                $dependenciesResult = Model\Element\Service::getRequiredByDependenciesForFrontend($dependencies, $offset, $limit);
+                // "Required By" is a live paginated SQL query with no free full-load, unlike
+                // "Requires" above, so permission filtering has to happen alongside a bounded
+                // scan: keep pulling raw chunks (skipping hidden rows) until enough VISIBLE
+                // items are collected to fill this page, the raw table is exhausted, or the
+                // safety cap is hit. $offset/$limit are indices in visible-item space (what the
+                // frontend sends), so every request re-derives the raw->visible mapping from
+                // raw offset 0 rather than resuming from the raw offset it was given - that is
+                // what keeps this correct across independent page requests.
+                $rawTotal = $dependencies->getRequiredByTotalCount();
 
-                $dependenciesResult['start'] = $offset;
-                $dependenciesResult['limit'] = $limit;
-                $dependenciesResult['total'] = $dependencies->getRequiredByTotalCount();
+                $visibleSeen = 0;
+                $hasHidden = false;
+                $page = [];
+                $rawOffset = 0;
+                $scannedRows = 0;
 
-                return $this->adminJson($dependenciesResult);
+                while (count($page) < $limit && $rawOffset < $rawTotal && $scannedRows < self::REQUIRED_BY_SCAN_CAP) {
+                    $chunkSize = max($limit, self::REQUIRED_BY_SCAN_CHUNK);
+                    $rows = $dependencies->getRequiredBy($rawOffset, $chunkSize);
+                    if (empty($rows)) {
+                        break;
+                    }
+
+                    foreach ($rows as $row) {
+                        $el = $this->resolveDependencyElement($row);
+                        if (!$el instanceof Element\ElementInterface) {
+                            continue;
+                        }
+                        if (!$el->isAllowed('list')) {
+                            $hasHidden = true;
+
+                            continue;
+                        }
+                        if ($visibleSeen >= $offset && count($page) < $limit) {
+                            $page[] = $this->dependencyToFrontendArray($el);
+                        }
+                        $visibleSeen++;
+                    }
+
+                    $rawOffset += count($rows);
+                    $scannedRows += count($rows);
+                }
+
+                // The exact permission-filtered total (cached briefly per element+user in core,
+                // see Model\Element\Service::getRequiredByVisibleTotalCount()) so the page count
+                // is accurate from the very first request, not just once paging reaches the end.
+                $total = Model\Element\Service::getRequiredByVisibleTotalCount($dependencies);
+
+                return $this->adminJson([
+                    'requiredBy' => $page,
+                    'hasHidden' => $hasHidden,
+                    'start' => $offset,
+                    'limit' => $limit,
+                    'total' => $total,
+                ]);
             }
         }
 

--- a/src/Controller/Admin/ElementController.php
+++ b/src/Controller/Admin/ElementController.php
@@ -700,6 +700,66 @@ class ElementController extends AdminAbstractController
         ];
     }
 
+    /**
+     * Chunk-scans a raw, permission-unaware dependency fetch (live SQL LIMIT/OFFSET, via
+     * $fetchChunk(rawOffset, chunkSize)), skipping hidden rows, to fill one page in
+     * visible-item space. $offset/$limit are visible-space indices - what the frontend sends.
+     *
+     * The scan budget scales with $offset so that legitimately paging forward always has
+     * enough headroom to make progress, rather than hitting a flat cap that becomes an
+     * unreachable wall for deep pages; each chunk request is itself bounded by the remaining
+     * budget so a single oversized $limit (e.g. the grid's "show all" option) can't blow past
+     * the cap before it's accounted for.
+     *
+     * @return array{items: array, hasHidden: bool, total: int}
+     */
+    private function scanDependencyPage(callable $fetchChunk, int $offset, int $limit): array
+    {
+        $visibleSeen = 0;
+        $hasHidden = false;
+        $page = [];
+        $rawOffset = 0;
+        $scannedRows = 0;
+        $scanBudget = $offset + $limit + self::REQUIRED_BY_SCAN_CAP;
+        $reachedEnd = false;
+
+        while (count($page) < $limit && $scannedRows < $scanBudget) {
+            $chunkSize = min(max($limit, self::REQUIRED_BY_SCAN_CHUNK), $scanBudget - $scannedRows);
+            $rows = $fetchChunk($rawOffset, $chunkSize);
+            if (empty($rows)) {
+                $reachedEnd = true;
+
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $el = $this->resolveDependencyElement($row);
+                if (!$el instanceof Element\ElementInterface) {
+                    continue;
+                }
+                if (!$el->isAllowed('list')) {
+                    $hasHidden = true;
+
+                    continue;
+                }
+                if ($visibleSeen >= $offset && count($page) < $limit) {
+                    $page[] = $this->dependencyToFrontendArray($el);
+                }
+                $visibleSeen++;
+            }
+
+            $rawOffset += count($rows);
+            $scannedRows += count($rows);
+        }
+
+        // If the scan actually reached the end of the (filtered) raw set, the total is exact.
+        // Otherwise the budget was hit first - report enough headroom for at least one more
+        // page rather than a truncated, too-small total that would strand navigation.
+        $total = $reachedEnd ? ($offset + count($page)) : ($offset + $limit + self::REQUIRED_BY_SCAN_CHUNK);
+
+        return ['items' => $page, 'hasHidden' => $hasHidden, 'total' => $total];
+    }
+
     #[Route('/element/get-requires-dependencies', name: 'pimcore_admin_element_getrequiresdependencies', methods: ['GET'])]
     public function getRequiresDependenciesAction(Request $request): JsonResponse
     {
@@ -710,7 +770,6 @@ class ElementController extends AdminAbstractController
         $limit = (int) $request->get('limit', 25);
         $filterRequires = $request->get('filter');
         $value = null;
-        $elements = null;
 
         if ($id && in_array($type, $allowedTypes)) {
             $element = Model\Element\Service::getElementById($type, $id);
@@ -720,30 +779,28 @@ class ElementController extends AdminAbstractController
                 $filters = $this->decodeJson($filterRequires);
 
                 foreach ($filters as $filter) {
-
                     if ($filter['type'] == 'string') {
                         $value = ($filter['value']??'');
                     }
-
-                    $elements = $element->getDependencies()->getFilterRequiresByPath($offset, $limit, $value);
-
                 }
 
-                $result = [
+                // getFilterRequiresByPath() is a live, permission-unaware SQL LIMIT/OFFSET
+                // query - same class of issue as the unfiltered "Required By" listing below,
+                // so it needs the same permission-aware chunk scan rather than filtering just
+                // the one raw page that happens to land on $offset/$limit.
+                $scan = $this->scanDependencyPage(
+                    fn (int $rawOffset, int $chunkSize) => $dependencies->getFilterRequiresByPath($rawOffset, $chunkSize, $value),
+                    $offset,
+                    $limit
+                );
+
+                return $this->adminJson([
+                    'requires' => $scan['items'],
+                    'hasHidden' => $scan['hasHidden'],
                     'start' => $offset,
                     'limit' => $limit,
-                    'requires' => [],  // Initialize 'requires' as an empty array
-                ];
-
-                if (count($elements) > 0) {
-                    $result = Model\Element\Service::getFilterRequiresForFrontend($elements);
-                    $result['total'] = count($result['requires']);
-
-                    return $this->adminJson($result);
-                } else {
-                    return $this->adminJson($elements);
-                }
-
+                    'total' => $scan['total'],
+                ]);
             }
 
             if ($element instanceof Model\Element\ElementInterface) {
@@ -788,7 +845,6 @@ class ElementController extends AdminAbstractController
         $limit = (int) $request->get('limit', 25);
         $filterRequiredBy = $request->get('filter');
         $value = null;
-        $elements = null;
 
         if ($id && in_array($type, $allowedTypes)) {
             $element = Model\Element\Service::getElementById($type, $id);
@@ -798,30 +854,28 @@ class ElementController extends AdminAbstractController
                 $filters = $this->decodeJson($filterRequiredBy);
 
                 foreach ($filters as $filter) {
-
                     if ($filter['type'] == 'string') {
                         $value = ($filter['value']??'');
                     }
-
-                    $elements = $element->getDependencies()->getFilterRequiredByPath($offset, $limit, $value);
-
                 }
 
-                $result = [
+                // getFilterRequiredByPath() is a live, permission-unaware SQL LIMIT/OFFSET
+                // query, same as the unfiltered listing below, so it needs the same
+                // permission-aware chunk scan rather than filtering just the one raw page that
+                // happens to land on $offset/$limit.
+                $scan = $this->scanDependencyPage(
+                    fn (int $rawOffset, int $chunkSize) => $dependencies->getFilterRequiredByPath($rawOffset, $chunkSize, $value),
+                    $offset,
+                    $limit
+                );
+
+                return $this->adminJson([
+                    'requiredBy' => $scan['items'],
+                    'hasHidden' => $scan['hasHidden'],
                     'start' => $offset,
                     'limit' => $limit,
-                    'requiredBy' => [], // Initialize 'requiredBy' as an empty array
-                ];
-
-                if (count($elements) > 0) {
-                    $result = Model\Element\Service::getFilterRequiredByPathForFrontend($elements);
-                    $result['total'] = count($result['requiredBy']);
-
-                    return $this->adminJson($result);
-                } else {
-                    return $this->adminJson($elements);
-                }
-
+                    'total' => $scan['total'],
+                ]);
             }
 
             if ($element instanceof Model\Element\ElementInterface) {
@@ -833,48 +887,21 @@ class ElementController extends AdminAbstractController
                 // frontend sends), so every request re-derives the raw->visible mapping from
                 // raw offset 0 rather than resuming from the raw offset it was given - that is
                 // what keeps this correct across independent page requests.
-                $rawTotal = $dependencies->getRequiredByTotalCount();
+                $scan = $this->scanDependencyPage(
+                    fn (int $rawOffset, int $chunkSize) => $dependencies->getRequiredBy($rawOffset, $chunkSize),
+                    $offset,
+                    $limit
+                );
 
-                $visibleSeen = 0;
-                $hasHidden = false;
-                $page = [];
-                $rawOffset = 0;
-                $scannedRows = 0;
-
-                while (count($page) < $limit && $rawOffset < $rawTotal && $scannedRows < self::REQUIRED_BY_SCAN_CAP) {
-                    $chunkSize = max($limit, self::REQUIRED_BY_SCAN_CHUNK);
-                    $rows = $dependencies->getRequiredBy($rawOffset, $chunkSize);
-                    if (empty($rows)) {
-                        break;
-                    }
-
-                    foreach ($rows as $row) {
-                        $el = $this->resolveDependencyElement($row);
-                        if (!$el instanceof Element\ElementInterface) {
-                            continue;
-                        }
-                        if (!$el->isAllowed('list')) {
-                            $hasHidden = true;
-
-                            continue;
-                        }
-                        if ($visibleSeen >= $offset && count($page) < $limit) {
-                            $page[] = $this->dependencyToFrontendArray($el);
-                        }
-                        $visibleSeen++;
-                    }
-
-                    $rawOffset += count($rows);
-                    $scannedRows += count($rows);
-                }
-
-                // The exact permission-filtered total (cached briefly per element+user in core,
-                // see Model\Element\Service::getRequiredByVisibleTotalCount()) so the page count
-                // is accurate from the very first request, not just once paging reaches the end.
+                // Authoritative, briefly-cached permission-filtered total and hidden-dependency
+                // flag (see Model\Element\Service::getRequiredByVisibleTotalCount()/
+                // getRequiredByHasHiddenDependencies()) so both are accurate and stable on
+                // every page, not just an artifact of what this one page's scan happened to see.
                 $total = Model\Element\Service::getRequiredByVisibleTotalCount($dependencies);
+                $hasHidden = Model\Element\Service::getRequiredByHasHiddenDependencies($dependencies);
 
                 return $this->adminJson([
-                    'requiredBy' => $page,
+                    'requiredBy' => $scan['items'],
                     'hasHidden' => $hasHidden,
                     'start' => $offset,
                     'limit' => $limit,


### PR DESCRIPTION
Resolves https://github.com/pimcore/service-operations/issues/851

Depends on: https://github.com/pimcore/pimcore/pull/19257

Required By pagination filtered permissions after the SQL LIMIT/OFFSET, so a restricted user's page count matched an admin's while individual pages could come back sparse or empty, and the ExtJS grid treated a zero-row page as the end of the dataset, blocking navigation to later pages that had visible items.

- getRequiredByDependenciesAction now scans past hidden rows to fill each page, re-deriving the raw-to-visible mapping from scratch on every request so paging stays correct across independent calls, and reports an exact permission-filtered total via the newly cached pimcore/pimcore Service::getRequiredByVisibleTotalCount().
- getRequiresDependenciesAction filters the already fully-loaded in-memory requires set before slicing, giving an exact total at no extra cost.
- dependencies.js refreshes the hidden-dependencies note on every page load instead of only the first.
- overrides.js adds a narrow Ext.toolbar.Paging fix so navigation isn't disabled when a page is empty but the store's total indicates more pages exist.