### PR TITLE
Add authorization check to reset2FaSecretAction

### DIFF
--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -821,11 +821,15 @@ class UserController extends AdminAbstractController implements KernelController
 
         if (!$adminUser->isAdmin()) {
             if ($user->isAdmin()) {
-                throw $this->createAccessDeniedHttpException('Only admin users are allowed to reset 2FA for admin users');
+                throw $this->createAccessDeniedHttpException(
+                    'Only admin users are allowed to reset 2FA for admin users'
+                );
             }
 
             if ($adminUser->getId() !== $user->getId()) {
-                throw $this->createAccessDeniedHttpException('Only admin users are allowed to reset 2FA for users other than themselves');
+                throw $this->createAccessDeniedHttpException(
+                    'Only admin users are allowed to reset 2FA for users other than themselves'
+                );
             }
         }
 

--- a/src/Controller/Admin/UserController.php
+++ b/src/Controller/Admin/UserController.php
@@ -816,6 +816,19 @@ class UserController extends AdminAbstractController implements KernelController
         if (!$user) {
             throw $this->createNotFoundException();
         }
+
+        $adminUser = $this->getAdminUser();
+
+        if (!$adminUser->isAdmin()) {
+            if ($user->isAdmin()) {
+                throw $this->createAccessDeniedHttpException('Only admin users are allowed to reset 2FA for admin users');
+            }
+
+            if ($adminUser->getId() !== $user->getId()) {
+                throw $this->createAccessDeniedHttpException('Only admin users are allowed to reset 2FA for users other than themselves');
+            }
+        }
+
         $user->setTwoFactorAuthentication('enabled', false);
         $user->setTwoFactorAuthentication('secret', '');
         $user->save();

--- a/tests/Model/Permissions/UserControllerReset2FaSecretTest.php
+++ b/tests/Model/Permissions/UserControllerReset2FaSecretTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Tests\Model\Controller;
+
+use Codeception\Stub;
+use Pimcore\Bundle\AdminBundle\Controller\Admin\UserController;
+use Pimcore\Model\User;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+use Pimcore\Tests\Support\Util\TestHelper;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class UserControllerReset2FaSecretTest extends ModelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        TestHelper::cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        TestHelper::cleanUp();
+        parent::tearDown();
+    }
+
+    private function buildController(User $actingUser): UserController
+    {
+        return Stub::construct(UserController::class, [], [
+            'getAdminUser' => function () use ($actingUser) {
+                return $actingUser;
+            },
+            'adminJson' => function ($data) {
+                return new JsonResponse($data);
+            },
+        ]);
+    }
+
+    private function createUser(string $name, bool $isAdmin): User
+    {
+        $user = new User();
+        $user->setName($name);
+        $user->setAdmin($isAdmin);
+        $user->setPermissions(['users']);
+        $user->setTwoFactorAuthentication('enabled', true);
+        $user->setTwoFactorAuthentication('secret', 'some-secret-value');
+        $user->save();
+
+        return $user;
+    }
+
+    private function resetSecretRequest(int $targetUserId): Request
+    {
+        return new Request([], ['id' => $targetUserId]);
+    }
+
+    public function testNonAdminCannotResetAnotherUsersSecret(): void
+    {
+        $actor = $this->createUser('reset2fa-actor', false);
+        $target = $this->createUser('reset2fa-target', false);
+
+        $controller = $this->buildController($actor);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->reset2FaSecretAction($this->resetSecretRequest($target->getId()));
+    }
+
+    public function testNonAdminCannotResetAnAdminsSecret(): void
+    {
+        $actor = $this->createUser('reset2fa-actor', false);
+        $admin = $this->createUser('reset2fa-admin-target', true);
+
+        $controller = $this->buildController($actor);
+
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller->reset2FaSecretAction($this->resetSecretRequest($admin->getId()));
+    }
+
+    public function testNonAdminCanResetTheirOwnSecret(): void
+    {
+        $actor = $this->createUser('reset2fa-self', false);
+
+        $controller = $this->buildController($actor);
+        $response = $controller->reset2FaSecretAction($this->resetSecretRequest($actor->getId()));
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertTrue($data['success']);
+
+        $reloaded = User::getById($actor->getId(), ['force' => true]);
+        $this->assertFalse($reloaded->getTwoFactorAuthentication('enabled'));
+        $this->assertSame('', $reloaded->getTwoFactorAuthentication('secret'));
+    }
+
+    public function testAdminCanResetAnyUsersSecret(): void
+    {
+        $admin = $this->createUser('reset2fa-admin-actor', true);
+        $target = $this->createUser('reset2fa-other-target', false);
+
+        $controller = $this->buildController($admin);
+        $response = $controller->reset2FaSecretAction($this->resetSecretRequest($target->getId()));
+
+        $data = json_decode($response->getContent(), true);
+        $this->assertTrue($data['success']);
+
+        $reloaded = User::getById($target->getId(), ['force' => true]);
+        $this->assertFalse($reloaded->getTwoFactorAuthentication('enabled'));
+        $this->assertSame('', $reloaded->getTwoFactorAuthentication('secret'));
+    }
+}

--- a/tests/Model/Permissions/UserControllerReset2FaSecretTest.php
+++ b/tests/Model/Permissions/UserControllerReset2FaSecretTest.php
@@ -33,6 +33,15 @@ class UserControllerReset2FaSecretTest extends ModelTestCase
 
     protected function tearDown(): void
     {
+        foreach ([
+            'reset2fa-actor-vs-user', 'reset2fa-target-user',
+            'reset2fa-actor-vs-admin', 'reset2fa-admin-target',
+            'reset2fa-self',
+            'reset2fa-admin-actor', 'reset2fa-other-target',
+        ] as $name) {
+            User::getByName($name)?->delete();
+        }
+
         TestHelper::cleanUp();
         parent::tearDown();
     }
@@ -69,8 +78,8 @@ class UserControllerReset2FaSecretTest extends ModelTestCase
 
     public function testNonAdminCannotResetAnotherUsersSecret(): void
     {
-        $actor = $this->createUser('reset2fa-actor', false);
-        $target = $this->createUser('reset2fa-target', false);
+        $actor = $this->createUser('reset2fa-actor-vs-user', false);
+        $target = $this->createUser('reset2fa-target-user', false);
 
         $controller = $this->buildController($actor);
 
@@ -80,7 +89,7 @@ class UserControllerReset2FaSecretTest extends ModelTestCase
 
     public function testNonAdminCannotResetAnAdminsSecret(): void
     {
-        $actor = $this->createUser('reset2fa-actor', false);
+        $actor = $this->createUser('reset2fa-actor-vs-admin', false);
         $admin = $this->createUser('reset2fa-admin-target', true);
 
         $controller = $this->buildController($actor);


### PR DESCRIPTION
## Summary

`reset2FaSecretAction()` in `src/Controller/Admin/UserController.php` loaded a target user by ID from the request and reset their 2FA secret with no check that the requesting user had authority over that account. Any user holding the general `users` permission could disable 2FA on any other account, including admin accounts, purely by supplying its ID.

**Fix:** apply the same admin-vs-target authorization pattern already used by `deleteImageAction()` in this same controller: a non-admin actor may only reset their own 2FA, and may never reset an admin account's 2FA.

## Test plan
- [x] `php -l` on the modified file — no syntax errors
- [x] Added `tests/Model/Permissions/UserControllerReset2FaSecretTest.php`, covering all four cases: non-admin vs. another non-admin (denied), non-admin vs. an admin (denied), non-admin vs. themselves (allowed, 2FA actually cleared), admin vs. anyone (allowed)
- [ ] CI (requires the full Codeception/container bootstrap, not run locally)

Co-Authored-By: Claude <noreply@anthropic.com>