### PR TITLE
[security] GHSA-j67g-8q5g-jpwc: Fix SQL injection via ORDER BY in GDPR data providers

### DIFF
--- a/src/GDPR/DataProvider/Assets.php
+++ b/src/GDPR/DataProvider/Assets.php
@@ -145,9 +145,16 @@ class Assets extends Elements implements DataProviderInterface
                 $sort = $sortMapping[$sortingSettings['orderKey']];
             }
 
-            $order = $sortingSettings['order'] ?? null;
+            // The sort column originates from the request and DBAL's orderBy()
+            // concatenates it into the SQL without quoting, so only let it through
+            // once it is confirmed to be a real column of the queried table.
+            $sort = $this->getValidSortColumn($db, 'assets', $sort);
 
-            $query->orderBy($sort, $order);
+            if ($sort !== null) {
+                $order = $sortingSettings['order'] ?? null;
+
+                $query->orderBy($sort, $order);
+            }
         }
 
         $query = $query->executeQuery();

--- a/src/GDPR/DataProvider/DataObjects.php
+++ b/src/GDPR/DataProvider/DataObjects.php
@@ -135,9 +135,16 @@ class DataObjects extends Elements implements DataProviderInterface
                 $sort = $sortMapping[$sortingSettings['orderKey']];
             }
 
-            $order = $sortingSettings['order'] ?? null;
+            // The sort column originates from the request and DBAL's orderBy()
+            // concatenates it into the SQL without quoting, so only let it through
+            // once it is confirmed to be a real column of the queried table.
+            $sort = $this->getValidSortColumn($db, 'objects', $sort);
 
-            $query->orderBy($sort, $order);
+            if ($sort !== null) {
+                $order = $sortingSettings['order'] ?? null;
+
+                $query->orderBy($sort, $order);
+            }
         }
 
         $query = $query->executeQuery();

--- a/src/GDPR/DataProvider/Elements.php
+++ b/src/GDPR/DataProvider/Elements.php
@@ -14,11 +14,36 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\AdminBundle\GDPR\DataProvider;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+
 /**
  * @internal
  */
 abstract class Elements implements DataProviderInterface
 {
+    /**
+     * Validates a user-supplied ORDER BY column against the real columns of the
+     * given table.
+     *
+     * Doctrine DBAL's QueryBuilder::orderBy() concatenates the column name into
+     * the SQL string without quoting or binding, so a value taken straight from
+     * the request allows SQL injection via the sort parameter. Only a value that
+     * matches an existing column of $table is returned; every other value
+     * (including any injection payload) yields null so the caller can safely omit
+     * the ordering. Schema introspection failures fail closed for the same reason.
+     */
+    protected function getValidSortColumn(Connection $db, string $table, string $column): ?string
+    {
+        try {
+            $tableColumns = $db->createSchemaManager()->listTableColumns($table);
+        } catch (Exception) {
+            return null;
+        }
+
+        return array_key_exists(strtolower($column), $tableColumns) ? $column : null;
+    }
+
     protected function prepareQueryString(string $query): string
     {
         if ($query == '*') {

--- a/tests/Model/GDPR/DataProviderSortInjectionTest.php
+++ b/tests/Model/GDPR/DataProviderSortInjectionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Tests\Model\GDPR;
+
+use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\Assets;
+use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataObjects;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+
+/**
+ * Regression test for GHSA-j67g-8q5g-jpwc: SQL injection via the unsanitized
+ * ORDER BY `property` of the sort parameter in the GDPR data providers.
+ *
+ * The crafted `property` below is read-only and syntactically invalid as an
+ * ORDER BY expression. Against the vulnerable code it is concatenated straight
+ * into the SQL by DBAL's orderBy(), so executeQuery() raises a DBAL exception
+ * and these tests fail. Against the fixed code the value is rejected because it
+ * is not a real column of the queried table, the ordering is skipped, and the
+ * search completes normally.
+ */
+class DataProviderSortInjectionTest extends ModelTestCase
+{
+    /**
+     * An injection payload that is invalid SQL when placed in an ORDER BY clause
+     * (unbalanced parenthesis) and touches no data, so it deterministically errors
+     * against the vulnerable code without any destructive side effect.
+     */
+    private const INJECTION_PROPERTY = '(SELECT 1 FROM information_schema.tables WHERE 1=1';
+
+    private function sortParam(string $property): string
+    {
+        return json_encode([['property' => $property, 'direction' => 'ASC']], JSON_THROW_ON_ERROR);
+    }
+
+    public function testAssetsRejectsSortColumnInjection(): void
+    {
+        // A non-empty firstname bypasses the early return so the query (and its
+        // ORDER BY) is actually built and executed.
+        $result = (new Assets())->searchData(0, 'no-such-gdpr-term', '', '', 0, 25, $this->sortParam(self::INJECTION_PROPERTY));
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testAssetsAppliesValidSortColumn(): void
+    {
+        $result = (new Assets())->searchData(0, 'no-such-gdpr-term', '', '', 0, 25, $this->sortParam('id'));
+
+        $this->assertTrue($result['success']);
+        $this->assertIsArray($result['data']);
+    }
+
+    public function testDataObjectsRejectsSortColumnInjection(): void
+    {
+        $result = (new DataObjects([]))->searchData(0, 'no-such-gdpr-term', '', '', 0, 25, $this->sortParam(self::INJECTION_PROPERTY));
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testDataObjectsAppliesValidSortColumn(): void
+    {
+        $result = (new DataObjects([]))->searchData(0, 'no-such-gdpr-term', '', '', 0, 25, $this->sortParam('id'));
+
+        $this->assertTrue($result['success']);
+        $this->assertIsArray($result['data']);
+    }
+}


### PR DESCRIPTION
## Vulnerability

**GHSA-j67g-8q5g-jpwc** — SQL injection via the unsanitized `ORDER BY` column in the GDPR data-provider search endpoints (`GET /admin/gdpr/asset/search-assets`, `GET /admin/gdpr/data-object/search-data-objects`).

### Root cause

The request-controlled `property` field of the `sort` parameter is extracted by `QueryParams::extractSortingSettings()` with no validation and handed straight to Doctrine DBAL's `QueryBuilder::orderBy()`:

- `src/GDPR/DataProvider/Assets.php` — `$query->orderBy($sort, $order)`
- `src/GDPR/DataProvider/DataObjects.php` — `$query->orderBy($sort, $order)`

DBAL's `orderBy()` concatenates the column name into the SQL string without quoting or binding, so a crafted `property` (e.g. a `CASE WHEN ... SLEEP() ...` expression) is injected verbatim into the `ORDER BY` clause. This enables boolean-blind and time-based blind SQL injection. The sort *direction* is already whitelisted to `ASC`/`DESC` in `extractSortingSettings()`; only the column was unvalidated — the classic asymmetric-sanitization pattern described in the advisory. Requires an authenticated admin with the `gdpr_data_extractor` permission.

## Fix

Add a shared `getValidSortColumn()` helper on the common `Elements` base class that validates the requested column against the **actual columns of the queried table** (via the DBAL schema manager) before it can reach `orderBy()`. Any value that is not a real column — every injection payload included — yields `null`, and the caller then skips ordering entirely. Introspection failures fail closed (return `null`) for the same reason.

This follows Pimcore's own established `getValidTableColumns()` convention (see `Model/GridConfig/Dao.php` et al.) rather than a hardcoded allowlist, so it cannot drift from the schema and continues to allow sorting by any legitimate column. The `type`→`subtype` / `classname`→`subtype` mappings are preserved and validated after mapping. Direction handling is left untouched since it was already safe — keeping the change scoped tightly to the vulnerability.

## Backward compatibility

Assessed against the Pimcore BC promise. Both `Assets` and `DataObjects` (and the `Elements` base) are annotated `@internal`, so they are **not** part of the public API covered by the promise; the new helper is `protected` on an `@internal` abstract class. No public signature, return type, service id, or route changes. The only observable behavior change is that a `sort` column which is not a real table column is now ignored (query runs unordered) instead of being concatenated into the SQL — previously such a value either produced a SQL error or executed injected SQL, so no legitimate consumer relied on it. Sorting by real columns is unchanged.

## Tests

Tests added: `tests/Model/GDPR/DataProviderSortInjectionTest.php`

Covers both providers with (a) an injection payload that is invalid, read-only `ORDER BY` SQL — it errors against the vulnerable code (fails the test) and is safely rejected against the fix (passes) — and (b) a legitimate `id` sort that must still succeed, confirming legitimate sorting is preserved. The tests could **not** be executed in this environment (no Composer/`vendor/`, no DB, no network); they are written against the standard `ModelTestCase` suite and lint clean (`php -l`).

Security-Advisory: pimcore/pimcore/GHSA-j67g-8q5g-jpwc




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/product-management/actions/runs/30472374631) · opus48 · 237.9 AIC · ⌖ 28.9 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fadmin-ui-classic-bundle+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-opus-4-8, id: 30472374631, workflow_id: advisory-fix, run: https://github.com/pimcore/product-management/actions/runs/30472374631 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/product-management/advisory-fix -->