### PR TITLE
[security] GHSA-g8pm-xq73-xqq8: Fix blind SQL injection in GDPR search ORDER BY

### DIFF
--- a/src/GDPR/DataProvider/Assets.php
+++ b/src/GDPR/DataProvider/Assets.php
@@ -147,7 +147,9 @@ class Assets extends Elements implements DataProviderInterface
 
             $order = $sortingSettings['order'] ?? null;
 
-            $query->orderBy($sort, $order);
+            // the sort column is an attacker-controlled identifier and cannot be bound as a
+            // parameter, so it must be quoted to prevent SQL injection via the ORDER BY clause
+            $query->orderBy($db->quoteIdentifier($sort), $order);
         }
 
         $query = $query->executeQuery();

--- a/src/GDPR/DataProvider/DataObjects.php
+++ b/src/GDPR/DataProvider/DataObjects.php
@@ -137,7 +137,9 @@ class DataObjects extends Elements implements DataProviderInterface
 
             $order = $sortingSettings['order'] ?? null;
 
-            $query->orderBy($sort, $order);
+            // the sort column is an attacker-controlled identifier and cannot be bound as a
+            // parameter, so it must be quoted to prevent SQL injection via the ORDER BY clause
+            $query->orderBy($db->quoteIdentifier($sort), $order);
         }
 
         $query = $query->executeQuery();

--- a/tests/Model/GDPR/GdprSearchSortInjectionTest.php
+++ b/tests/Model/GDPR/GdprSearchSortInjectionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\AdminBundle\Tests\Model\GDPR;
+
+use Doctrine\DBAL\Exception as DBALException;
+use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\Assets;
+use Pimcore\Bundle\AdminBundle\GDPR\DataProvider\DataObjects;
+use Pimcore\Tests\Support\Test\ModelTestCase;
+
+/**
+ * Regression test for GHSA-g8pm-xq73-xqq8: blind SQL injection through the `sort` property of the
+ * GDPR search endpoints. The sort property is placed into the ORDER BY clause, where it cannot be
+ * bound as a parameter, so it must be quoted as an identifier. An unquoted value lets an
+ * authenticated `gdpr_data_extractor` user run arbitrary SQL expressions in ORDER BY.
+ *
+ * Each injection case uses `(SELECT 1)` as the sort property: that is a valid SQL expression but
+ * not a column name. Against the vulnerable code it is emitted verbatim as `ORDER BY (SELECT 1)`
+ * and executes without error, so the test's expected exception is never thrown and the test fails.
+ * Against the fixed code it is quoted to `ORDER BY `(SELECT 1)``, which the database rejects as an
+ * unknown column, proving the value can no longer break out of the identifier position.
+ */
+class GdprSearchSortInjectionTest extends ModelTestCase
+{
+    private const INJECTION_SORT = '[{"property":"(SELECT 1)","direction":"ASC"}]';
+
+    public function testDataObjectsSearchRejectsSortInjection(): void
+    {
+        $this->expectException(DBALException::class);
+
+        (new DataObjects([]))->searchData(1, '', '', '', 0, 10, self::INJECTION_SORT);
+    }
+
+    public function testAssetsSearchRejectsSortInjection(): void
+    {
+        $this->expectException(DBALException::class);
+
+        (new Assets([]))->searchData(1, '', '', '', 0, 10, self::INJECTION_SORT);
+    }
+
+    public function testDataObjectsSearchAllowsLegitimateSort(): void
+    {
+        $result = (new DataObjects([]))->searchData(1, '', '', '', 0, 10, '[{"property":"id","direction":"ASC"}]');
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testAssetsSearchAllowsLegitimateSort(): void
+    {
+        $result = (new Assets([]))->searchData(1, '', '', '', 0, 10, '[{"property":"filename","direction":"ASC"}]');
+
+        $this->assertTrue($result['success']);
+    }
+}


### PR DESCRIPTION
## Vulnerability

Blind SQL injection (CWE-89) in the GDPR search endpoints `GET /admin/gdpr/data-object/search-data-objects` and `GET /admin/gdpr/asset/search-assets`. An authenticated user with the low-privilege `gdpr_data_extractor` permission controls the `sort[].property` value, which `QueryParams::extractSortingSettings()` returns as-is (only remapping `classname`/`type` to `subtype`, with no field allowlist).

**Root cause:** that attacker-controlled property was passed directly into the `ORDER BY` clause:

```php
$query->orderBy($sort, $order); // $sort unquoted, unvalidated
```

in `src/GDPR/DataProvider/DataObjects.php` and `src/GDPR/DataProvider/Assets.php`. Identifiers in `ORDER BY` cannot be bound as parameters, and the `WHERE id = :id` clause is bound separately, so the sort value is a working injection sink independent of the filter. It escalates to a full read of the database (e.g. `users` password hashes) via an error-based `extractvalue` payload, since MariaDB evaluates the `ORDER BY` expression even for a single-row result.

This is a new, previously unpatched sink, distinct from the already-fixed filter/date SQL-injection paths.

## Fix

The sort identifier is now quoted with `\Pimcore\Db::get()->quoteIdentifier()` before being placed into `ORDER BY`, in both data providers:

```php
$query->orderBy($db->quoteIdentifier($sort), $order);
```

Quoting escapes any embedded backticks and wraps the value as a single identifier, so an injected expression such as `extractvalue(...)` or `(SELECT 1)` becomes an unknown-column reference the database rejects rather than SQL it executes. This matches the existing convention in this repository — `QueryParams::getFilterCondition()` already uses `quoteIdentifier()` for dynamic identifiers — and the Pimcore coding guideline that dynamic column names which cannot be bound must be passed through `quoteIdentifier()`. The sort direction (`$order`) was already constrained to `ASC`/`DESC` by `extractSortingSettings()` and is unchanged.

Legitimate sorting is preserved: real column names (`id`, `type`, `subtype`, `filename`, ...) quote to themselves and sort as before; only values that are not valid identifiers are now rejected.

The sibling GDPR provider `PimcoreUsers` is not affected: it sorts via `User\Listing::setOrderKey()`, which handles identifier quoting in the listing DAO, not through a raw `orderBy()` call. The other `extractSortingSettings()` callers reach the ORM listing layer rather than a hand-built query builder.

## Backward compatibility

No BC break. Both `DataObjects` and `Assets` are annotated `@internal`, so they are outside the BC promise; the public `searchData()` signature is unchanged, and legitimate column sorts return identical results. The only behavioral change is that malformed/malicious sort identifiers now raise a DB error instead of being executed — the intended security effect.

## Tests

Tests added: `tests/Model/GDPR/GdprSearchSortInjectionTest.php`

The test exercises both providers. The injection cases pass `(SELECT 1)` as the sort property (valid SQL, not a column): against the vulnerable code it is emitted as `ORDER BY (SELECT 1)` and executes without error, so the expected exception is never thrown and the test fails; against the fix it is quoted to ``ORDER BY `(SELECT 1)` `` and rejected as an unknown column, so the test passes. Two companion cases assert that legitimate sorts (`id`, `filename`) still succeed, confirming valid behavior is retained.

The tests could not be executed in this environment (no Composer install / DB available in the sandbox); they are written to run under the existing Codeception `Model` suite, which provides the DB connection the query builder needs.

Security-Advisory: pimcore/pimcore/GHSA-g8pm-xq73-xqq8




> Generated by [Draft a security-advisory fix](https://github.com/pimcore/product-management/actions/runs/30525774595) · opus48 · 195.3 AIC · ⌖ 32.1 AIC · ⊞ 6.2K · [◷](https://github.com/search?q=repo%3Apimcore%2Fadmin-ui-classic-bundle+%22gh-aw-workflow-id%3A+advisory-fix%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Draft a security-advisory fix, engine: claude, model: claude-opus-4-8, id: 30525774595, workflow_id: advisory-fix, run: https://github.com/pimcore/product-management/actions/runs/30525774595 -->

<!-- gh-aw-workflow-id: advisory-fix -->
<!-- gh-aw-workflow-call-id: pimcore/product-management/advisory-fix -->