### PR TITLE
Pin setup-matrix checkout to PR base ref (trusted test matrix)

### DIFF
--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -22,7 +22,7 @@ jobs:
             matrix: ${{ steps.set-matrix.outputs.matrix }}
             private_repo: ${{ env.PRIVATE_REPO }}
         steps:
-            - name: Checkout PR head (only for pull_request_target)
+            - name: Checkout base ref (matrix source)
               if: github.event_name == 'pull_request_target'
               uses: "actions/checkout@v4"
               with:

--- a/.github/workflows/codeception.yaml
+++ b/.github/workflows/codeception.yaml
@@ -26,7 +26,9 @@ jobs:
               if: github.event_name == 'pull_request_target'
               uses: "actions/checkout@v4"
               with:
-                ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
+                # Build the test matrix from the PR base branch's composer.json, not the
+                # PR's -- the matrix must not be attacker-controlled.
+                ref: ${{ github.event.pull_request.base.ref || github.ref }}
 
             - name: Checkout PR head (for push or other events)
               if: github.event_name != 'pull_request_target'


### PR DESCRIPTION
## Summary
Pin the **`setup-matrix` job's** checkout to the PR base ref, so the test matrix is built from trusted configuration instead of the PR's.

```diff
     - name: Checkout code
       uses: actions/checkout@v5
       with:
-        ref: <PR head / merge ref>
+        # Build the test matrix from the PR base branch's composer.json, not the
+        # PR's -- the matrix must not be attacker-controlled.
+        ref: ${{ github.event.pull_request.base.ref || github.ref }}
```

## Why
This workflow runs on `pull_request_target`. Its `setup-matrix` job checks out the **PR's** code and then does nothing with it except read `composer.json`:

```
php_versions=$(jq -r '.require.php' composer.json | grep -oP '\d+\.\d+' | ...)
```

That value selects which PHP/database combinations run. Because the checkout is the PR's code, **a pull request currently controls its own test matrix** — e.g. narrowing it so a combination that would fail is never executed. The base branch's `composer.json` is the trusted source for that decision.

## Why this is safe
- **The code under test is not affected.** It is checked out separately in the `codeception-tests` job; this PR does not touch that job, nor the second checkout of `pimcore/workflows-collection-public` in `setup-matrix`.
- **Fork PRs still run exactly as before** — only where the matrix *definition* comes from changes.
- **No trigger change.** `pull_request_target` is left exactly as-is; the `pull_request` vs `pull_request_target` decision in pimcore/product-management#1311 is deliberately not pre-empted.
- On `push` / `schedule` / `workflow_dispatch`, `github.event.pull_request` is null, so `||` falls back to `github.ref` — today's behaviour is preserved.

Same one-line fix already merged in `payment-provider-mpay24-seamless/codeception.yaml`, `data-hub/codeception.yml` and `generic-data-index-bundle/{elastic,open}-search-codeception.yaml`.

## Known trade-off
A PR that raises `.require.php` will not have the new version tested until it merges, since the matrix now comes from the base branch. This is the accepted behaviour of the already-pinned workflows above.

Part of pimcore/product-management#1312.
